### PR TITLE
[REFACTOR] Removed rogue print statement

### DIFF
--- a/azure-iot-device/azure/iot/device/iothub/sync_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/sync_clients.py
@@ -238,7 +238,6 @@ class GenericIoTHubClient(AbstractIoTHubClient):
             patch=reported_properties_patch, callback=on_pipeline_op_complete
         )
         op_complete.wait()
-        print("Done with patch")
 
     def receive_twin_desired_properties_patch(self, block=True, timeout=None):
         """


### PR DESCRIPTION
There was a print statement executing upon sending a twin patch. No longer!