### PR TITLE
Adding notice that 3.6 is also supported

### DIFF
--- a/build_all/mac/setup.sh
+++ b/build_all/mac/setup.sh
@@ -21,7 +21,7 @@ process_args()
         PYTHON_VERSION="$arg"
         if [ $PYTHON_VERSION != "2.7" ] && [ $PYTHON_VERSION != "3.4" ] && [ $PYTHON_VERSION != "3.5" ] && [ $PYTHON_VERSION != "3.6" ]
         then
-          echo "Supported python versions are 2.7, 3.4 or 3.5"
+          echo "Supported python versions are 2.7, 3.4, 3.5 or 3.6"
           exit 1
         fi 
         save_next_arg=0


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT python SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-python/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 
  - [X] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [X] I have squashed my changes into one with a clear description of the change.

  
# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Original text stated that it only supported up to 3.5, but if statement was covering to 3.6.

# Description of the solution
Just adding that 3.6 is supported. 