### PR TITLE
Fix for #230 - method callbacks

### DIFF
--- a/device/iothub_client_python/src/iothub_client_python.cpp
+++ b/device/iothub_client_python/src/iothub_client_python.cpp
@@ -1225,7 +1225,7 @@ InboundDeviceMethodCallback(
     ScopedGILAcquire acquire;
     try
     {
-        boost::python::object user_response_obj = deviceMethodCallback(method_name_std_string, payload_std_string, (unsigned long int)method_id, userContext);
+        boost::python::object user_response_obj = deviceMethodCallback(method_name_std_string, payload_std_string, (unsigned long long)method_id, userContext);
 
 
         retVal = boost::python::extract<int>(user_response_obj)();
@@ -1955,7 +1955,7 @@ public:
     }
 
     void DeviceMethodResponse(
-        unsigned long int method_id,
+        unsigned long long method_id,
         std::string response,
         size_t size,
         int statusCode

--- a/device/iothub_client_python/src/iothub_client_python.cpp
+++ b/device/iothub_client_python/src/iothub_client_python.cpp
@@ -1225,11 +1225,10 @@ InboundDeviceMethodCallback(
     ScopedGILAcquire acquire;
     try
     {
-        boost::python::object user_response_obj = deviceMethodCallback(method_name_std_string, payload_std_string, method_id, userContext);
+        boost::python::object user_response_obj = deviceMethodCallback(method_name_std_string, payload_std_string, (unsigned long int)method_id, userContext);
 
-        DeviceMethodReturnValue user_response_value = boost::python::extract<DeviceMethodReturnValue>(user_response_obj)();
 
-        retVal = user_response_value.status;
+        retVal = boost::python::extract<int>(user_response_obj)();
     }
     catch (const boost::python::error_already_set)
     {
@@ -1956,7 +1955,7 @@ public:
     }
 
     void DeviceMethodResponse(
-        METHOD_HANDLE method_id,
+        unsigned long int method_id,
         std::string response,
         size_t size,
         int statusCode
@@ -1965,7 +1964,7 @@ public:
         IOTHUB_CLIENT_RESULT result;
         {
             ScopedGILRelease release;
-            result = IoTHubDeviceClient_DeviceMethodResponse(iotHubClientHandle, method_id, (const unsigned char*)response.c_str(), size, statusCode);
+            result = IoTHubDeviceClient_DeviceMethodResponse(iotHubClientHandle, (METHOD_HANDLE)method_id, (const unsigned char*)response.c_str(), size, statusCode);
         }
         if (result != IOTHUB_CLIENT_OK)
         {

--- a/device/tests/iothub_client_ut.py
+++ b/device/tests/iothub_client_ut.py
@@ -966,7 +966,7 @@ class TestClassDefinitions(unittest.TestCase):
         self.assertIsNone(result)
 
         # device_method_response
-        method_id = None
+        method_id = 42
         response = "{}"
         size = 2
         statusCode = 0


### PR DESCRIPTION
The method_id parameter wasn't properly marshalled between the boost wrapper and the python code.
Also, the boost wrapper was not unpacking the return value of the callback with the appropriate tag.