### PR TITLE
Fix #135 - Mac: not a supported wheel on this platform

### DIFF
--- a/build_all/mac/release.sh
+++ b/build_all/mac/release.sh
@@ -37,9 +37,9 @@ process_args $*
 
 # identify processor architecture
 if [[ "$(uname -m)" = "x86_64" ]] ; then
-    PLAT_ARCH="macos64"
+    PLAT_ARCH="macosx_10_6_x86_64"
 else
-    PLAT_ARCH="macos32"
+    PLAT_ARCH="macosx_10_6_i386"
 fi
 
 ########################################################


### PR DESCRIPTION
# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-python/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 
  - [X] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [X] I have squashed my changes into one with a clear description of the change.

 # Reference/Link to the issue solved with this PR (if any)
Issue #135

# Description of the solution
Wheels built for MacOSX can't be installed on MacOSX.
This is similar to issue #36 -- the PLAT_ARCH is embedded
as a tag in the wheel name. But as far as I can tell,
macos64 and macos32 are not supported platforms on any machine.

Update the two PLAT_ARCH tags to macosx_10_6_x86_64 and macosx_10_6_i386

$ python --version
Python 3.6.5

$ azure-iot-sdk-python/build_all/mac/release.sh --build-python 3.6

$ pip install azure-iot-sdk-python/build_all/mac/release_service_client/dist/azure_iothub_service_client-1.3.2-py3-none-macosx_10_6_x86_64.whl
Processing ./release_service_client/dist/azure_iothub_service_client-1.3.2-py3-none-macosx_10_6_x86_64.whl
Installing collected packages: azure-iothub-service-client
Successfully installed azure-iothub-service-client-1.3.2

$ pip freeze
azure-iothub-service-client==1.3.2