### PR TITLE
Argname --python-version to reflect other builds/readme

### DIFF
--- a/build_all/mac/setup.sh
+++ b/build_all/mac/setup.sh
@@ -27,7 +27,7 @@ process_args()
         save_next_arg=0
       else
         case "$arg" in
-          "--build-python" ) save_next_arg=1;;
+          "--python-version" ) save_next_arg=1;;
           * ) ;;
         esac
       fi


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-python/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Unlike setup scripts for linux and windows (and in the documentation), the command line argument for the python version was --build-python instead of --python-version.

# Description of the solution
Changed the command line argument to --python-version.