### PR TITLE
Mods to allow older compilers to build code

### DIFF
--- a/service/src/iothub_service_client_python.cpp
+++ b/service/src/iothub_service_client_python.cpp
@@ -731,12 +731,12 @@ void iothubServiceClientAuthError(const IoTHubServiceClientAuthError& x)
 
 class IoTHubServiceClientAuth
 {
-    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE _iothubServiceClientAuthHandle = NULL;
+    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE _iothubServiceClientAuthHandle;
 public:
 
     IoTHubServiceClientAuth(
         std::string connectionString
-        )
+        ) : _iothubServiceClientAuthHandle(NULL)
     {
         ScopedGILRelease release;
         _iothubServiceClientAuthHandle = IoTHubServiceClientAuth_CreateFromConnectionString(connectionString.c_str());
@@ -829,13 +829,13 @@ struct DEVICE_CREATE
 
 class IoTHubRegistryManager
 {
-    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE _iothubServiceClientAuthHandle = NULL;
-    IOTHUB_REGISTRYMANAGER_HANDLE _iothubRegistryManagerHandle = NULL;
+    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE _iothubServiceClientAuthHandle;
+    IOTHUB_REGISTRYMANAGER_HANDLE _iothubRegistryManagerHandle;
 public:
 
     IoTHubRegistryManager(
         std::string connectionString
-        )
+        ) : _iothubServiceClientAuthHandle(NULL), _iothubRegistryManagerHandle(NULL)
     {
         ScopedGILRelease release;
         PlatformCallHandler::Platform_Init();
@@ -1217,11 +1217,11 @@ FeedbackMessageReceivedCallback(
 
 class IoTHubMessaging
 {
-    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE _iothubServiceClientAuthHandle = NULL;
-    IOTHUB_MESSAGING_CLIENT_HANDLE _iothubMessagingHandle = NULL;
-    OpenCompleteContext *openCompleteContext = NULL;
-    SendCompleteContext *sendCompleteContext = NULL;
-    FeedbackMessageReceivedContext *feedbackMessageContext = NULL;
+    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE _iothubServiceClientAuthHandle;
+    IOTHUB_MESSAGING_CLIENT_HANDLE _iothubMessagingHandle;
+    OpenCompleteContext *openCompleteContext;
+    SendCompleteContext *sendCompleteContext;
+    FeedbackMessageReceivedContext *feedbackMessageContext;
 
     void CreateContexts()
     {
@@ -1251,7 +1251,11 @@ class IoTHubMessaging
 public:
     IoTHubMessaging(
         std::string connectionString
-        )
+        ) : _iothubServiceClientAuthHandle(NULL),
+			_iothubMessagingHandle(NULL),
+			openCompleteContext(NULL),
+			sendCompleteContext(NULL),
+			feedbackMessageContext(NULL)
     {
         ScopedGILRelease release;
         PlatformCallHandler::Platform_Init();
@@ -1442,12 +1446,13 @@ struct IoTHubDeviceMethodResponse
 
 class IoTHubDeviceMethod
 {
-    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE _iothubServiceClientAuthHandle = NULL;
-    IOTHUB_SERVICE_CLIENT_DEVICE_METHOD_HANDLE _iothubDeviceMethodHandle = NULL;
+    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE _iothubServiceClientAuthHandle; 
+    IOTHUB_SERVICE_CLIENT_DEVICE_METHOD_HANDLE _iothubDeviceMethodHandle;
 public:
     IoTHubDeviceMethod(
         std::string connectionString
-        )
+        ) : _iothubServiceClientAuthHandle(NULL),
+			_iothubDeviceMethodHandle(NULL)
     {
         ScopedGILRelease release;
         PlatformCallHandler::Platform_Init();
@@ -1587,12 +1592,13 @@ void iothubDeviceTwinError(const IoTHubDeviceTwinError& x)
 
 class IoTHubDeviceTwin
 {
-    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE _iothubServiceClientAuthHandle = NULL;
-    IOTHUB_SERVICE_CLIENT_DEVICE_TWIN_HANDLE _iothubDeviceTwinHandle = NULL;
+    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE _iothubServiceClientAuthHandle;
+    IOTHUB_SERVICE_CLIENT_DEVICE_TWIN_HANDLE _iothubDeviceTwinHandle;
 public:
     IoTHubDeviceTwin(
         std::string connectionString
-        )
+        ) : _iothubServiceClientAuthHandle(NULL),
+			_iothubDeviceTwinHandle(NULL)
     {
         ScopedGILRelease release;
         PlatformCallHandler::Platform_Init();


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT python SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-python/blob/master/.github/CONTRIBUTING.md).
- [N/A ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [N/A ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [N/A] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
The use of initializing non-static member variables in classes is not supported by older compilers. This is causing compatibility problems with certain Linux distributions.

# Description of the solution
Removed all non-static member inline initialization and added them to the constructor using the original notation of classname(parameterlist) : variablename(initialvalue) {}