### PR TITLE
build Python Module on Mac OS

### DIFF
--- a/build_all/mac/build.sh
+++ b/build_all/mac/build.sh
@@ -37,18 +37,18 @@ process_args $*
 cd $build_root
 
 echo copy iothub_client library to samples folder
-cp $build_folder/python/src/iothub_client.dylib ./device/samples/iothub_client.dylib
+cp $build_folder/python/src/iothub_client.so ./device/samples/iothub_client.so
 echo copy iothub_client_mock library to tests folder
-cp $build_folder/python/test/iothub_client_mock.dylib ./device/tests/iothub_client_mock.dylib
-cp $build_folder/python/src/iothub_client.dylib ./device/tests/iothub_client.dylib
-cp $build_folder/python_service_client/src/iothub_service_client.dylib ./device/tests/iothub_service_client.dylib
+cp $build_folder/python/test/iothub_client_mock.so ./device/tests/iothub_client_mock.so
+cp $build_folder/python/src/iothub_client.so ./device/tests/iothub_client.so
+cp $build_folder/python_service_client/src/iothub_service_client.so ./device/tests/iothub_service_client.so
 
 echo copy iothub_service_client library to samples folder
-cp $build_folder/python_service_client/src/iothub_service_client.dylib ./service/samples/iothub_service_client.dylib
+cp $build_folder/python_service_client/src/iothub_service_client.so ./service/samples/iothub_service_client.so
 echo copy iothub_service_client_mock library to tests folder
-cp $build_folder/python_service_client/tests/iothub_service_client_mock.dylib ./service/tests/iothub_service_client_mock.dylib
-cp $build_folder/python_service_client/src/iothub_service_client.dylib ./service/tests/iothub_service_client.dylib
-cp $build_folder/python/src/iothub_client.dylib ./service/tests/iothub_client.dylib
+cp $build_folder/python_service_client/tests/iothub_service_client_mock.so ./service/tests/iothub_service_client_mock.so
+cp $build_folder/python_service_client/src/iothub_service_client.so ./service/tests/iothub_service_client.so
+cp $build_folder/python/src/iothub_client.so ./service/tests/iothub_client.so
 
 cd $build_root/device/tests/
 echo "python${PYTHON_VERSION}" iothub_client_ut.py

--- a/build_all/mac/build.sh
+++ b/build_all/mac/build.sh
@@ -18,6 +18,11 @@ process_args()
       if [ $save_next_arg == 1 ]
       then
         PYTHON_VERSION="$arg"
+        if [ $PYTHON_VERSION != "2.7" ] && [ $PYTHON_VERSION != "3.4" ] && [ $PYTHON_VERSION != "3.5" ] && [ $PYTHON_VERSION != "3.6" ]
+        then
+          echo "Supported python versions are 2.7, 3.4, 3.5 or 3.6"
+          exit 1
+        fi
         save_next_arg=0
       else
         case "$arg" in
@@ -30,25 +35,55 @@ process_args()
 
 process_args $*
 
-# instruct C builder to include python library and to skip tests
+########################################################
+#build azure-iot-sdk-c
+export OPENSSL_ROOT_DIR=/usr/local/opt/openssl
+c_build_root=${build_root}"/c"
 
-./c/build_all/mac/build.sh -cl -Qunused-arguments --build-python $PYTHON_VERSION $*
+# brew installes python 3.x to $prefix/include/python3.xm
+if [ $PYTHON_VERSION != "3.4" ] && [ $PYTHON_VERSION != "3.5" ] && [ $PYTHON_VERSION != "3.6" ]
+then
+	python_prefix=$(python-config --prefix)
+	python_include=$python_prefix/include/python$PYTHON_VERSION
+	python_lib=$python_prefix/lib/libpython$PYTHON_VERSION.dylib
+else
+	python_prefix=$(python3-config --prefix)
+	python_include=$python_prefix/include/python${PYTHON_VERSION}m
+	python_lib=$python_prefix/lib/libpython${PYTHON_VERSION}m.dylib
+fi
+
+
+rm -r -f $build_folder
+mkdir -p $build_folder
+pushd $build_folder
+cmake -Drun_valgrind:BOOL=OFF -DcompileOption_CXX:STRING="-Wno-unused-value" -DcompileOption_C:STRING="-Wno-unused-value" -Drun_e2e_tests:BOOL=OFF -Drun_longhaul_tests=OFF -Duse_amqp:BOOL=ON -Duse_http:BOOL=ON -Duse_mqtt:BOOL=ON -Ddont_use_uploadtoblob:BOOL=OFF -Duse_wsio:BOOL=OFF -Drun_unittests:BOOL=OFF -Dbuild_python:STRING=$PYTHON_VERSION -Dbuild_javawrapper:BOOL=OFF -Dno_logging:BOOL=OFF $c_build_root -Dwip_use_c2d_amqp_methods:BOOL=OFF -DPYTHON_LIBRARY=$python_lib -DPYTHON_INCLUDE_DIR=$python_include
+
+# Set the default cores
+CORES=$(sysctl -n hw.ncpu)
+
+make --jobs=$CORES
+ctest -j $CORES -C "Debug" --output-on-failure
+
+popd
+########################################################
+
+
 [ $? -eq 0 ] || exit $?
 cd $build_root
 
 echo copy iothub_client library to samples folder
-cp $build_folder/python/src/iothub_client.so ./device/samples/iothub_client.so
+cp $build_folder/python/src/iothub_client.dylib ./device/samples/iothub_client.so
 echo copy iothub_client_mock library to tests folder
-cp $build_folder/python/test/iothub_client_mock.so ./device/tests/iothub_client_mock.so
-cp $build_folder/python/src/iothub_client.so ./device/tests/iothub_client.so
-cp $build_folder/python_service_client/src/iothub_service_client.so ./device/tests/iothub_service_client.so
+cp $build_folder/python/test/iothub_client_mock.dylib ./device/tests/iothub_client_mock.so
+cp $build_folder/python/src/iothub_client.dylib ./device/tests/iothub_client.so
+cp $build_folder/python_service_client/src/iothub_service_client.dylib ./device/tests/iothub_service_client.so
 
 echo copy iothub_service_client library to samples folder
-cp $build_folder/python_service_client/src/iothub_service_client.so ./service/samples/iothub_service_client.so
+cp $build_folder/python_service_client/src/iothub_service_client.dylib ./service/samples/iothub_service_client.so
 echo copy iothub_service_client_mock library to tests folder
-cp $build_folder/python_service_client/tests/iothub_service_client_mock.so ./service/tests/iothub_service_client_mock.so
-cp $build_folder/python_service_client/src/iothub_service_client.so ./service/tests/iothub_service_client.so
-cp $build_folder/python/src/iothub_client.so ./service/tests/iothub_client.so
+cp $build_folder/python_service_client/tests/iothub_service_client_mock.dylib ./service/tests/iothub_service_client_mock.so
+cp $build_folder/python_service_client/src/iothub_service_client.dylib ./service/tests/iothub_service_client.so
+cp $build_folder/python/src/iothub_client.dylib ./service/tests/iothub_client.so
 
 cd $build_root/device/tests/
 echo "python${PYTHON_VERSION}" iothub_client_ut.py

--- a/build_all/mac/build.sh
+++ b/build_all/mac/build.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+build_root=$(cd "$(dirname "$0")/../.." && pwd)
+build_folder=$build_root"/c/cmake/iotsdk_mac"
+
+cd $build_root
+
+PYTHON_VERSION=2.7
+
+process_args()
+{
+    save_next_arg=0
+    
+    for arg in $*
+    do
+      if [ $save_next_arg == 1 ]
+      then
+        PYTHON_VERSION="$arg"
+        save_next_arg=0
+      else
+        case "$arg" in
+          "--build-python" ) save_next_arg=1;;
+          * ) ;;
+        esac
+      fi
+    done
+}
+
+process_args $*
+
+# instruct C builder to include python library and to skip tests
+
+./c/build_all/mac/build.sh -cl -Qunused-arguments --build-python $PYTHON_VERSION $*
+[ $? -eq 0 ] || exit $?
+cd $build_root
+
+echo copy iothub_client library to samples folder
+cp $build_folder/python/src/iothub_client.dylib ./device/samples/iothub_client.dylib
+echo copy iothub_client_mock library to tests folder
+cp $build_folder/python/test/iothub_client_mock.dylib ./device/tests/iothub_client_mock.dylib
+cp $build_folder/python/src/iothub_client.dylib ./device/tests/iothub_client.dylib
+cp $build_folder/python_service_client/src/iothub_service_client.dylib ./device/tests/iothub_service_client.dylib
+
+echo copy iothub_service_client library to samples folder
+cp $build_folder/python_service_client/src/iothub_service_client.dylib ./service/samples/iothub_service_client.dylib
+echo copy iothub_service_client_mock library to tests folder
+cp $build_folder/python_service_client/tests/iothub_service_client_mock.dylib ./service/tests/iothub_service_client_mock.dylib
+cp $build_folder/python_service_client/src/iothub_service_client.dylib ./service/tests/iothub_service_client.dylib
+cp $build_folder/python/src/iothub_client.dylib ./service/tests/iothub_client.dylib
+
+cd $build_root/device/tests/
+echo "python${PYTHON_VERSION}" iothub_client_ut.py
+"python${PYTHON_VERSION}" iothub_client_ut.py
+[ $? -eq 0 ] || exit $?
+echo "python${PYTHON_VERSION}" iothub_client_map_test.py
+"python${PYTHON_VERSION}" iothub_client_map_test.py
+[ $? -eq 0 ] || exit $?
+cd $build_root
+
+cd $build_root/service/tests/
+echo "python${PYTHON_VERSION}" iothub_service_client_ut.py
+"python${PYTHON_VERSION}" iothub_service_client_ut.py
+[ $? -eq 0 ] || exit $?
+echo "python${PYTHON_VERSION}" iothub_service_client_map_test.py
+"python${PYTHON_VERSION}" iothub_service_client_map_test.py
+[ $? -eq 0 ] || exit $?
+cd $build_root

--- a/build_all/mac/release.sh
+++ b/build_all/mac/release.sh
@@ -36,14 +36,14 @@ process_args $*
 cd $build_root
 
 echo copy iothub_client library to samples folder
-cp $build_folder/python/src/iothub_client.dylib ./device/samples/iothub_client.dylib
+cp $build_folder/python/src/iothub_client.so ./device/samples/iothub_client.so
 echo copy iothub_client_mock library to tests folder
-cp $build_folder/python/test/iothub_client_mock.dylib ./device/tests/iothub_client_mock.dylib
+cp $build_folder/python/test/iothub_client_mock.so ./device/tests/iothub_client_mock.so
 
 echo copy iothub_service_client library to samples folder
-cp $build_folder/python_service_client/src/iothub_service_client.dylib ./service/samples/iothub_service_client.dylib
+cp $build_folder/python_service_client/src/iothub_service_client.so ./service/samples/iothub_service_client.so
 echo copy iothub_service_client_mock library to tests folder
-cp $build_folder/python_service_client/tests/iothub_service_client_mock.dylib ./service/tests/iothub_service_client_mock.dylib
+cp $build_folder/python_service_client/tests/iothub_service_client_mock.so ./service/tests/iothub_service_client_mock.so
 
 cd $build_root/device/tests/
 echo "python${PYTHON_VERSION}" iothub_client_ut.py
@@ -64,12 +64,12 @@ echo "python${PYTHON_VERSION}" iothub_service_client_map_test.py
 cd $build_root
 
 cd ./build_all/mac/release_device_client
-cp $build_folder/python/src/iothub_client.dylib iothub_client/iothub_client.dylib
+cp $build_folder/python/src/iothub_client.so iothub_client/iothub_client.so
 "python${PYTHON_VERSION}" setup_device_client.py bdist_wheel
 cd $build_root
 
 cd ./build_all/mac/release_service_client
-cp $build_folder/python_service_client/src/iothub_service_client.dylib iothub_service_client/iothub_service_client.dylib
+cp $build_folder/python_service_client/src/iothub_service_client.so iothub_service_client/iothub_service_client.so
 "python${PYTHON_VERSION}" setup_service_client.py bdist_wheel
 
 cd $build_root

--- a/build_all/mac/release.sh
+++ b/build_all/mac/release.sh
@@ -3,73 +3,10 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 build_root=$(cd "$(dirname "$0")/../.." && pwd)
-build_folder=$build_root"/c/cmake/iotsdk_mac"
 
-cd $build_root
+# run build script
+./build.sh $*
 
-PYTHON_VERSION=2.7
-
-process_args()
-{
-    save_next_arg=0
-    
-    for arg in $*
-    do
-      if [ $save_next_arg == 1 ]
-      then
-        PYTHON_VERSION="$arg"
-        save_next_arg=0
-      else
-        case "$arg" in
-          "--build-python" ) save_next_arg=1;;
-          * ) ;;
-        esac
-      fi
-    done
-}
-
-process_args $*
-
-# instruct C builder to include python library and to skip tests
-./c/build_all/mac/build.sh --build-python $PYTHON_VERSION $*
-[ $? -eq 0 ] || exit $?
-cd $build_root
-
-echo copy iothub_client library to samples folder
-cp $build_folder/python/src/iothub_client.so ./device/samples/iothub_client.so
-echo copy iothub_client_mock library to tests folder
-cp $build_folder/python/test/iothub_client_mock.so ./device/tests/iothub_client_mock.so
-
-echo copy iothub_service_client library to samples folder
-cp $build_folder/python_service_client/src/iothub_service_client.so ./service/samples/iothub_service_client.so
-echo copy iothub_service_client_mock library to tests folder
-cp $build_folder/python_service_client/tests/iothub_service_client_mock.so ./service/tests/iothub_service_client_mock.so
-
-cd $build_root/device/tests/
-echo "python${PYTHON_VERSION}" iothub_client_ut.py
-"python${PYTHON_VERSION}" iothub_client_ut.py
-[ $? -eq 0 ] || exit $?
-echo "python${PYTHON_VERSION}" iothub_client_map_test.py
-"python${PYTHON_VERSION}" iothub_client_map_test.py
-[ $? -eq 0 ] || exit $?
-cd $build_root
-
-cd $build_root/service/tests/
-echo "python${PYTHON_VERSION}" iothub_service_client_ut.py
-"python${PYTHON_VERSION}" iothub_service_client_ut.py
-[ $? -eq 0 ] || exit $?
-echo "python${PYTHON_VERSION}" iothub_service_client_map_test.py
-"python${PYTHON_VERSION}" iothub_service_client_map_test.py
-[ $? -eq 0 ] || exit $?
-cd $build_root
-
-cd ./build_all/mac/release_device_client
-cp $build_folder/python/src/iothub_client.so iothub_client/iothub_client.so
-"python${PYTHON_VERSION}" setup_device_client.py bdist_wheel
-cd $build_root
-
-cd ./build_all/mac/release_service_client
-cp $build_folder/python_service_client/src/iothub_service_client.so iothub_service_client/iothub_service_client.so
-"python${PYTHON_VERSION}" setup_service_client.py bdist_wheel
-
-cd $build_root
+# copy lib to release folder
+cp $build_root/device/samples/iothub_client.so iothub_client/iothub_client.so
+cp $build_root/service/samples/iothub_service_client.so iothub_service_client/iothub_service_client.so

--- a/build_all/mac/release.sh
+++ b/build_all/mac/release.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+build_root=$(cd "$(dirname "$0")/../.." && pwd)
+build_folder=$build_root"/c/cmake/iotsdk_mac"
+
+cd $build_root
+
+PYTHON_VERSION=2.7
+
+process_args()
+{
+    save_next_arg=0
+    
+    for arg in $*
+    do
+      if [ $save_next_arg == 1 ]
+      then
+        PYTHON_VERSION="$arg"
+        save_next_arg=0
+      else
+        case "$arg" in
+          "--build-python" ) save_next_arg=1;;
+          * ) ;;
+        esac
+      fi
+    done
+}
+
+process_args $*
+
+# instruct C builder to include python library and to skip tests
+./c/build_all/mac/build.sh --build-python $PYTHON_VERSION $*
+[ $? -eq 0 ] || exit $?
+cd $build_root
+
+echo copy iothub_client library to samples folder
+cp $build_folder/python/src/iothub_client.dylib ./device/samples/iothub_client.dylib
+echo copy iothub_client_mock library to tests folder
+cp $build_folder/python/test/iothub_client_mock.dylib ./device/tests/iothub_client_mock.dylib
+
+echo copy iothub_service_client library to samples folder
+cp $build_folder/python_service_client/src/iothub_service_client.dylib ./service/samples/iothub_service_client.dylib
+echo copy iothub_service_client_mock library to tests folder
+cp $build_folder/python_service_client/tests/iothub_service_client_mock.dylib ./service/tests/iothub_service_client_mock.dylib
+
+cd $build_root/device/tests/
+echo "python${PYTHON_VERSION}" iothub_client_ut.py
+"python${PYTHON_VERSION}" iothub_client_ut.py
+[ $? -eq 0 ] || exit $?
+echo "python${PYTHON_VERSION}" iothub_client_map_test.py
+"python${PYTHON_VERSION}" iothub_client_map_test.py
+[ $? -eq 0 ] || exit $?
+cd $build_root
+
+cd $build_root/service/tests/
+echo "python${PYTHON_VERSION}" iothub_service_client_ut.py
+"python${PYTHON_VERSION}" iothub_service_client_ut.py
+[ $? -eq 0 ] || exit $?
+echo "python${PYTHON_VERSION}" iothub_service_client_map_test.py
+"python${PYTHON_VERSION}" iothub_service_client_map_test.py
+[ $? -eq 0 ] || exit $?
+cd $build_root
+
+cd ./build_all/mac/release_device_client
+cp $build_folder/python/src/iothub_client.dylib iothub_client/iothub_client.dylib
+"python${PYTHON_VERSION}" setup_device_client.py bdist_wheel
+cd $build_root
+
+cd ./build_all/mac/release_service_client
+cp $build_folder/python_service_client/src/iothub_service_client.dylib iothub_service_client/iothub_service_client.dylib
+"python${PYTHON_VERSION}" setup_service_client.py bdist_wheel
+
+cd $build_root

--- a/build_all/mac/release_device_client/build/lib.linux-x86_64-2.7/iothub_client/__init__.py
+++ b/build_all/mac/release_device_client/build/lib.linux-x86_64-2.7/iothub_client/__init__.py
@@ -1,0 +1,1 @@
+from .iothub_client import *

--- a/build_all/mac/release_device_client/build/lib/iothub_client/__init__.py
+++ b/build_all/mac/release_device_client/build/lib/iothub_client/__init__.py
@@ -1,0 +1,1 @@
+from .iothub_client import *

--- a/build_all/mac/release_device_client/iothub_client/__init__.py
+++ b/build_all/mac/release_device_client/iothub_client/__init__.py
@@ -1,0 +1,1 @@
+from .iothub_client import *

--- a/build_all/mac/release_device_client/setup_device_client.py
+++ b/build_all/mac/release_device_client/setup_device_client.py
@@ -1,0 +1,56 @@
+from setuptools import setup, Distribution
+import sys
+
+class PlatformError(Exception):
+    def __init__(self, value):
+        self.value = value
+    def __str__(self):
+        return repr(self.value)
+
+class BinaryDistribution(Distribution):
+    def is_pure(self):
+        return False
+
+_long_description=()
+
+try:
+    if sys.version_info < (2, 7):
+        raise PlatformError("Require Python 2.7 or greater")
+    if sys.version_info >= (3, 0) and sys.version_info < (3, 4):
+        raise PlatformError("Require Python 3.4 or greater")
+except PlatformError as e:
+    sys.exit(e.value)
+
+try:
+    from iothub_client import iothub_client
+    _version = iothub_client.__version__
+except Exception as e:
+    sys.exit(e)
+
+setup(
+    name='azure_iothub_device_client',
+    version=_version, # using version of actual c device client release plus minor release for Python
+    description='IoT Hub Device Client Library',
+    license='Apache Software License',
+    url='https://github.com/Azure/azure-iot-sdk-python/tree/master/device',
+    author='aziotclb',
+    author_email='aziotclb@microsoft.com',
+    long_description='IoT Hub Device Client Library for Python 2.7 and 3.6 - iothub_client.so',
+    packages=['iothub_client'],
+    classifiers=[
+        'Environment :: Linux',
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Build Tools',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6'],
+    package_data={
+        'iothub_client': ['__init__.py','iothub_client.so'],
+    },
+    distclass=BinaryDistribution
+) 

--- a/build_all/mac/release_service_client/build/lib.linux-x86_64-2.7/iothub_service_client/__init__.py
+++ b/build_all/mac/release_service_client/build/lib.linux-x86_64-2.7/iothub_service_client/__init__.py
@@ -1,0 +1,1 @@
+from .iothub_service_client import *

--- a/build_all/mac/release_service_client/build/lib/iothub_service_client/__init__.py
+++ b/build_all/mac/release_service_client/build/lib/iothub_service_client/__init__.py
@@ -1,0 +1,1 @@
+from .iothub_service_client import *

--- a/build_all/mac/release_service_client/iothub_service_client/__init__.py
+++ b/build_all/mac/release_service_client/iothub_service_client/__init__.py
@@ -1,0 +1,1 @@
+from .iothub_service_client import *

--- a/build_all/mac/release_service_client/setup_service_client.py
+++ b/build_all/mac/release_service_client/setup_service_client.py
@@ -1,0 +1,56 @@
+from setuptools import setup, Distribution
+import sys
+
+class PlatformError(Exception):
+    def __init__(self, value):
+        self.value = value
+    def __str__(self):
+        return repr(self.value)
+
+class BinaryDistribution(Distribution):
+    def is_pure(self):
+        return False
+
+_long_description=()
+
+try:
+    if sys.version_info < (2, 7):
+        raise PlatformError("Require Python 2.7 or greater")
+    if sys.version_info >= (3, 0) and sys.version_info < (3, 4):
+        raise PlatformError("Require Python 3.4 or greater")
+except PlatformError as e:
+    sys.exit(e.value)
+
+try:
+    from iothub_service_client import iothub_service_client
+    _version = iothub_service_client.__version__
+except Exception as e:
+    sys.exit(e)
+
+setup(
+    name='azure_iothub_service_client',
+    version=_version, # using version of actual c device client release plus minor release for Python
+    description='IoT Hub Service Client Library',
+    license='Apache Software License',
+    url='https://github.com/Azure/azure-iot-sdk-python/tree/master/service',
+    author='aziotclb',
+    author_email='aziotclb@microsoft.com',
+    long_description='IoT Hub Service Client Library for Python 2.7 and 3.6 - iothub_service_client.so',
+    packages=['iothub_service_client'],
+    classifiers=[
+        'Environment :: Linux',
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Build Tools',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6'],
+    package_data={
+        'iothub_service_client': ['__init__.py','iothub_service_client.so'],
+    },
+    distclass=BinaryDistribution
+) 

--- a/build_all/mac/setup.sh
+++ b/build_all/mac/setup.sh
@@ -36,10 +36,6 @@ process_args()
 
 process_args $*
 
-# instruct C setup to install all dependent libraries
-./c/build_all/mac/setup.sh
-[ $? -eq 0 ] || exit $?
-
 scriptdir=$(cd "$(dirname "$0")" && pwd)
 
 if [ $PYTHON_VERSION == "3.4" ] || [ $PYTHON_VERSION == "3.5" ] || [ $PYTHON_VERSION == "3.6" ]
@@ -53,7 +49,9 @@ fi
 
 deps_install ()
 {
+	# install all dependent libraries for azure-iot-sdk-c
 	brew install boost openssl cmake
+
 	if brew list boost-python >/dev/null 2>&1; then
 		echo "Reinstall boost-python"
 		brew uninstall boost-python

--- a/build_all/mac/setup.sh
+++ b/build_all/mac/setup.sh
@@ -44,13 +44,16 @@ scriptdir=$(cd "$(dirname "$0")" && pwd)
 
 if [ $PYTHON_VERSION == "3.4" ] || [ $PYTHON_VERSION == "3.5" ] || [ $PYTHON_VERSION == "3.6" ]
 then
+	echo "BUILDING BOOST for PYTHON $PYTHON_VERSION"
 	deps="boost-python --with-python3"
 else
+	echo "INSTALL BOOST for PYTHON $PYTHON_VERSION"
 	deps="boost-python"
 fi 
 
 deps_install ()
 {
+	brew uninstall boost-python
 	brew install $deps
 }
 

--- a/build_all/mac/setup.sh
+++ b/build_all/mac/setup.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# This script updates a fresh Ubuntu installation with all the dependent
+# components necessary to use the IoT Client SDK for C and Python.
+
+build_root=$(cd "$(dirname "$0")/../.." && pwd)
+cd $build_root
+
+# instruct C setup to install all dependent libraries
+
+./c/build_all/mac/setup.sh 
+[ $? -eq 0 ] || exit $?
+
+PYTHON_VERSION=2.7
+
+process_args()
+{
+    save_next_arg=0
+    
+    for arg in $*
+    do
+      if [ $save_next_arg == 1 ]
+      then
+        PYTHON_VERSION="$arg"
+        save_next_arg=0
+      else
+        case "$arg" in
+          "--python-version" ) save_next_arg=1;;
+          * ) ;;
+        esac
+      fi
+    done
+}
+
+process_args $*
+
+scriptdir=$(cd "$(dirname "$0")" && pwd)
+deps="python${PYTHON_VERSION}-dev libboost-python-dev"
+
+deps_install ()
+{
+	brew install boost
+}
+
+deps_install
+

--- a/build_all/mac/setup.sh
+++ b/build_all/mac/setup.sh
@@ -8,11 +8,6 @@
 build_root=$(cd "$(dirname "$0")/../.." && pwd)
 cd $build_root
 
-# instruct C setup to install all dependent libraries
-
-./c/build_all/mac/setup.sh 
-[ $? -eq 0 ] || exit $?
-
 PYTHON_VERSION=2.7
 
 process_args()
@@ -24,10 +19,15 @@ process_args()
       if [ $save_next_arg == 1 ]
       then
         PYTHON_VERSION="$arg"
+        if [ $PYTHON_VERSION != "2.7" ] && [ $PYTHON_VERSION != "3.4" ] && [ $PYTHON_VERSION != "3.5" ] && [ $PYTHON_VERSION != "3.6" ]
+        then
+          echo "Supported python versions are 2.7, 3.4 or 3.5"
+          exit 1
+        fi 
         save_next_arg=0
       else
         case "$arg" in
-          "--python-version" ) save_next_arg=1;;
+          "--build-python" ) save_next_arg=1;;
           * ) ;;
         esac
       fi
@@ -36,12 +36,22 @@ process_args()
 
 process_args $*
 
+# instruct C setup to install all dependent libraries
+./c/build_all/mac/setup.sh
+[ $? -eq 0 ] || exit $?
+
 scriptdir=$(cd "$(dirname "$0")" && pwd)
-deps="python${PYTHON_VERSION}-dev libboost-python-dev"
+
+if [ $PYTHON_VERSION == "3.4" ] || [ $PYTHON_VERSION == "3.5" ] || [ $PYTHON_VERSION == "3.6" ]
+then
+	deps="boost-python --with-python3"
+else
+	deps="boost-python"
+fi 
 
 deps_install ()
 {
-	brew install boost
+	brew install $deps
 }
 
 deps_install

--- a/build_all/mac/setup.sh
+++ b/build_all/mac/setup.sh
@@ -53,6 +53,7 @@ fi
 
 deps_install ()
 {
+	brew install boost openssl cmake
 	if brew list boost-python >/dev/null 2>&1; then
 		echo "Reinstall boost-python"
 		brew uninstall boost-python

--- a/build_all/mac/setup.sh
+++ b/build_all/mac/setup.sh
@@ -53,7 +53,10 @@ fi
 
 deps_install ()
 {
-	brew uninstall boost-python
+	if brew list boost-python >/dev/null 2>&1; then
+		echo "Reinstall boost-python"
+		brew uninstall boost-python
+	fi
 	brew install $deps
 }
 

--- a/device/iothub_client_python/CMakeLists.txt
+++ b/device/iothub_client_python/CMakeLists.txt
@@ -34,6 +34,9 @@ if(WIN32)
         message("of the extracted boost package with headers and libraries")
         message(FATAL_ERROR "iothub_client_python needs Boost library")
     endif()
+elseif(APPLE)
+    # mac boost-python libs didn't support versions
+    find_package(Boost COMPONENTS python)
 else()
     # older boost-python libs didn't support versions
     if (${build_python} STREQUAL "2.7")

--- a/device/iothub_client_python/CMakeLists.txt
+++ b/device/iothub_client_python/CMakeLists.txt
@@ -35,8 +35,13 @@ if(WIN32)
         message(FATAL_ERROR "iothub_client_python needs Boost library")
     endif()
 elseif(APPLE)
-    # mac boost-python libs didn't support versions
-    find_package(Boost COMPONENTS python)
+    if (${build_python} STREQUAL "2.7")
+        find_package(Boost COMPONENTS python)
+    else()
+        find_package(Boost COMPONENTS python)
+        # mac boost-python libs don't support versions
+        string(REPLACE "libboost_python-mt.dylib" "libboost_python3-mt.dylib" Boost_LIBRARIES ${Boost_LIBRARIES})
+    endif()
 else()
     # older boost-python libs didn't support versions
     if (${build_python} STREQUAL "2.7")

--- a/doc/python-devbox-setup.md
+++ b/doc/python-devbox-setup.md
@@ -5,6 +5,7 @@ This document describes how to prepare your development environment to use the *
 - [Setup your development environment](#devenv)
 - [Install on Windows using PyPI wheels](#windows-wheels)
 - [Build the samples on Linux](#linux)
+- [Build the samples on Mac](#mac)
 - [Build the samples on Windows using nuget packages](#windows)
 - [Build the samples on Windows using cmake and boost libraries](#windows-cmake)
 - [Sample applications](#samplecode)
@@ -58,6 +59,32 @@ The Python iothub_client and iothub_service_client modules support python versio
 If you run into this issue, check the **memory consumption** of the device using `free -m command` in another terminal window during that time. If you are running out of memory while compiling iothub_client_python.cpp file, you may have to temporarily increase the **swap space** to get more available memory to successfully build the Python client side device SDK library.
 
 2.) CentOS7: Only Python 2.7 is supported due to a missing boost-python3 library package
+
+<a name="mac"></a>
+## Build the Azure IoT Hub SDKs for Python on Mac OS
+
+### Installs needed to compile the SDKs for Python from souce code
+Because the Azure IoT SDKs for Python are wrappers on top of the [SDKs for C][azure-iot-sdk-c], you will need to compile the C libraries if you want or need to generate the Python libraries from source code.
+You will notice that the C SDKs are brought in as submodules to the current repository.
+In order to setup your development environment to build the C binaries, you need to follow the instructions [here][c-devbox-setup]:
+* On Mac OS you will need XCode and install the Commandline Utils
+
+### Compile the Python modules
+The Python iothub_client and iothub_service_client modules support python versions 2.7.x, 3.4.x or 3.5.x. Know the appropriate version you would like to build the library with for the following instructions.
+
+1. Ensure that the desired Python version (2.7.x, 3.4 or 3.5.x) is installed and active. Run `python --version` or `python3 --version` at the command line to check the version.
+2. Open a shell and navigate to the folder **build_all/mac** in your local copy of the repository.
+3. Run the `./setup.sh` script to install the prerequisite packages and the dependent libraries.
+    * Setup will default to python 2.7
+    * To setup dependencies for python 3.4 or 3.5, run `./setup.sh --python-version 3.4` or `./setup.sh --python-version 3.5` respectively
+4. Run the `./build.sh` script.
+    * Build will default to python 2.7
+    * To build with python 3.4 or 3.5, run `./build.sh --build-python 3.4` or `./build.sh --build-python 3.5` respectively 
+5. After a successful build, the `iothub_client.so` Python extension module is copied to the [**device/samples**][device-samples] and [**service/samples**][service-samples] folders. Visit these folders for instructions on how to run the samples.
+
+###Known build issues: 
+
+none so far.
 
 <a name="windows"></a>
 ## Build the Python device and service client modules on Windows using Nuget packages (recommended)

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -34,6 +34,9 @@ if(WIN32)
         message("of the extracted boost package with headers and libraries")
         message(FATAL_ERROR "iothub_client_python needs Boost library")
     endif()
+elseif(APPLE)
+    # mac boost-python libs didn't support versions
+    find_package(Boost COMPONENTS python)
 else()
     # older boost-python libs didn't support versions
     if (${build_python} STREQUAL "2.7")

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -35,8 +35,13 @@ if(WIN32)
         message(FATAL_ERROR "iothub_client_python needs Boost library")
     endif()
 elseif(APPLE)
-    # mac boost-python libs didn't support versions
-    find_package(Boost COMPONENTS python)
+    if (${build_python} STREQUAL "2.7")
+        find_package(Boost COMPONENTS python)
+    else()
+        find_package(Boost COMPONENTS python)
+        # mac boost-python libs don't support versions
+        string(REPLACE "libboost_python-mt.dylib" "libboost_python3-mt.dylib" Boost_LIBRARIES ${Boost_LIBRARIES})
+    endif()
 else()
     # older boost-python libs didn't support versions
     if (${build_python} STREQUAL "2.7")


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT python SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-python/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Python module does not build on Mac OS

# Description of the solution
I copied the linux version, and changed the parameters to work on Mac OS.