### PR TITLE
Pin boost version to 1.58 to fix Azure Devops build agent

### DIFF
--- a/device/iothub_client_python/CMakeLists.txt
+++ b/device/iothub_client_python/CMakeLists.txt
@@ -46,11 +46,11 @@ elseif(APPLE)
 else()
     # older boost-python libs didn't support versions
     if (${build_python} STREQUAL "2.7")
-        find_package(Boost COMPONENTS python)
+        find_package(Boost 1.58 EXACT COMPONENTS python)
     else()
         # Remove the period from python version for boost component
         string(REPLACE "." "" boost_python ${build_python})
-        find_package(Boost COMPONENTS "python-py${boost_python}")
+        find_package(Boost 1.58 EXACT COMPONENTS "python-py${boost_python}")
     endif()
 endif()
 

--- a/device/iothub_client_python/CMakeLists.txt
+++ b/device/iothub_client_python/CMakeLists.txt
@@ -46,11 +46,11 @@ elseif(APPLE)
 else()
     # older boost-python libs didn't support versions
     if (${build_python} STREQUAL "2.7")
-        find_package(Boost 1.58 EXACT COMPONENTS python)
+        find_package(Boost 1.58.0 EXACT COMPONENTS python)
     else()
         # Remove the period from python version for boost component
         string(REPLACE "." "" boost_python ${build_python})
-        find_package(Boost 1.58 EXACT COMPONENTS "python-py${boost_python}")
+        find_package(Boost 1.58.0 EXACT COMPONENTS "python-py${boost_python}")
     endif()
 endif()
 

--- a/provisioning_device_client/CMakeLists.txt
+++ b/provisioning_device_client/CMakeLists.txt
@@ -46,11 +46,11 @@ elseif(APPLE)
 else()
     # older boost-python libs didn't support versions
     if (${build_python} STREQUAL "2.7")
-        find_package(Boost COMPONENTS python)
+        find_package(Boost 1.58 EXACT COMPONENTS python)
     else()
         # Remove the period from python version for boost component
         string(REPLACE "." "" boost_python ${build_python})
-        find_package(Boost COMPONENTS "python-py${boost_python}")
+        find_package(Boost 1.58 EXACT COMPONENTS "python-py${boost_python}")
     endif()
 endif()
 

--- a/provisioning_device_client/CMakeLists.txt
+++ b/provisioning_device_client/CMakeLists.txt
@@ -46,11 +46,11 @@ elseif(APPLE)
 else()
     # older boost-python libs didn't support versions
     if (${build_python} STREQUAL "2.7")
-        find_package(Boost 1.58 EXACT COMPONENTS python)
+        find_package(Boost 1.58.0 EXACT COMPONENTS python)
     else()
         # Remove the period from python version for boost component
         string(REPLACE "." "" boost_python ${build_python})
-        find_package(Boost 1.58 EXACT COMPONENTS "python-py${boost_python}")
+        find_package(Boost 1.58.0 EXACT COMPONENTS "python-py${boost_python}")
     endif()
 endif()
 

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -46,11 +46,11 @@ elseif(APPLE)
 else()
     # older boost-python libs didn't support versions
     if (${build_python} STREQUAL "2.7")
-        find_package(Boost COMPONENTS python)
+        find_package(Boost 1.58 EXACT COMPONENTS python)
     else()
         # Remove the period from python version for boost component
         string(REPLACE "." "" boost_python ${build_python})
-        find_package(Boost COMPONENTS "python-py${boost_python}")
+        find_package(Boost 1.58 EXACT COMPONENTS "python-py${boost_python}")
     endif()
 endif()
 

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -46,11 +46,11 @@ elseif(APPLE)
 else()
     # older boost-python libs didn't support versions
     if (${build_python} STREQUAL "2.7")
-        find_package(Boost 1.58 EXACT COMPONENTS python)
+        find_package(Boost 1.58.0 EXACT COMPONENTS python)
     else()
         # Remove the period from python version for boost component
         string(REPLACE "." "" boost_python ${build_python})
-        find_package(Boost 1.58 EXACT COMPONENTS "python-py${boost_python}")
+        find_package(Boost 1.58.0 EXACT COMPONENTS "python-py${boost_python}")
     endif()
 endif()
 


### PR DESCRIPTION
Looks like the msft-hosted build agents for Ubuntu 16.04 now have Boost 1.69 installed and this version isn't building with our SDK so we need to pin the version to 1.58