### PR TITLE
create random registration names

### DIFF
--- a/azure_provisioning_e2e/pytest.ini
+++ b/azure_provisioning_e2e/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --timeout 30

--- a/azure_provisioning_e2e/tests/test_async_certificate_enrollments.py
+++ b/azure_provisioning_e2e/tests/test_async_certificate_enrollments.py
@@ -16,6 +16,7 @@ from provisioningserviceclient.protocol.models import AttestationMechanism, Repr
 import pytest
 import logging
 import os
+import uuid
 
 from scripts.create_x509_chain_pipeline import (
     call_intermediate_cert_creation_from_pipeline,
@@ -30,7 +31,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 intermediate_common_name = "e2edpshomenum"
 intermediate_password = "revelio"
-device_common_name = "e2edpslocomotor"
+device_common_name = "e2edpslocomotor" + str(uuid.uuid4())
 device_password = "mortis"
 
 service_client = ProvisioningServiceClient.create_from_connection_string(
@@ -74,7 +75,9 @@ def before_all_tests(request):
 
 
 @pytest.mark.it(
-    "A device gets provisioned to the linked IoTHub with the user supplied device_id different from the registration_id of the individual enrollment that has been created with a selfsigned X509 authentication"
+    "A device gets provisioned to the linked IoTHub with the user supplied device_id different "
+    "from the registration_id of the individual enrollment that has been created with a "
+    "selfsigned X509 authentication"
 )
 async def test_device_register_with_device_id_for_a_x509_individual_enrollment():
     device_id = "e2edpsthunderbolt"
@@ -129,7 +132,7 @@ async def test_device_register_with_no_device_id_for_a_x509_individual_enrollmen
     "A group of devices get provisioned to the linked IoTHub with device_ids equal to the individual registration_ids inside a group enrollment that has been created with intermediate X509 authentication"
 )
 async def test_group_of_devices_register_with_no_device_id_for_a_x509_intermediate_authentication_group_enrollment():
-    group_id = "e2e-intermediate-durmstrang"
+    group_id = "e2e-intermediate-durmstrang" + str(uuid.uuid4())
     common_device_id = device_common_name
     devices_indices = type_to_device_indices.get("group_intermediate")
     device_count_in_group = len(devices_indices)
@@ -188,7 +191,7 @@ async def test_group_of_devices_register_with_no_device_id_for_a_x509_intermedia
     "A group of devices get provisioned to the linked IoTHub with device_ids equal to the individual registration_ids inside a group enrollment that has been created with an already uploaded ca cert X509 authentication"
 )
 async def test_group_of_devices_register_with_no_device_id_for_a_x509_ca_authentication_group_enrollment():
-    group_id = "e2e-ca-ilvermorny"
+    group_id = "e2e-ca-ilvermorny" + str(uuid.uuid4())
     common_device_id = device_common_name
     devices_indices = type_to_device_indices.get("group_ca")
     device_count_in_group = len(devices_indices)

--- a/azure_provisioning_e2e/tests/test_async_symmetric_enrollments.py
+++ b/azure_provisioning_e2e/tests/test_async_symmetric_enrollments.py
@@ -11,7 +11,7 @@ from provisioningserviceclient.protocol.models import AttestationMechanism, Repr
 import pytest
 import logging
 import os
-
+import uuid
 
 pytestmark = pytest.mark.asyncio
 logging.basicConfig(level=logging.DEBUG)
@@ -29,11 +29,14 @@ linked_iot_hub = connection_string_to_hostname(os.getenv("IOTHUB_CONNECTION_STRI
 
 
 @pytest.mark.it(
-    "A device gets provisioned to the linked IoTHub with the device_id equal to the registration_id of the individual enrollment that has been created with a symmetric key authentication"
+    "A device gets provisioned to the linked IoTHub with the device_id equal to the registration_id"
+    "of the individual enrollment that has been created with a symmetric key authentication"
 )
 async def test_device_register_with_no_device_id_for_a_symmetric_key_individual_enrollment():
     try:
-        individual_enrollment_record = create_individual_enrollment("e2e-dps-legilimens")
+        individual_enrollment_record = create_individual_enrollment(
+            "e2e-dps-legilimens" + str(uuid.uuid4())
+        )
 
         registration_id = individual_enrollment_record.registration_id
         symmetric_key = individual_enrollment_record.attestation.symmetric_key.primary_key
@@ -56,7 +59,7 @@ async def test_device_register_with_device_id_for_a_symmetric_key_individual_enr
     device_id = "e2edpsgoldensnitch"
     try:
         individual_enrollment_record = create_individual_enrollment(
-            registration_id="e2e-dps-levicorpus", device_id=device_id
+            registration_id="e2e-dps-levicorpus" + str(uuid.uuid4()), device_id=device_id
         )
 
         registration_id = individual_enrollment_record.registration_id
@@ -68,7 +71,6 @@ async def test_device_register_with_device_id_for_a_symmetric_key_individual_enr
         assert_device_provisioned(device_id=device_id, registration_result=registration_result)
         device_registry_helper.try_delete_device(device_id)
     finally:
-        pass
         service_client.delete_individual_enrollment_by_param(registration_id)
 
 

--- a/azure_provisioning_e2e/tests/test_sync_certificate_enrollments.py
+++ b/azure_provisioning_e2e/tests/test_sync_certificate_enrollments.py
@@ -16,6 +16,7 @@ from provisioningserviceclient.protocol.models import AttestationMechanism, Repr
 import pytest
 import logging
 import os
+import uuid
 
 from scripts.create_x509_chain_pipeline import (
     call_intermediate_cert_creation_from_pipeline,
@@ -29,7 +30,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 intermediate_common_name = "e2edpswingardium"
 intermediate_password = "leviosa"
-device_common_name = "e2edpsexpecto"
+device_common_name = "e2edpsexpecto" + str(uuid.uuid4())
 device_password = "patronum"
 
 service_client = ProvisioningServiceClient.create_from_connection_string(
@@ -128,7 +129,7 @@ def test_device_register_with_no_device_id_for_a_x509_individual_enrollment():
     "A group of devices get provisioned to the linked IoTHub with device_ids equal to the individual registration_ids inside a group enrollment that has been created with intermediate X509 authentication"
 )
 def test_group_of_devices_register_with_no_device_id_for_a_x509_intermediate_authentication_group_enrollment():
-    group_id = "e2e-intermediate-hogwarts"
+    group_id = "e2e-intermediate-hogwarts" + str(uuid.uuid4())
     common_device_id = device_common_name
     devices_indices = type_to_device_indices.get("group_intermediate")
     device_count_in_group = len(devices_indices)
@@ -187,7 +188,7 @@ def test_group_of_devices_register_with_no_device_id_for_a_x509_intermediate_aut
     "A group of devices get provisioned to the linked IoTHub with device_ids equal to the individual registration_ids inside a group enrollment that has been created with an already uploaded ca cert X509 authentication"
 )
 def test_group_of_devices_register_with_no_device_id_for_a_x509_ca_authentication_group_enrollment():
-    group_id = "e2e-ca-beauxbatons"
+    group_id = "e2e-ca-beauxbatons" + str(uuid.uuid4())
     common_device_id = device_common_name
     devices_indices = type_to_device_indices.get("group_ca")
     device_count_in_group = len(devices_indices)

--- a/azure_provisioning_e2e/tests/test_sync_symmetric_enrollments.py
+++ b/azure_provisioning_e2e/tests/test_sync_symmetric_enrollments.py
@@ -11,6 +11,7 @@ from provisioningserviceclient.protocol.models import AttestationMechanism, Repr
 import pytest
 import logging
 import os
+import uuid
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -29,7 +30,7 @@ linked_iot_hub = connection_string_to_hostname(os.getenv("IOTHUB_CONNECTION_STRI
 def test_device_register_with_no_device_id_for_a_symmetric_key_individual_enrollment():
     try:
         individual_enrollment_record = create_individual_enrollment(
-            "e2e-dps-underthewhompingwillow"
+            "e2e-dps-underthewhompingwillow" + str(uuid.uuid4())
         )
 
         registration_id = individual_enrollment_record.registration_id
@@ -53,7 +54,7 @@ def test_device_register_with_device_id_for_a_symmetric_key_individual_enrollmen
     device_id = "e2edpstommarvoloriddle"
     try:
         individual_enrollment_record = create_individual_enrollment(
-            registration_id="e2e-dps-prioriincantatem", device_id=device_id
+            registration_id="e2e-dps-prioriincantatem" + str(uuid.uuid4()), device_id=device_id
         )
 
         registration_id = individual_enrollment_record.registration_id

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,7 @@ pytest-mock
 pytest-asyncio; python_version >= '3.5'
 pytest-testdox>=1.1.1
 pytest-cov
+pytest-timeout
 mock #remove this as soon as no references to it remain in the code
 flake8
 azure-iothub-provisioningserviceclient >= 1.2.0  # Only needed for end to end tests for DPS


### PR DESCRIPTION
sometimes enrollments are being left out because we are cancelling builds and that is causing issues for the next build to run.

have added random uuids to the names of the registration names so that consecutive builds can run even with getting cancelled.

also added time out.