### PR TITLE
issue179 empty message problem on mqtt

### DIFF
--- a/device/samples/iothub_client_simple_sample.py
+++ b/device/samples/iothub_client_simple_sample.py
@@ -1,4 +1,5 @@
 from iothub_client import IoTHubClient, IoTHubTransportProvider, IoTHubMessage
+import time
 
 CONNECTION_STRING = "<YOUR DEVICE CONNECTION STRING HERE>"
 PROTOCOL = IoTHubTransportProvider.MQTT
@@ -13,3 +14,6 @@ if __name__ == '__main__':
     message = IoTHubMessage("test message")
     client.send_event_async(message, send_confirmation_callback, None)
     print("Message transmitted to IoT Hub")
+
+    while True:
+        time.sleep(1)

--- a/device/tests/iothub_client_e2e.py
+++ b/device/tests/iothub_client_e2e.py
@@ -11,6 +11,7 @@ import time
 import threading
 import types
 import base64
+import time
 
 from iothub_service_client import IoTHubRegistryManager, IoTHubRegistryManagerAuthMethod
 from iothub_service_client import IoTHubMessaging
@@ -546,6 +547,18 @@ def run_e2e_device_client(iothub_service_client_messaging, iothub_device_method,
 
         # verify
         assert MESSAGE_RECEIVE_CALLBACK_COUNTER > 0, "Error: message has not been received"
+
+        # prepare
+        MESSAGING_MESSAGE = ""
+        empty_message = IoTHubMessage(MESSAGING_MESSAGE)
+        # act
+        sc_send_message(iothub_service_client_messaging, device_id, empty_message, testing_modules)
+        time.sleep(60) 
+        MESSAGE_RECEIVE_EVENT.wait(CALLBACK_TIMEOUT)
+
+        # verify
+        assert MESSAGE_RECEIVE_CALLBACK_COUNTER > 1, "Error: empty message has not been received"
+
         ###########################################################################
 
     ###########################################################################

--- a/device/tests/iothub_client_e2e.py
+++ b/device/tests/iothub_client_e2e.py
@@ -553,7 +553,7 @@ def run_e2e_device_client(iothub_service_client_messaging, iothub_device_method,
         empty_message = IoTHubMessage(MESSAGING_MESSAGE)
         # act
         sc_send_message(iothub_service_client_messaging, device_id, empty_message, testing_modules)
-        time.sleep(60) 
+        time.sleep(30) 
         MESSAGE_RECEIVE_EVENT.wait(CALLBACK_TIMEOUT)
 
         # verify


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT python SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-python/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x ] I have squashed my changes into one with a clear description of the change.
 I have squashed it to some meaningful commits. 

  
# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
https://github.com/Azure/azure-iot-sdk-python/issues/179

# Description of the solution
The C SDK was modified to rectify the error. Previously when the message payload is empty it would still try send the message , but now the code has been modified to remove the empty message item from the list of messages waiting to be sent.