### PR TITLE
[INFRASTRUCTURE] Updated urllib3 subdependency

### DIFF
--- a/azure-iot-device/setup.py
+++ b/azure-iot-device/setup.py
@@ -58,7 +58,12 @@ setup(
     install_requires=[
         # Define sub-dependencies due to pip dependency resolution bug
         # https://github.com/pypa/pip/issues/988
-        "urllib3>1.21.1,<1.25",
+        # ---requests dependencies---
+        # requests 2.22+ does not support 1.25.0 or 1.251 (https://github.com/psf/requests/pull/5092)
+        # requests 2.22+ is not compatible with python34
+        "urllib3>1.21.1,<1.26,!=1.25.0,!=1.25.1;python_version=='2.7'",
+        "urllib3>1.21.1,<1.25;python_version=='3.4'",
+        "urllib3>1.21.1,<1.26,!=1.25.0,!=1.25.1;python_version>='3.5'",
         # Actual project dependencies
         "six>=1.12.0,<2.0.0",
         "paho-mqtt>=1.4.0,<2.0.0",


### PR DESCRIPTION
* Requests 2.22.0 is available, and now supports up to urllib3 1.26, while being incompatible with 1.25.0 and 1.25.1.
* Because subdependencies have to be managed due to a pip bug, we need to manage the urllib version ourselves
* Additionally, because 2.22.0 drops support for Python 3.4, we have to restrict the urllib3 version for such scenarios