### PR TITLE
add option to not run make, add -ggdb for debug builds

### DIFF
--- a/build_all/linux/build.sh
+++ b/build_all/linux/build.sh
@@ -9,11 +9,12 @@ cd $build_root
 
 PYTHON_VERSION=2.7
 USE_TPM_SIM=
+make=true
 
 process_args()
 {
     save_next_arg=0
-    
+
     for arg in $*
     do
       if [ $save_next_arg == 1 ]
@@ -27,6 +28,7 @@ process_args()
         esac
         case "$arg" in
           "--use-tpm-simulator" ) USE_TPM_SIM="--use-tpm-simulator";;
+          "--no-make" ) make=false;;
           * ) ;;
         esac
       fi
@@ -37,7 +39,11 @@ process_args $*
 
 # instruct C builder to include python library and to skip tests
 
-./c/build_all/linux/build.sh --build-python $PYTHON_VERSION $* --provisioning $USE_TPM_SIM --use-edge-modules
+if [ "$make" = false ]; then
+  $NO_MAKE="--no-make"
+fi
+
+./c/build_all/linux/build.sh --build-python $PYTHON_VERSION $* --provisioning $USE_TPM_SIM --use-edge-modules $NO_MAKE
 [ $? -eq 0 ] || exit $?
 cd $build_root
 

--- a/device/iothub_client_python/CMakeLists.txt
+++ b/device/iothub_client_python/CMakeLists.txt
@@ -65,6 +65,12 @@ if (WIN32)
   add_definitions( -DBOOST_PYTHON_STATIC_LIB )
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  if (CMAKE_BUILD_TYPE EQUAL "DEBUG")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb")
+  endif()
+endif()
 
 # get python
 # some versions of cmake shipped with Linux


### PR DESCRIPTION
These are two changes from my edge e2e work that make debugging the edge tests much easier.  

adding --no-make to build.sh.  This makes my edge-e2e Dockerfile run much more efficiently because it lets me run build incrementally in a way that takes advantages of intermediate images.

Adding -ggdb when build debug python for linux.  This gives me symbols when debugging under gdb.  (-g generates symbols, but if your gcc and gdb aren't "in sync", gdb can't read these symbols.  It's better to be explicit here.)