### PR TITLE
refactor operation_flow as part of retry changes

### DIFF
--- a/azure-iot-device/azure/iot/device/common/chainable_exception.py
+++ b/azure-iot-device/azure/iot/device/common/chainable_exception.py
@@ -14,3 +14,8 @@ class ChainableException(Exception):
         # while still being able to operate in Python 2.
         self.__cause__ = cause
         super(ChainableException, self).__init__(message)
+
+    def __repr__(self):
+        return "{} caused by {}".format(
+            super(ChainableException, self).__repr__(), self.__cause__.__repr__()
+        )

--- a/azure-iot-device/azure/iot/device/common/evented_callback.py
+++ b/azure-iot-device/azure/iot/device/common/evented_callback.py
@@ -31,7 +31,6 @@ class EventedCallback(object):
 
         def wrapping_callback(*args, **kwargs):
             if "error" in kwargs and kwargs["error"]:
-                logger.error("Callback called with error {}".format(kwargs["error"]))
                 self.exception = kwargs["error"]
             elif return_arg_name:
                 if return_arg_name in kwargs:

--- a/azure-iot-device/azure/iot/device/common/pipeline/operation_flow.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/operation_flow.py
@@ -15,124 +15,145 @@ from six.moves import queue
 logger = logging.getLogger(__name__)
 
 
-@pipeline_thread.runs_on_pipeline_thread
-def delegate_to_different_op(stage, original_op, new_op):
-    """
-    Continue an operation using a new operation.  This means that the new operation
-    will be passed down the pipeline (starting at the next stage). When that new
-    operation completes, the original operation will also complete.  In this way,
-    a stage can accept one type of operation and, effectively, change that operation
-    into a different type of operation before passing it to the next stage.
+class PipelineFlow(object):
+    @pipeline_thread.runs_on_pipeline_thread
+    def _send_worker_op_down(self, worker_op, op):
+        """
+        Continue an operation using a new operation.  This means that the new operation
+        will be passed down the pipeline (starting at the next stage). When that new
+        operation completes, the original operation will be completed.  In this way,
+        a stage can accept one type of operation and, effectively, change that operation
+        into a different type of operation before passing it to the next stage.
 
-    This is useful when a generic operation (such as "enable feature") needs to be
-    converted into a more specific operation (such as "subscribe to mqtt topic").
-    In that case, a stage's _execute_op function would call this function passing in
-    the original "enable feature" op and the new "subscribe to mqtt topic"
-    op.  This function will pass the "subscribe" down. When the "subscribe" op
-    is completed, this function will cause the original op to complete.
+        This is useful when a generic operation (such as "enable feature") needs to be
+        converted into a more specific operation (such as "subscribe to mqtt topic").
+        In that case, a stage's _execute_op function would call this function passing in
+        the original "enable feature" op and the new "subscribe to mqtt topic"
+        op.  This function will pass the "subscribe" down. When the "subscribe" op
+        is completed, this function will cause the original op to complete.
 
-    This function is only really useful if there is no data returned in the
-    new_op that that needs to be copied back into the original_op before
-    completing it.  If data needs to be copied this way, some other method needs
-    to be used.  (or a "copy data back" function needs to be added to this function
-    as an optional parameter.)
+        This function is only really useful if there is no data returned in the
+        new_op that that needs to be copied back into the original_op before
+        completing it.  If data needs to be copied this way, some other method needs
+        to be used.  (or a "copy data back" function needs to be added to this function
+        as an optional parameter.)
 
-    :param PipelineStage stage: stage to delegate the operation to
-    :param PipelineOperation original_op: Operation that is being continued using a
-      different op.  This is most likely the operation that is currently being handled
-      by the stage.  This operation is not actually continued, in that it is not
-      actually passed down the pipeline.  Instead, the original_op operation is
-      effectively paused while we wait for the new_op operation to complete.  When
-      the new_op operation completes, the original_op operation will also be completed.
-    :param PipelineOperation new_op: Operation that is being passed down the pipeline
-      to effectively continue the work represented by original_op.  This is most likely
-      a different type of operation that is able to accomplish the intention of the
-      original_op in a way that is more specific than the original_op.
-    """
+        :param PipelineOperation op: Operation that is being continued using a
+          different op.  This is most likely the operation that is currently being handled
+          by the stage.  This operation is not actually continued, in that it is not
+          actually passed down the pipeline.  Instead, the original_op operation is
+          effectively paused while we wait for the new_op operation to complete.  When
+          the new_op operation completes, the original_op operation will also be completed.
+        :param PipelineOperation worker_op: Operation that is being passed down the pipeline
+          to effectively continue the work represented by the original op.  This is most likely
+          a different type of operation that is able to accomplish the intention of the
+          original op in a way that is more specific than the original op.
+        """
 
-    logger.debug("{}({}): continuing with {} op".format(stage.name, original_op.name, new_op.name))
+        logger.debug("{}({}): continuing with {} op".format(self.name, op.name, worker_op.name))
+
+        @pipeline_thread.runs_on_pipeline_thread
+        def worker_op_complete(new_op, error):
+            logger.debug(
+                "{}({}): completing with result from {}".format(self.name, op.name, new_op.name)
+            )
+            self._complete_op(op, error=error)
+
+        worker_op.callback = worker_op_complete
+        self._send_op_down(worker_op)
 
     @pipeline_thread.runs_on_pipeline_thread
-    def new_op_complete(op):
-        logger.debug(
-            "{}({}): completing with result from {}".format(
-                stage.name, original_op.name, new_op.name
+    def _send_op_down(self, op):
+        """
+        Helper function to continue a given operation by passing it to the next stage
+        in the pipeline.  If there is no next stage in the pipeline, this function
+        will fail the operation and call _complete_op to return the failure back up the
+        pipeline.
+
+        :param PipelineOperation op: Operation which is being passed on
+        """
+        if not self.next:
+            logger.error("{}({}): no next stage.  completing with error".format(self.name, op.name))
+            error = PipelineError(
+                "{} not handled after {} stage with no next stage".format(op.name, self.name)
             )
-        )
-        original_op.error = new_op.error
-        complete_op(stage, original_op)
+            self._complete_op(op, error=error)
+        else:
+            logger.debug("{}({}): passing to next stage.".format(self.name, op.name))
+            self.next.run_op(op)
 
-    new_op.callback = new_op_complete
-    pass_op_to_next_stage(stage, new_op)
+    @pipeline_thread.runs_on_pipeline_thread
+    def _complete_op(self, op, error=None):
+        """
+        Helper function to complete an operation by calling its callback function thus
+        returning the result of the operation back up the pipeline.  This is perferred to
+        calling the operation's callback directly as it provides several layers of protection
+        (such as a try/except wrapper) which are strongly advised.
+        """
+        if error:
+            logger.error("{}({}): completing with error {}".format(self.name, op.name, error))
+        else:
+            logger.debug("{}({}): completing without error".format(self.name, op.name))
 
+        if op.completed:
+            logger.error(
+                "{}({}): completing op that has already been completed!".format(self.name, op.name)
+            )
+            e = PipelineError(
+                "Internal pipeline error: attempting to complete an already-completed operation: {}({})".format(
+                    self.name, op.name
+                )
+            )
+            handle_exceptions.handle_background_exception(e)
+        else:
+            op.completed = True
+            self._send_completed_op_up(op, error)
 
-@pipeline_thread.runs_on_pipeline_thread
-def pass_op_to_next_stage(stage, op):
-    """
-    Helper function to continue a given operation by passing it to the next stage
-    in the pipeline.  If there is no next stage in the pipeline, this function
-    will fail the operation and call complete_op to return the failure back up the
-    pipeline.  If the operation is already in an error state, this function will
-    complete the operation in order to return that error to the caller.
+    @pipeline_thread.runs_on_pipeline_thread
+    def _send_completed_op_up(self, op, error=None):
+        if not op.completed:
+            raise PipelineError(
+                "Internal pipeline error: attempting to send an incomplete {} op up".format(op.name)
+            )
 
-    :param PipelineStage stage: stage that the operation is being passed from
-    :param PipelineOperation op: Operation which is being passed on
-    """
-    if op.error:
-        logger.error("{}({}): op has error.  completing.".format(stage.name, op.name))
-        complete_op(stage, op)
-    elif not stage.next:
-        logger.error("{}({}): no next stage.  completing with error".format(stage.name, op.name))
-        op.error = PipelineError(
-            "{} not handled after {} stage with no next stage".format(op.name, stage.name)
-        )
-        complete_op(stage, op)
-    else:
-        logger.debug("{}({}): passing to next stage.".format(stage.name, op.name))
-        stage.next.run_op(op)
+        try:
+            op.callback(op, error=error)
+        except Exception as e:
+            _, e, _ = sys.exc_info()
+            logger.error(
+                msg="Unhandled error calling back inside {}._complete_op() after {} complete".format(
+                    self.name, op.name
+                ),
+                exc_info=e,
+            )
+            handle_exceptions.handle_background_exception(e)
 
+    @pipeline_thread.runs_on_pipeline_thread
+    def _send_event_up(self, event):
+        """
+        Helper function to pass an event to the previous stage of the pipeline.  This is the default
+        behavior of events while traveling through the pipeline. They start somewhere (maybe the
+        bottom) and move up the pipeline until they're handled or until they error out.
+        """
+        if self.previous:
+            logger.debug(
+                "{}({}): pushing event up to {}".format(self.name, event.name, self.previous.name)
+            )
+            self.previous.handle_pipeline_event(event)
+        else:
+            logger.error("{}({}): Error: unhandled event".format(self.name, event.name))
+            error = PipelineError(
+                "{} unhandled at {} stage with no previous stage".format(event.name, self.name)
+            )
+            handle_exceptions.handle_background_exception(error)
 
-@pipeline_thread.runs_on_pipeline_thread
-def complete_op(stage, op):
-    """
-    Helper function to complete an operation by calling its callback function thus
-    returning the result of the operation back up the pipeline.  This is perferred to
-    calling the operation's callback directly as it provides several layers of protection
-    (such as a try/except wrapper) which are strongly advised.
-    """
-    if op.error:
-        logger.error("{}({}): completing with error {}".format(stage.name, op.name, op.error))
-    else:
-        logger.debug("{}({}): completing without error".format(stage.name, op.name))
+    @pipeline_thread.runs_on_pipeline_thread
+    def _send_op_down_and_intercept_return(self, op, intercept_return):
+        old_callback = op.callback
 
-    try:
-        op.callback(op)
-    except Exception as e:
-        _, e, _ = sys.exc_info()
-        logger.error(
-            msg="Unhandled error calling back inside {}.complete_op() after {} complete".format(
-                stage.name, op.name
-            ),
-            exc_info=e,
-        )
-        handle_exceptions.handle_background_exception(e)
+        def new_callback(op, error):
+            op.callback = old_callback
+            intercept_return(op=op, error=error)
 
-
-@pipeline_thread.runs_on_pipeline_thread
-def pass_event_to_previous_stage(stage, event):
-    """
-    Helper function to pass an event to the previous stage of the pipeline.  This is the default
-    behavior of events while traveling through the pipeline. They start somewhere (maybe the
-    bottom) and move up the pipeline until they're handled or until they error out.
-    """
-    if stage.previous:
-        logger.debug(
-            "{}({}): pushing event up to {}".format(stage.name, event.name, stage.previous.name)
-        )
-        stage.previous.handle_pipeline_event(event)
-    else:
-        logger.error("{}({}): Error: unhandled event".format(stage.name, event.name))
-        error = PipelineError(
-            "{} unhandled at {} stage with no previous stage".format(event.name, stage.name)
-        )
-        handle_exceptions.handle_background_exception(error)
+        op.callback = new_callback
+        self._send_op_down(op)

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_base.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import sys
 
 
 class PipelineOperation(object):
@@ -30,7 +31,7 @@ class PipelineOperation(object):
     :type error: Error
     """
 
-    def __init__(self, callback=None):
+    def __init__(self, callback):
         """
         Initializer for PipelineOperation objects.
 
@@ -45,7 +46,20 @@ class PipelineOperation(object):
         self.name = self.__class__.__name__
         self.callback = callback
         self.needs_connection = False
-        self.error = None
+        self.completed = False
+
+    if "pytest" in sys.modules:
+        # If we're running under pytest, raise an exception if someone tries to use the old-school
+        # "errors are a property of the operation" style.
+        # If you find yourself questioning if this needs to be here, you should remove it.  This is
+        # an interim check while we get used to something new.
+        @property
+        def error(self):
+            assert False
+
+        @error.setter
+        def error(self, error):
+            assert False
 
 
 class ConnectOperation(PipelineOperation):
@@ -101,7 +115,7 @@ class EnableFeatureOperation(PipelineOperation):
     Even though this is an base operation, it will most likely be handled by a more specific stage (such as an IoTHub or MQTT stage).
     """
 
-    def __init__(self, feature_name, callback=None):
+    def __init__(self, feature_name, callback):
         """
         Initializer for EnableFeatureOperation objects.
 
@@ -129,7 +143,7 @@ class DisableFeatureOperation(PipelineOperation):
     Even though this is an base operation, it will most likely be handled by a more specific stage (such as an IoTHub or MQTT stage).
     """
 
-    def __init__(self, feature_name, callback=None):
+    def __init__(self, feature_name, callback):
         """
         Initializer for DisableFeatureOperation objects.
 
@@ -154,7 +168,7 @@ class UpdateSasTokenOperation(PipelineOperation):
     (such as IoTHub or MQTT stages).
     """
 
-    def __init__(self, sas_token, callback=None):
+    def __init__(self, sas_token, callback):
         """
         Initializer for UpdateSasTokenOperation objects.
 
@@ -187,7 +201,7 @@ class SendIotRequestAndWaitForResponseOperation(PipelineOperation):
     :type response_body: Undefined
     """
 
-    def __init__(self, request_type, method, resource_location, request_body, callback=None):
+    def __init__(self, request_type, method, resource_location, request_body, callback):
         """
         Initializer for SendIotRequestAndWaitForResponseOperation objects
 
@@ -222,9 +236,7 @@ class SendIotRequestOperation(PipelineOperation):
     (such as IoTHub or MQTT stages).
     """
 
-    def __init__(
-        self, request_type, method, resource_location, request_body, request_id, callback=None
-    ):
+    def __init__(self, request_type, method, resource_location, request_body, request_id, callback):
         """
         Initializer for SendIotRequestOperation objects
 

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_mqtt.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_mqtt.py
@@ -18,10 +18,10 @@ class SetMQTTConnectionArgsOperation(PipelineOperation):
         client_id,
         hostname,
         username,
+        callback,
         ca_cert=None,
         client_cert=None,
         sas_token=None,
-        callback=None,
     ):
         """
         Initializer for SetMQTTConnectionArgsOperation objects.
@@ -54,7 +54,7 @@ class MQTTPublishOperation(PipelineOperation):
     This operation is in the group of MQTT operations because its attributes are very specific to the MQTT protocol.
     """
 
-    def __init__(self, topic, payload, callback=None):
+    def __init__(self, topic, payload, callback):
         """
         Initializer for MQTTPublishOperation objects.
 
@@ -77,7 +77,7 @@ class MQTTSubscribeOperation(PipelineOperation):
     This operation is in the group of MQTT operations because its attributes are very specific to the MQTT protocol.
     """
 
-    def __init__(self, topic, callback=None):
+    def __init__(self, topic, callback):
         """
         Initializer for MQTTSubscribeOperation objects.
 
@@ -98,7 +98,7 @@ class MQTTUnsubscribeOperation(PipelineOperation):
     This operation is in the group of MQTT operations because its attributes are very specific to the MQTT protocol.
     """
 
-    def __init__(self, topic, callback=None):
+    def __init__(self, topic, callback):
         """
         Initializer for MQTTUnsubscribeOperation objects.
 

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/iothub_pipeline.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/iothub_pipeline.py
@@ -110,9 +110,6 @@ class IoTHubPipeline(object):
 
         self._pipeline.run_op(op)
         callback.wait_for_completion()
-        if op.error:
-            logger.error("{} failed: {}".format(op.name, op.error))
-            raise op.error
 
     def connect(self, callback):
         """
@@ -130,11 +127,8 @@ class IoTHubPipeline(object):
         """
         logger.debug("Starting ConnectOperation on the pipeline")
 
-        def on_complete(op):
-            if op.error:
-                callback(error=op.error)
-            else:
-                callback()
+        def on_complete(op, error):
+            callback(error=error)
 
         self._pipeline.run_op(pipeline_ops_base.ConnectOperation(callback=on_complete))
 
@@ -151,11 +145,8 @@ class IoTHubPipeline(object):
         """
         logger.debug("Starting DisconnectOperation on the pipeline")
 
-        def on_complete(op):
-            if op.error:
-                callback(error=op.error)
-            else:
-                callback()
+        def on_complete(op, error):
+            callback(error=error)
 
         self._pipeline.run_op(pipeline_ops_base.DisconnectOperation(callback=on_complete))
 
@@ -175,11 +166,8 @@ class IoTHubPipeline(object):
         :raises: :class:`azure.iot.device.iothub.pipeline.exceptions.ProtocolClientError`
         """
 
-        def on_complete(op):
-            if op.error:
-                callback(error=op.error)
-            else:
-                callback()
+        def on_complete(op, error):
+            callback(error=error)
 
         self._pipeline.run_op(
             pipeline_ops_iothub.SendD2CMessageOperation(message=message, callback=on_complete)
@@ -201,11 +189,8 @@ class IoTHubPipeline(object):
         :raises: :class:`azure.iot.device.iothub.pipeline.exceptions.ProtocolClientError`
         """
 
-        def on_complete(op):
-            if op.error:
-                callback(error=op.error)
-            else:
-                callback()
+        def on_complete(op, error):
+            callback(error=error)
 
         self._pipeline.run_op(
             pipeline_ops_iothub.SendOutputEventOperation(message=message, callback=on_complete)
@@ -228,11 +213,8 @@ class IoTHubPipeline(object):
         """
         logger.debug("IoTHubPipeline send_method_response called")
 
-        def on_complete(op):
-            if op.error:
-                callback(error=op.error)
-            else:
-                callback()
+        def on_complete(op, error):
+            callback(error=error)
 
         self._pipeline.run_op(
             pipeline_ops_iothub.SendMethodResponseOperation(
@@ -256,9 +238,9 @@ class IoTHubPipeline(object):
         :raises: :class:`azure.iot.device.iothub.pipeline.exceptions.ProtocolClientError`
         """
 
-        def on_complete(op):
-            if op.error:
-                callback(error=op.error, twin=None)
+        def on_complete(op, error):
+            if error:
+                callback(error=error, twin=None)
             else:
                 callback(twin=op.twin)
 
@@ -280,11 +262,8 @@ class IoTHubPipeline(object):
         :raises: :class:`azure.iot.device.iothub.pipeline.exceptions.ProtocolClientError`
         """
 
-        def on_complete(op):
-            if op.error:
-                callback(error=op.error)
-            else:
-                callback()
+        def on_complete(op, error):
+            callback(error=error)
 
         self._pipeline.run_op(
             pipeline_ops_iothub.PatchTwinReportedPropertiesOperation(
@@ -306,11 +285,8 @@ class IoTHubPipeline(object):
             raise ValueError("Invalid feature_name")
         self.feature_enabled[feature_name] = True
 
-        def on_complete(op):
-            if op.error:
-                callback(error=op.error)
-            else:
-                callback()
+        def on_complete(op, error):
+            callback(error=error)
 
         self._pipeline.run_op(
             pipeline_ops_base.EnableFeatureOperation(
@@ -332,11 +308,8 @@ class IoTHubPipeline(object):
             raise ValueError("Invalid feature_name")
         self.feature_enabled[feature_name] = False
 
-        def on_complete(op):
-            if op.error:
-                callback(error=op.error)
-            else:
-                callback()
+        def on_complete(op, error):
+            callback(error=error)
 
         self._pipeline.run_op(
             pipeline_ops_base.DisableFeatureOperation(

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_ops_iothub.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_ops_iothub.py
@@ -18,7 +18,7 @@ class SetX509AuthProviderOperation(PipelineOperation):
     very IoTHub-specific
     """
 
-    def __init__(self, auth_provider, callback=None):
+    def __init__(self, auth_provider, callback):
         """
         Initializer for SetAuthProviderOperation objects.
 
@@ -42,7 +42,7 @@ class SetAuthProviderOperation(PipelineOperation):
     very IoTHub-specific
     """
 
-    def __init__(self, auth_provider, callback=None):
+    def __init__(self, auth_provider, callback):
         """
         Initializer for SetAuthProviderOperation objects.
 
@@ -69,12 +69,12 @@ class SetIoTHubConnectionArgsOperation(PipelineOperation):
         self,
         device_id,
         hostname,
+        callback,
         module_id=None,
         gateway_hostname=None,
         ca_cert=None,
         client_cert=None,
         sas_token=None,
-        callback=None,
     ):
         """
         Initializer for SetIoTHubConnectionArgsOperation objects.
@@ -111,7 +111,7 @@ class SendD2CMessageOperation(PipelineOperation):
     This operation is in the group of IoTHub operations because it is very specific to the IoTHub client
     """
 
-    def __init__(self, message, callback=None):
+    def __init__(self, message, callback):
         """
         Initializer for SendD2CMessageOperation objects.
 
@@ -131,7 +131,7 @@ class SendOutputEventOperation(PipelineOperation):
     This operation is in the group of IoTHub operations because it is very specific to the IoTHub client
     """
 
-    def __init__(self, message, callback=None):
+    def __init__(self, message, callback):
         """
         Initializer for SendOutputEventOperation objects.
 
@@ -152,7 +152,7 @@ class SendMethodResponseOperation(PipelineOperation):
     This operation is in the group of IoTHub operations because it is very specific to the IoTHub client.
     """
 
-    def __init__(self, method_response, callback=None):
+    def __init__(self, method_response, callback):
         """
         Initializer for SendMethodResponseOperation objects.
 
@@ -176,7 +176,7 @@ class GetTwinOperation(PipelineOperation):
     :type twin: Twin
     """
 
-    def __init__(self, callback=None):
+    def __init__(self, callback):
         """
         Initializer for GetTwinOperation objects.
         """
@@ -190,7 +190,7 @@ class PatchTwinReportedPropertiesOperation(PipelineOperation):
     IoT Hub or Azure IoT Edge Hub service.
     """
 
-    def __init__(self, patch, callback=None):
+    def __init__(self, patch, callback):
         """
         Initializer for PatchTwinReportedPropertiesOperation object
 

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub.py
@@ -6,12 +6,7 @@
 
 import json
 import logging
-from azure.iot.device.common.pipeline import (
-    pipeline_ops_base,
-    PipelineStage,
-    operation_flow,
-    pipeline_thread,
-)
+from azure.iot.device.common.pipeline import pipeline_ops_base, PipelineStage, pipeline_thread
 from azure.iot.device import exceptions
 from azure.iot.device.common import handle_exceptions
 from azure.iot.device.common.callable_weak_method import CallableWeakMethod
@@ -40,34 +35,34 @@ class UseAuthProviderStage(PipelineStage):
             self.auth_provider.on_sas_token_updated_handler = CallableWeakMethod(
                 self, "on_sas_token_updated"
             )
-            operation_flow.delegate_to_different_op(
-                stage=self,
-                original_op=op,
-                new_op=pipeline_ops_iothub.SetIoTHubConnectionArgsOperation(
+            self._send_worker_op_down(
+                worker_op=pipeline_ops_iothub.SetIoTHubConnectionArgsOperation(
                     device_id=self.auth_provider.device_id,
                     module_id=getattr(self.auth_provider, "module_id", None),
                     hostname=self.auth_provider.hostname,
                     gateway_hostname=getattr(self.auth_provider, "gateway_hostname", None),
                     ca_cert=getattr(self.auth_provider, "ca_cert", None),
                     sas_token=self.auth_provider.get_current_sas_token(),
+                    callback=op.callback,
                 ),
+                op=op,
             )
         elif isinstance(op, pipeline_ops_iothub.SetX509AuthProviderOperation):
             self.auth_provider = op.auth_provider
-            operation_flow.delegate_to_different_op(
-                stage=self,
-                original_op=op,
-                new_op=pipeline_ops_iothub.SetIoTHubConnectionArgsOperation(
+            self._send_worker_op_down(
+                worker_op=pipeline_ops_iothub.SetIoTHubConnectionArgsOperation(
                     device_id=self.auth_provider.device_id,
                     module_id=getattr(self.auth_provider, "module_id", None),
                     hostname=self.auth_provider.hostname,
                     gateway_hostname=getattr(self.auth_provider, "gateway_hostname", None),
                     ca_cert=getattr(self.auth_provider, "ca_cert", None),
                     client_cert=self.auth_provider.get_x509_certificate(),
+                    callback=op.callback,
                 ),
+                op=op,
             )
         else:
-            operation_flow.pass_op_to_next_stage(self, op)
+            self._send_op_down(op)
 
     @pipeline_thread.invoke_on_pipeline_thread_nowait
     def on_sas_token_updated(self):
@@ -76,25 +71,24 @@ class UseAuthProviderStage(PipelineStage):
         )
 
         @pipeline_thread.runs_on_pipeline_thread
-        def on_token_update_complete(op):
-            if op.error:
+        def on_token_update_complete(op, error):
+            if error:
                 logger.error(
                     "{}({}): token update operation failed.  Error={}".format(
-                        self.name, op.name, op.error
+                        self.name, op.name, error
                     )
                 )
-                handle_exceptions.handle_background_exception(op.error)
+                handle_exceptions.handle_background_exception(error)
             else:
                 logger.debug(
                     "{}({}): token update operation is complete".format(self.name, op.name)
                 )
 
-        operation_flow.pass_op_to_next_stage(
-            stage=self,
+        self._send_op_down(
             op=pipeline_ops_base.UpdateSasTokenOperation(
                 sas_token=self.auth_provider.get_current_sas_token(),
                 callback=on_token_update_complete,
-            ),
+            )
         )
 
 
@@ -110,64 +104,60 @@ class HandleTwinOperationsStage(PipelineStage):
 
     @pipeline_thread.runs_on_pipeline_thread
     def _execute_op(self, op):
-        def map_twin_error(original_op, twin_op):
-            if twin_op.error:
-                original_op.error = twin_op.error
+        def map_twin_error(error, twin_op):
+            if error:
+                return error
             elif twin_op.status_code >= 300:
                 # TODO map error codes to correct exceptions
                 logger.error("Error {} received from twin operation".format(twin_op.status_code))
                 logger.error("response body: {}".format(twin_op.response_body))
-                original_op.error = exceptions.ServiceError(
+                return exceptions.ServiceError(
                     "twin operation returned status {}".format(twin_op.status_code)
                 )
 
         if isinstance(op, pipeline_ops_iothub.GetTwinOperation):
 
-            def on_twin_response(twin_op):
+            def on_twin_response(twin_op, error):
                 logger.debug("{}({}): Got response for GetTwinOperation".format(self.name, op.name))
-                map_twin_error(original_op=op, twin_op=twin_op)
-                if not twin_op.error:
+                error = map_twin_error(error=error, twin_op=twin_op)
+                if not error:
                     op.twin = json.loads(twin_op.response_body.decode("utf-8"))
-                operation_flow.complete_op(self, op)
+                self._complete_op(op, error=error)
 
-            operation_flow.pass_op_to_next_stage(
-                self,
+            self._send_op_down(
                 pipeline_ops_base.SendIotRequestAndWaitForResponseOperation(
                     request_type=constant.TWIN,
                     method="GET",
                     resource_location="/",
                     request_body=" ",
                     callback=on_twin_response,
-                ),
+                )
             )
 
         elif isinstance(op, pipeline_ops_iothub.PatchTwinReportedPropertiesOperation):
 
-            def on_twin_response(twin_op):
+            def on_twin_response(twin_op, error):
                 logger.debug(
                     "{}({}): Got response for PatchTwinReportedPropertiesOperation operation".format(
                         self.name, op.name
                     )
                 )
-                map_twin_error(original_op=op, twin_op=twin_op)
-                operation_flow.complete_op(self, op)
+                error = map_twin_error(error=error, twin_op=twin_op)
+                self._complete_op(op, error=error)
 
             logger.debug(
                 "{}({}): Sending reported properties patch: {}".format(self.name, op.name, op.patch)
             )
 
-            operation_flow.pass_op_to_next_stage(
-                self,
-                (
-                    pipeline_ops_base.SendIotRequestAndWaitForResponseOperation(
-                        request_type=constant.TWIN,
-                        method="PATCH",
-                        resource_location="/properties/reported/",
-                        request_body=json.dumps(op.patch),
-                        callback=on_twin_response,
-                    )
-                ),
+            self._send_op_down(
+                pipeline_ops_base.SendIotRequestAndWaitForResponseOperation(
+                    request_type=constant.TWIN,
+                    method="PATCH",
+                    resource_location="/properties/reported/",
+                    request_body=json.dumps(op.patch),
+                    callback=on_twin_response,
+                )
             )
 
         else:
-            operation_flow.pass_op_to_next_stage(self, op)
+            self._send_op_down(op)

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub_mqtt.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub_mqtt.py
@@ -13,7 +13,6 @@ from azure.iot.device.common.pipeline import (
     pipeline_ops_mqtt,
     pipeline_events_mqtt,
     PipelineStage,
-    operation_flow,
     pipeline_thread,
 )
 from azure.iot.device.iothub.models import Message, MethodRequest
@@ -68,17 +67,17 @@ class IoTHubMQTTConverterStage(PipelineStage):
                 hostname = op.hostname
 
             # TODO: test to make sure client_cert and sas_token travel down correctly
-            operation_flow.delegate_to_different_op(
-                stage=self,
-                original_op=op,
-                new_op=pipeline_ops_mqtt.SetMQTTConnectionArgsOperation(
+            self._send_worker_op_down(
+                worker_op=pipeline_ops_mqtt.SetMQTTConnectionArgsOperation(
                     client_id=client_id,
                     hostname=hostname,
                     username=username,
                     ca_cert=op.ca_cert,
                     client_cert=op.client_cert,
                     sas_token=op.sas_token,
+                    callback=op.callback,
                 ),
+                op=op,
             )
 
         elif (
@@ -92,45 +91,43 @@ class IoTHubMQTTConverterStage(PipelineStage):
             )
 
             # make a callback that can call the user's callback after the reconnect is complete
-            def on_reconnect_complete(reconnect_op):
-                if reconnect_op.error:
-                    op.error = reconnect_op.error
+            def on_reconnect_complete(reconnect_op, error):
+                if error:
                     logger.error(
                         "{}({}) reconnection failed.  returning error {}".format(
-                            self.name, op.name, op.error
+                            self.name, op.name, error
                         )
                     )
-                    operation_flow.complete_op(stage=self, op=op)
+                    self._send_completed_op_up(op, error=error)
                 else:
                     logger.debug(
                         "{}({}) reconnection succeeded.  returning success.".format(
                             self.name, op.name
                         )
                     )
-                    operation_flow.complete_op(stage=self, op=op)
+                    self._send_completed_op_up(op)
 
             # save the old user callback so we can call it later.
             old_callback = op.callback
 
             # make a callback that either fails the UpdateSasTokenOperation (if the lower level failed it),
             # or issues a ReconnectOperation (if the lower level returned success for the UpdateSasTokenOperation)
-            def on_token_update_complete(op):
+            def on_token_update_complete(op, error):
                 op.callback = old_callback
-                if op.error:
+                if error:
                     logger.error(
                         "{}({}) token update failed.  returning failure {}".format(
-                            self.name, op.name, op.error
+                            self.name, op.name, error
                         )
                     )
-                    operation_flow.complete_op(stage=self, op=op)
+                    self._send_completed_op_up(op, error=error)
                 else:
                     logger.debug(
                         "{}({}) token update succeeded.  reconnecting".format(self.name, op.name)
                     )
 
-                    operation_flow.pass_op_to_next_stage(
-                        stage=self,
-                        op=pipeline_ops_base.ReconnectOperation(callback=on_reconnect_complete),
+                    self._send_op_down(
+                        pipeline_ops_base.ReconnectOperation(callback=on_reconnect_complete)
                     )
 
                 logger.debug(
@@ -141,17 +138,18 @@ class IoTHubMQTTConverterStage(PipelineStage):
 
             # now, pass the UpdateSasTokenOperation down with our new callback.
             op.callback = on_token_update_complete
-            operation_flow.pass_op_to_next_stage(stage=self, op=op)
+            self._send_op_down(op)
 
         elif isinstance(op, pipeline_ops_iothub.SendD2CMessageOperation) or isinstance(
             op, pipeline_ops_iothub.SendOutputEventOperation
         ):
             # Convert SendTelementry and SendOutputEventOperation operations into MQTT Publish operations
             topic = mqtt_topic_iothub.encode_properties(op.message, self.telemetry_topic)
-            operation_flow.delegate_to_different_op(
-                stage=self,
-                original_op=op,
-                new_op=pipeline_ops_mqtt.MQTTPublishOperation(topic=topic, payload=op.message.data),
+            self._send_worker_op_down(
+                worker_op=pipeline_ops_mqtt.MQTTPublishOperation(
+                    topic=topic, payload=op.message.data, callback=op.callback
+                ),
+                op=op,
             )
 
         elif isinstance(op, pipeline_ops_iothub.SendMethodResponseOperation):
@@ -160,28 +158,31 @@ class IoTHubMQTTConverterStage(PipelineStage):
                 op.method_response.request_id, str(op.method_response.status)
             )
             payload = json.dumps(op.method_response.payload)
-            operation_flow.delegate_to_different_op(
-                stage=self,
-                original_op=op,
-                new_op=pipeline_ops_mqtt.MQTTPublishOperation(topic=topic, payload=payload),
+            self._send_worker_op_down(
+                worker_op=pipeline_ops_mqtt.MQTTPublishOperation(
+                    topic=topic, payload=payload, callback=op.callback
+                ),
+                op=op,
             )
 
         elif isinstance(op, pipeline_ops_base.EnableFeatureOperation):
             # Enabling a feature gets translated into an MQTT subscribe operation
             topic = self.feature_to_topic[op.feature_name]
-            operation_flow.delegate_to_different_op(
-                stage=self,
-                original_op=op,
-                new_op=pipeline_ops_mqtt.MQTTSubscribeOperation(topic=topic),
+            self._send_worker_op_down(
+                worker_op=pipeline_ops_mqtt.MQTTSubscribeOperation(
+                    topic=topic, callback=op.callback
+                ),
+                op=op,
             )
 
         elif isinstance(op, pipeline_ops_base.DisableFeatureOperation):
             # Disabling a feature gets turned into an MQTT unsubscribe operation
             topic = self.feature_to_topic[op.feature_name]
-            operation_flow.delegate_to_different_op(
-                stage=self,
-                original_op=op,
-                new_op=pipeline_ops_mqtt.MQTTUnsubscribeOperation(topic=topic),
+            self._send_worker_op_down(
+                worker_op=pipeline_ops_mqtt.MQTTUnsubscribeOperation(
+                    topic=topic, callback=op.callback
+                ),
+                op=op,
             )
 
         elif isinstance(op, pipeline_ops_base.SendIotRequestOperation):
@@ -191,12 +192,11 @@ class IoTHubMQTTConverterStage(PipelineStage):
                     resource_location=op.resource_location,
                     request_id=op.request_id,
                 )
-                operation_flow.delegate_to_different_op(
-                    stage=self,
-                    original_op=op,
-                    new_op=pipeline_ops_mqtt.MQTTPublishOperation(
-                        topic=topic, payload=op.request_body
+                self._send_worker_op_down(
+                    worker_op=pipeline_ops_mqtt.MQTTPublishOperation(
+                        topic=topic, payload=op.request_body, callback=op.callback
                     ),
+                    op=op,
                 )
             else:
                 raise pipeline_exceptions.OperationError(
@@ -205,7 +205,7 @@ class IoTHubMQTTConverterStage(PipelineStage):
 
         else:
             # All other operations get passed down
-            operation_flow.pass_op_to_next_stage(self, op)
+            self._send_op_down(op)
 
     @pipeline_thread.runs_on_pipeline_thread
     def _set_topic_names(self, device_id, module_id):
@@ -241,17 +241,13 @@ class IoTHubMQTTConverterStage(PipelineStage):
             if mqtt_topic_iothub.is_c2d_topic(topic, self.device_id):
                 message = Message(event.payload)
                 mqtt_topic_iothub.extract_properties_from_topic(topic, message)
-                operation_flow.pass_event_to_previous_stage(
-                    self, pipeline_events_iothub.C2DMessageEvent(message)
-                )
+                self._send_event_up(pipeline_events_iothub.C2DMessageEvent(message))
 
             elif mqtt_topic_iothub.is_input_topic(topic, self.device_id, self.module_id):
                 message = Message(event.payload)
                 mqtt_topic_iothub.extract_properties_from_topic(topic, message)
                 input_name = mqtt_topic_iothub.get_input_name_from_topic(topic)
-                operation_flow.pass_event_to_previous_stage(
-                    self, pipeline_events_iothub.InputMessageEvent(input_name, message)
-                )
+                self._send_event_up(pipeline_events_iothub.InputMessageEvent(input_name, message))
 
             elif mqtt_topic_iothub.is_method_topic(topic):
                 request_id = mqtt_topic_iothub.get_method_request_id_from_topic(topic)
@@ -261,32 +257,28 @@ class IoTHubMQTTConverterStage(PipelineStage):
                     name=method_name,
                     payload=json.loads(event.payload.decode("utf-8")),
                 )
-                operation_flow.pass_event_to_previous_stage(
-                    self, pipeline_events_iothub.MethodRequestEvent(method_received)
-                )
+                self._send_event_up(pipeline_events_iothub.MethodRequestEvent(method_received))
 
             elif mqtt_topic_iothub.is_twin_response_topic(topic):
                 request_id = mqtt_topic_iothub.get_twin_request_id_from_topic(topic)
                 status_code = int(mqtt_topic_iothub.get_twin_status_code_from_topic(topic))
-                operation_flow.pass_event_to_previous_stage(
-                    self,
+                self._send_event_up(
                     pipeline_events_base.IotResponseEvent(
                         request_id=request_id, status_code=status_code, response_body=event.payload
-                    ),
+                    )
                 )
 
             elif mqtt_topic_iothub.is_twin_desired_property_patch_topic(topic):
-                operation_flow.pass_event_to_previous_stage(
-                    self,
+                self._send_event_up(
                     pipeline_events_iothub.TwinDesiredPropertiesPatchEvent(
                         patch=json.loads(event.payload.decode("utf-8"))
-                    ),
+                    )
                 )
 
             else:
                 logger.debug("Uunknown topic: {} passing up to next handler".format(topic))
-                operation_flow.pass_event_to_previous_stage(self, event)
+                self._send_event_up(event)
 
         else:
             # all other messages get passed up
-            operation_flow.pass_event_to_previous_stage(self, event)
+            self._send_event_up(event)

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/pipeline_ops_provisioning.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/pipeline_ops_provisioning.py
@@ -16,7 +16,7 @@ class SetSymmetricKeySecurityClientOperation(PipelineOperation):
     very provisioning-specific
     """
 
-    def __init__(self, security_client, callback=None):
+    def __init__(self, security_client, callback):
         """
         Initializer for SetSecurityClient.
 
@@ -41,7 +41,7 @@ class SetX509SecurityClientOperation(PipelineOperation):
     (such as a Provisioning client).
     """
 
-    def __init__(self, security_client, callback=None):
+    def __init__(self, security_client, callback):
         """
         Initializer for SetSecurityClient.
 
@@ -71,9 +71,9 @@ class SetProvisioningClientConnectionArgsOperation(PipelineOperation):
         provisioning_host,
         registration_id,
         id_scope,
+        callback,
         client_cert=None,
         sas_token=None,
-        callback=None,
     ):
         """
         Initializer for SetProvisioningClientConnectionArgsOperation.
@@ -99,7 +99,7 @@ class SendRegistrationRequestOperation(PipelineOperation):
     This operation is in the group of DPS operations because it is very specific to the DPS client.
     """
 
-    def __init__(self, request_id, request_payload, callback=None):
+    def __init__(self, request_id, request_payload, callback):
         """
         Initializer for SendRegistrationRequestOperation objects.
 
@@ -122,7 +122,7 @@ class SendQueryRequestOperation(PipelineOperation):
     This operation is in the group of DPS operations because it is very specific to the DPS client.
     """
 
-    def __init__(self, request_id, operation_id, request_payload, callback=None):
+    def __init__(self, request_id, operation_id, request_payload, callback):
         """
         Initializer for SendRegistrationRequestOperation objects.
 

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/pipeline_stages_provisioning.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/pipeline_stages_provisioning.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from azure.iot.device.common.pipeline import pipeline_ops_base, operation_flow, pipeline_thread
+from azure.iot.device.common.pipeline import pipeline_ops_base, pipeline_thread
 from azure.iot.device.common.pipeline.pipeline_stages_base import PipelineStage
 from . import pipeline_ops_provisioning
 
@@ -22,29 +22,29 @@ class UseSecurityClientStage(PipelineStage):
         if isinstance(op, pipeline_ops_provisioning.SetSymmetricKeySecurityClientOperation):
 
             security_client = op.security_client
-            operation_flow.delegate_to_different_op(
-                stage=self,
-                original_op=op,
-                new_op=pipeline_ops_provisioning.SetProvisioningClientConnectionArgsOperation(
+            self._send_worker_op_down(
+                worker_op=pipeline_ops_provisioning.SetProvisioningClientConnectionArgsOperation(
                     provisioning_host=security_client.provisioning_host,
                     registration_id=security_client.registration_id,
                     id_scope=security_client.id_scope,
                     sas_token=security_client.get_current_sas_token(),
+                    callback=op.callback,
                 ),
+                op=op,
             )
 
         elif isinstance(op, pipeline_ops_provisioning.SetX509SecurityClientOperation):
             security_client = op.security_client
-            operation_flow.delegate_to_different_op(
-                stage=self,
-                original_op=op,
-                new_op=pipeline_ops_provisioning.SetProvisioningClientConnectionArgsOperation(
+            self._send_worker_op_down(
+                worker_op=pipeline_ops_provisioning.SetProvisioningClientConnectionArgsOperation(
                     provisioning_host=security_client.provisioning_host,
                     registration_id=security_client.registration_id,
                     id_scope=security_client.id_scope,
                     client_cert=security_client.get_x509_certificate(),
+                    callback=op.callback,
                 ),
+                op=op,
             )
 
         else:
-            operation_flow.pass_op_to_next_stage(self, op)
+            self._send_op_down(op)

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/provisioning_pipeline.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/provisioning_pipeline.py
@@ -82,9 +82,6 @@ class ProvisioningPipeline(object):
 
         self._pipeline.run_op(op)
         callback.wait_for_completion()
-        if op.error:
-            logger.error("{} failed: {}".format(op.name, op.error))
-            raise op.error
 
     def connect(self, callback=None):
         """
@@ -94,8 +91,8 @@ class ProvisioningPipeline(object):
         """
         logger.info("connect called")
 
-        def pipeline_callback(call):
-            if call.error:
+        def pipeline_callback(op, error):
+            if error:
                 # TODO we need error semantics on the client
                 exit(1)
             if callback:
@@ -111,8 +108,8 @@ class ProvisioningPipeline(object):
         """
         logger.info("disconnect called")
 
-        def pipeline_callback(call):
-            if call.error:
+        def pipeline_callback(op, error):
+            if error:
                 # TODO we need error semantics on the client
                 exit(1)
             if callback:
@@ -129,8 +126,8 @@ class ProvisioningPipeline(object):
         :param callback: callback which is called when the message publish has been acknowledged by the service.
         """
 
-        def pipeline_callback(call):
-            if call.error:
+        def pipeline_callback(op, error):
+            if error:
                 # TODO we need error semantics on the client
                 exit(1)
             if callback:
@@ -159,8 +156,8 @@ class ProvisioningPipeline(object):
         """
         logger.debug("enable_responses called")
 
-        def pipeline_callback(call):
-            if call.error:
+        def pipeline_callback(op, error):
+            if error:
                 # TODO we need error semantics on the client
                 exit(1)
             if callback:
@@ -178,8 +175,8 @@ class ProvisioningPipeline(object):
         """
         logger.debug("disable_responses called")
 
-        def pipeline_callback(call):
-            if call.error:
+        def pipeline_callback(op, error):
+            if error:
                 # TODO we need error semantics on the client
                 exit(1)
             if callback:

--- a/azure-iot-device/tests/common/pipeline/pipeline_data_object_test.py
+++ b/azure-iot-device/tests/common/pipeline/pipeline_data_object_test.py
@@ -21,12 +21,12 @@ def get_next_fake_value():
     return "__fake_value_{}__".format(fake_count)
 
 
-base_operation_defaults = {"needs_connection": False, "error": None}
+base_operation_defaults = {"needs_connection": False}
 base_event_defaults = {}
 
 
 def add_operation_test(
-    cls, module, extra_defaults={}, positional_arguments=[], keyword_arguments={}
+    cls, module, extra_defaults={}, positional_arguments=["callback"], keyword_arguments={}
 ):
     """
     Add a test class to test the given PipelineOperation class.  The class that

--- a/azure-iot-device/tests/common/pipeline/test_operation_flow.py
+++ b/azure-iot-device/tests/common/pipeline/test_operation_flow.py
@@ -11,11 +11,6 @@ from azure.iot.device.common.pipeline import (
     pipeline_ops_base,
     pipeline_events_base,
 )
-from azure.iot.device.common.pipeline.operation_flow import (
-    delegate_to_different_op,
-    complete_op,
-    pass_op_to_next_stage,
-)
 from tests.common.pipeline.helpers import (
     make_mock_stage,
     assert_callback_failed,
@@ -37,7 +32,7 @@ def apply_fake_pipeline_thread(fake_pipeline_thread):
 
 class MockPipelineStage(pipeline_stages_base.PipelineStage):
     def _execute_op(self, op):
-        pass_op_to_next_stage(self, op)
+        self._send_op_down(op)
 
 
 @pytest.fixture
@@ -50,11 +45,11 @@ def stage(mocker, arbitrary_exception, arbitrary_base_exception):
     )
 
 
-@pytest.mark.describe("delegate_to_different_op()")
+@pytest.mark.describe("_send_worker_op_down()")
 class TestContineWithDifferntOp(object):
     @pytest.mark.it("Runs the new op and does not continue running the original op")
     def test_runs_new_op(self, mocker, stage, op, new_op):
-        delegate_to_different_op(stage, original_op=op, new_op=new_op)
+        stage._send_worker_op_down(worker_op=new_op, op=op)
         assert stage.next.run_op.call_count == 1
         assert stage.next.run_op.call_args == mocker.call(new_op)
 
@@ -63,58 +58,48 @@ class TestContineWithDifferntOp(object):
         op.callback = callback
         new_op.action = "pend"
 
-        delegate_to_different_op(stage, original_op=op, new_op=new_op)
+        stage._send_worker_op_down(worker_op=new_op, op=op)
         assert callback.call_count == 0  # because new_op is pending
 
-        complete_op(stage.next, new_op)
+        stage.next._complete_op(new_op)
         assert_callback_succeeded(op=op)
 
     @pytest.mark.it("Returns the new op failure in the original op if new op fails")
     def test_returns_new_op_failure_in_original_op(self, stage, op, new_op, callback):
         op.callback = callback
         new_op.action = "fail"
-        delegate_to_different_op(stage, original_op=op, new_op=new_op)
-        assert_callback_failed(op=op, error=new_op.error)
+        stage._send_worker_op_down(worker_op=new_op, op=op)
+        assert_callback_failed(op)
 
 
-@pytest.mark.describe("pass_op_to_next_stage()")
+@pytest.mark.describe("_send_op_down()")
 class TestContinueOp(object):
-    @pytest.mark.it("Completes the op without continuing if the op has an error")
-    def test_completes_op_with_error(self, mocker, stage, op, arbitrary_exception, callback):
-        op.error = arbitrary_exception
-        op.callback = callback
-        pass_op_to_next_stage(stage, op)
-        assert_callback_failed(op=op, error=arbitrary_exception)
-        assert stage.next.run_op.call_count == 0
-
     @pytest.mark.it("Fails the op if there is no next stage")
     def test_fails_op_when_no_next_stage(self, stage, op, callback):
         op.callback = callback
         stage.next = None
-        pass_op_to_next_stage(stage, op)
+        stage._send_op_down(op)
         assert_callback_failed(op=op)
-        pass
 
     @pytest.mark.it("Passes the op to the next stage")
     def test_passes_op_to_next_stage(self, mocker, stage, op, callback):
-        pass_op_to_next_stage(stage, op)
+        stage._send_op_down(op)
         assert stage.next.run_op.call_count == 1
         assert stage.next.run_op.call_args == mocker.call(op)
 
 
-@pytest.mark.describe("complete_op()")
+@pytest.mark.describe("_complete_op()")
 class TestCompleteOp(object):
     @pytest.mark.it("Calls the op callback on success")
     def test_calls_callback_on_success(self, stage, op, callback):
         op.callback = callback
-        complete_op(stage, op)
+        stage._complete_op(op)
         assert_callback_succeeded(op)
 
     @pytest.mark.it("Calls the op callback on failure")
     def test_calls_callback_on_error(self, stage, op, callback, arbitrary_exception):
-        op.error = arbitrary_exception
         op.callback = callback
-        complete_op(stage, op)
+        stage._complete_op(op, error=arbitrary_exception)
         assert_callback_failed(op=op, error=arbitrary_exception)
 
     @pytest.mark.it(
@@ -124,9 +109,9 @@ class TestCompleteOp(object):
         self, stage, op, arbitrary_exception, mocker, unhandled_error_handler
     ):
         op.callback = mocker.Mock(side_effect=arbitrary_exception)
-        complete_op(stage, op)
+        stage._complete_op(op)
         assert op.callback.call_count == 1
-        assert op.callback.call_args == mocker.call(op)
+        assert op.callback.call_args == mocker.call(op, error=None)
         assert unhandled_error_handler.call_count == 1
         assert unhandled_error_handler.call_args == mocker.call(arbitrary_exception)
 
@@ -134,4 +119,4 @@ class TestCompleteOp(object):
     def test_op_callback_raises_base_exception(self, stage, op, arbitrary_base_exception, mocker):
         op.callback = mocker.Mock(side_effect=arbitrary_base_exception)
         with pytest.raises(arbitrary_base_exception.__class__):
-            complete_op(stage, op)
+            stage._complete_op(op)

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_ops_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_ops_base.py
@@ -22,46 +22,39 @@ class TestPipelineOperation(object):
 
 
 pipeline_data_object_test.add_operation_test(
-    cls=pipeline_ops_base.ConnectOperation,
-    module=this_module,
-    positional_arguments=[],
-    keyword_arguments={"callback": None},
+    cls=pipeline_ops_base.ConnectOperation, module=this_module
 )
 pipeline_data_object_test.add_operation_test(
-    cls=pipeline_ops_base.DisconnectOperation,
-    module=this_module,
-    positional_arguments=[],
-    keyword_arguments={"callback": None},
+    cls=pipeline_ops_base.DisconnectOperation, module=this_module
 )
 pipeline_data_object_test.add_operation_test(
-    cls=pipeline_ops_base.ReconnectOperation,
-    module=this_module,
-    positional_arguments=[],
-    keyword_arguments={"callback": None},
+    cls=pipeline_ops_base.ReconnectOperation, module=this_module
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_base.EnableFeatureOperation,
     module=this_module,
-    positional_arguments=["feature_name"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["feature_name", "callback"],
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_base.DisableFeatureOperation,
     module=this_module,
-    positional_arguments=["feature_name"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["feature_name", "callback"],
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_base.UpdateSasTokenOperation,
     module=this_module,
-    positional_arguments=["sas_token"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["sas_token", "callback"],
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_base.SendIotRequestAndWaitForResponseOperation,
     module=this_module,
-    positional_arguments=["request_type", "method", "resource_location", "request_body"],
-    keyword_arguments={"callback": None},
+    positional_arguments=[
+        "request_type",
+        "method",
+        "resource_location",
+        "request_body",
+        "callback",
+    ],
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_base.SendIotRequestOperation,
@@ -72,6 +65,6 @@ pipeline_data_object_test.add_operation_test(
         "resource_location",
         "request_body",
         "request_id",
+        "callback",
     ],
-    keyword_arguments={"callback": None},
 )

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_ops_mqtt.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_ops_mqtt.py
@@ -14,27 +14,24 @@ this_module = sys.modules[__name__]
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_mqtt.SetMQTTConnectionArgsOperation,
     module=this_module,
-    positional_arguments=["client_id", "hostname", "username"],
-    keyword_arguments={"ca_cert": None, "client_cert": None, "sas_token": None, "callback": None},
+    positional_arguments=["client_id", "hostname", "username", "callback"],
+    keyword_arguments={"ca_cert": None, "client_cert": None, "sas_token": None},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_mqtt.MQTTPublishOperation,
     module=this_module,
-    positional_arguments=["topic", "payload"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["topic", "payload", "callback"],
     extra_defaults={"needs_connection": True},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_mqtt.MQTTSubscribeOperation,
     module=this_module,
-    positional_arguments=["topic"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["topic", "callback"],
     extra_defaults={"needs_connection": True},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_mqtt.MQTTUnsubscribeOperation,
     module=this_module,
-    positional_arguments=["topic"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["topic", "callback"],
     extra_defaults={"needs_connection": True},
 )

--- a/azure-iot-device/tests/iothub/pipeline/test_iothub_pipeline.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_iothub_pipeline.py
@@ -11,7 +11,6 @@ from azure.iot.device.common.pipeline import (
     pipeline_stages_base,
     pipeline_stages_mqtt,
     pipeline_ops_base,
-    operation_flow,
 )
 from azure.iot.device.iothub.pipeline import (
     pipeline_stages_iothub,
@@ -146,8 +145,7 @@ class TestIoTHubPipelineInstantiation(object):
 
         def fail_set_auth_provider(self, op):
             if isinstance(op, pipeline_ops_iothub.SetAuthProviderOperation):
-                op.error = arbitrary_exception
-                operation_flow.complete_op(stage=self, op=op)
+                self._complete_op(op, error=arbitrary_exception)
             else:
                 old_execute_op(self, op)
 
@@ -184,8 +182,7 @@ class TestIoTHubPipelineInstantiation(object):
 
         def fail_set_auth_provider(self, op):
             if isinstance(op, pipeline_ops_iothub.SetX509AuthProviderOperation):
-                op.error = arbitrary_exception
-                operation_flow.complete_op(stage=self, op=op)
+                self._complete_op(op, error=arbitrary_exception)
             else:
                 old_execute_op(self, op)
 
@@ -224,10 +221,10 @@ class TestIoTHubPipelineConnect(object):
 
         # Trigger op completion callback
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
+        op.callback(op, error=None)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call()
+        assert cb.call_args == mocker.call(error=None)
 
     @pytest.mark.it(
         "Calls the callback with the error upon unsuccessful completion of the ConnectOperation"
@@ -237,11 +234,10 @@ class TestIoTHubPipelineConnect(object):
 
         pipeline.connect(callback=cb)
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = arbitrary_exception
 
-        op.callback(op)
+        op.callback(op, error=arbitrary_exception)
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call(error=op.error)
+        assert cb.call_args == mocker.call(error=arbitrary_exception)
 
 
 @pytest.mark.describe("IoTHubPipeline - .disconnect()")
@@ -264,10 +260,10 @@ class TestIoTHubPipelineDisconnect(object):
 
         # Trigger op completion callback
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
+        op.callback(op, error=None)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call()
+        assert cb.call_args == mocker.call(error=None)
 
     @pytest.mark.it(
         "Calls the callback with the error upon unsuccessful completion of the DisconnectOperation"
@@ -277,11 +273,10 @@ class TestIoTHubPipelineDisconnect(object):
         pipeline.disconnect(callback=cb)
 
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = arbitrary_exception
-        op.callback(op)
+        op.callback(op, error=arbitrary_exception)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call(error=op.error)
+        assert cb.call_args == mocker.call(error=arbitrary_exception)
 
 
 @pytest.mark.describe("IoTHubPipeline - .send_message()")
@@ -307,10 +302,10 @@ class TestIoTHubPipelineSendD2CMessage(object):
 
         # Trigger op completion callback
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
+        op.callback(op, error=None)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call()
+        assert cb.call_args == mocker.call(error=None)
 
     @pytest.mark.it(
         "Calls the callback with the error upon unsuccessful completion of the SendD2CMessageOperation"
@@ -320,11 +315,10 @@ class TestIoTHubPipelineSendD2CMessage(object):
         pipeline.send_message(message, callback=cb)
 
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = arbitrary_exception
-        op.callback(op)
+        op.callback(op, error=arbitrary_exception)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call(error=op.error)
+        assert cb.call_args == mocker.call(error=arbitrary_exception)
 
 
 @pytest.mark.describe("IoTHubPipeline - .send_output_event()")
@@ -356,10 +350,10 @@ class TestIoTHubPipelineSendOutputEvent(object):
 
         # Trigger op completion callback
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
+        op.callback(op, error=None)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call()
+        assert cb.call_args == mocker.call(error=None)
 
     @pytest.mark.it(
         "Calls the callback with the error upon unsuccessful completion of the SendOutputEventOperation"
@@ -369,11 +363,10 @@ class TestIoTHubPipelineSendOutputEvent(object):
         pipeline.send_output_event(message, callback=cb)
 
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = arbitrary_exception
-        op.callback(op)
+        op.callback(op, error=arbitrary_exception)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call(error=op.error)
+        assert cb.call_args == mocker.call(error=arbitrary_exception)
 
 
 @pytest.mark.describe("IoTHubPipeline - .send_method_response()")
@@ -401,10 +394,10 @@ class TestIoTHubPipelineSendMethodResponse(object):
 
         # Trigger op completion callback
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
+        op.callback(op, error=None)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call()
+        assert cb.call_args == mocker.call(error=None)
 
     @pytest.mark.it(
         "Calls the callback with the error upon unsuccessful completion of the SendMethodResponseOperation"
@@ -414,11 +407,10 @@ class TestIoTHubPipelineSendMethodResponse(object):
         pipeline.send_method_response(method_response, callback=cb)
 
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = arbitrary_exception
-        op.callback(op)
+        op.callback(op, error=arbitrary_exception)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call(error=op.error)
+        assert cb.call_args == mocker.call(error=arbitrary_exception)
 
 
 @pytest.mark.describe("IoTHubPipeline - .get_twin()")
@@ -444,7 +436,7 @@ class TestIoTHubPipelineGetTwin(object):
 
         # Trigger op completion callback
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
+        op.callback(op, error=None)
 
         assert cb.call_count == 1
         assert cb.call_args == mocker.call(twin=None)
@@ -457,11 +449,10 @@ class TestIoTHubPipelineGetTwin(object):
         pipeline.get_twin(callback=cb)
 
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = arbitrary_exception
-        op.callback(op)
+        op.callback(op, error=arbitrary_exception)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call(twin=None, error=op.error)
+        assert cb.call_args == mocker.call(twin=None, error=arbitrary_exception)
 
 
 @pytest.mark.describe("IoTHubPipeline - .patch_twin_reported_properties()")
@@ -489,10 +480,10 @@ class TestIoTHubPipelinePatchTwinReportedProperties(object):
 
         # Trigger op completion callback
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
+        op.callback(op, error=None)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call()
+        assert cb.call_args == mocker.call(error=None)
 
     @pytest.mark.it(
         "Calls the callback with the error upon unsuccessful completion of the PatchTwinReportedPropertiesOperation"
@@ -502,11 +493,10 @@ class TestIoTHubPipelinePatchTwinReportedProperties(object):
         pipeline.patch_twin_reported_properties(twin_patch, callback=cb)
 
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = arbitrary_exception
-        op.callback(op)
+        op.callback(op, error=arbitrary_exception)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call(error=op.error)
+        assert cb.call_args == mocker.call(error=arbitrary_exception)
 
 
 @pytest.mark.describe("IoTHubPipeline - .enable_feature()")
@@ -551,10 +541,10 @@ class TestIoTHubPipelineEnableFeature(object):
 
         # Trigger op completion callback
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
+        op.callback(op, error=None)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call()
+        assert cb.call_args == mocker.call(error=None)
 
     @pytest.mark.it(
         "Calls the callback with the error upon unsuccessful completion of the EnableFeatureOperation"
@@ -565,11 +555,10 @@ class TestIoTHubPipelineEnableFeature(object):
         pipeline.enable_feature(feature, callback=cb)
 
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = arbitrary_exception
-        op.callback(op)
+        op.callback(op, error=arbitrary_exception)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call(error=op.error)
+        assert cb.call_args == mocker.call(error=arbitrary_exception)
 
 
 @pytest.mark.describe("IoTHubPipeline - .disable_feature()")
@@ -616,10 +605,10 @@ class TestIoTHubPipelineDisableFeature(object):
 
         # Trigger op completion callback
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.callback(op)
+        op.callback(op, error=None)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call()
+        assert cb.call_args == mocker.call(error=None)
 
     @pytest.mark.it(
         "Calls the callback with the error upon unsuccessful completion of the DisableFeatureOperation"
@@ -630,11 +619,10 @@ class TestIoTHubPipelineDisableFeature(object):
         pipeline.disable_feature(feature, callback=cb)
 
         op = pipeline._pipeline.run_op.call_args[0][0]
-        op.error = arbitrary_exception
-        op.callback(op)
+        op.callback(op, error=arbitrary_exception)
 
         assert cb.call_count == 1
-        assert cb.call_args == mocker.call(error=op.error)
+        assert cb.call_args == mocker.call(error=arbitrary_exception)
 
 
 @pytest.mark.describe("IoTHubPipeline - EVENT: Connected")

--- a/azure-iot-device/tests/iothub/pipeline/test_pipeline_ops_iothub.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_pipeline_ops_iothub.py
@@ -14,55 +14,45 @@ this_module = sys.modules[__name__]
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_iothub.SetAuthProviderOperation,
     module=this_module,
-    positional_arguments=["auth_provider"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["auth_provider", "callback"],
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_iothub.SetX509AuthProviderOperation,
     module=this_module,
-    positional_arguments=["auth_provider"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["auth_provider", "callback"],
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_iothub.SetIoTHubConnectionArgsOperation,
     module=this_module,
-    positional_arguments=["device_id", "hostname"],
+    positional_arguments=["device_id", "hostname", "callback"],
     keyword_arguments={
         "module_id": None,
         "gateway_hostname": None,
         "ca_cert": None,
         "client_cert": None,
         "sas_token": None,
-        "callback": None,
     },
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_iothub.SendD2CMessageOperation,
     module=this_module,
-    positional_arguments=["message"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["message", "callback"],
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_iothub.SendOutputEventOperation,
     module=this_module,
-    positional_arguments=["message"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["message", "callback"],
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_iothub.SendMethodResponseOperation,
     module=this_module,
-    positional_arguments=["method_response"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["method_response", "callback"],
 )
 pipeline_data_object_test.add_operation_test(
-    cls=pipeline_ops_iothub.GetTwinOperation,
-    module=this_module,
-    positional_arguments=[],
-    keyword_arguments={"callback": None},
+    cls=pipeline_ops_iothub.GetTwinOperation, module=this_module
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_iothub.PatchTwinReportedPropertiesOperation,
     module=this_module,
-    positional_arguments=["patch"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["patch", "callback"],
 )

--- a/azure-iot-device/tests/iothub/pipeline/test_pipeline_stages_iothub_mqtt.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_pipeline_stages_iothub_mqtt.py
@@ -473,7 +473,7 @@ class TestIoTHubMQTTConverterWithUpdateSasTokenOperationConnected(object):
         def run_op(op):
             print("in run_op {}".format(op.__class__.__name__))
             if isinstance(op, pipeline_ops_base.UpdateSasTokenOperation):
-                op.callback(op)
+                op.callback(op, error=None)
             else:
                 pass
 
@@ -508,10 +508,9 @@ class TestIoTHubMQTTConverterWithUpdateSasTokenOperationConnected(object):
         def run_op(op):
             print("in run_op {}".format(op.__class__.__name__))
             if isinstance(op, pipeline_ops_base.UpdateSasTokenOperation):
-                op.callback(op)
+                stage.next._complete_op(op, error=None)
             elif isinstance(op, pipeline_ops_base.ReconnectOperation):
-                op.error = arbitrary_exception
-                op.callback(op)
+                stage.next._complete_op(op, error=arbitrary_exception)
             else:
                 pass
 
@@ -529,27 +528,27 @@ class TestIoTHubMQTTConverterWithUpdateSasTokenOperationConnected(object):
 basic_ops = [
     {
         "op_class": pipeline_ops_iothub.SendD2CMessageOperation,
-        "op_init_kwargs": {"message": fake_message},
+        "op_init_kwargs": {"message": fake_message, "callback": None},
         "new_op_class": pipeline_ops_mqtt.MQTTPublishOperation,
     },
     {
         "op_class": pipeline_ops_iothub.SendOutputEventOperation,
-        "op_init_kwargs": {"message": fake_message},
+        "op_init_kwargs": {"message": fake_message, "callback": None},
         "new_op_class": pipeline_ops_mqtt.MQTTPublishOperation,
     },
     {
         "op_class": pipeline_ops_iothub.SendMethodResponseOperation,
-        "op_init_kwargs": {"method_response": fake_method_response},
+        "op_init_kwargs": {"method_response": fake_method_response, "callback": None},
         "new_op_class": pipeline_ops_mqtt.MQTTPublishOperation,
     },
     {
         "op_class": pipeline_ops_base.EnableFeatureOperation,
-        "op_init_kwargs": {"feature_name": constant.C2D_MSG},
+        "op_init_kwargs": {"feature_name": constant.C2D_MSG, "callback": None},
         "new_op_class": pipeline_ops_mqtt.MQTTSubscribeOperation,
     },
     {
         "op_class": pipeline_ops_base.DisableFeatureOperation,
-        "op_init_kwargs": {"feature_name": constant.C2D_MSG},
+        "op_init_kwargs": {"feature_name": constant.C2D_MSG, "callback": None},
         "new_op_class": pipeline_ops_mqtt.MQTTUnsubscribeOperation,
     },
 ]
@@ -602,7 +601,7 @@ publish_ops = [
         "name": "send telemetry",
         "stage_type": "device",
         "op_class": pipeline_ops_iothub.SendD2CMessageOperation,
-        "op_init_kwargs": {"message": Message(fake_message_body)},
+        "op_init_kwargs": {"message": Message(fake_message_body), "callback": None},
         "topic": "devices/{}/messages/events/{}&{}".format(
             fake_device_id, default_content_type_encoded, default_content_encoding_encoded
         ),
@@ -617,7 +616,8 @@ publish_ops = [
                 fake_message_body,
                 content_type=fake_content_type,
                 content_encoding=fake_content_encoding,
-            )
+            ),
+            "callback": None,
         },
         "topic": "devices/{}/messages/events/{}&{}".format(
             fake_device_id, fake_content_type_encoded, fake_content_encoding_encoded
@@ -628,7 +628,10 @@ publish_ops = [
         "name": "send telemetry overriding only the content type",
         "stage_type": "device",
         "op_class": pipeline_ops_iothub.SendD2CMessageOperation,
-        "op_init_kwargs": {"message": Message(fake_message_body, content_type=fake_content_type)},
+        "op_init_kwargs": {
+            "message": Message(fake_message_body, content_type=fake_content_type),
+            "callback": None,
+        },
         "topic": "devices/{}/messages/events/{}&{}".format(
             fake_device_id, fake_content_type_encoded, default_content_encoding_encoded
         ),
@@ -638,7 +641,10 @@ publish_ops = [
         "name": "send telemetry with single system property",
         "stage_type": "device",
         "op_class": pipeline_ops_iothub.SendD2CMessageOperation,
-        "op_init_kwargs": {"message": Message(fake_message_body, output_name=fake_output_name)},
+        "op_init_kwargs": {
+            "message": Message(fake_message_body, output_name=fake_output_name),
+            "callback": None,
+        },
         "topic": "devices/{}/messages/events/{}&{}&{}".format(
             fake_device_id,
             fake_output_name_encoded,
@@ -651,7 +657,7 @@ publish_ops = [
         "name": "send security message",
         "stage_type": "device",
         "op_class": pipeline_ops_iothub.SendD2CMessageOperation,
-        "op_init_kwargs": {"message": create_security_message(fake_message_body)},
+        "op_init_kwargs": {"message": create_security_message(fake_message_body), "callback": None},
         "topic": "devices/{}/messages/events/{}&{}&{}".format(
             fake_device_id,
             default_content_type_encoded,
@@ -667,7 +673,8 @@ publish_ops = [
         "op_init_kwargs": {
             "message": Message(
                 fake_message_body, message_id=fake_message_id, output_name=fake_output_name
-            )
+            ),
+            "callback": None,
         },
         "topic": "devices/{}/messages/events/{}&{}&{}&{}".format(
             fake_device_id,
@@ -683,7 +690,8 @@ publish_ops = [
         "stage_type": "device",
         "op_class": pipeline_ops_iothub.SendD2CMessageOperation,
         "op_init_kwargs": {
-            "message": create_message_with_user_properties(fake_message_body, is_multiple=False)
+            "message": create_message_with_user_properties(fake_message_body, is_multiple=False),
+            "callback": None,
         },
         "topic": "devices/{}/messages/events/{}&{}&{}".format(
             fake_device_id,
@@ -698,7 +706,8 @@ publish_ops = [
         "stage_type": "device",
         "op_class": pipeline_ops_iothub.SendD2CMessageOperation,
         "op_init_kwargs": {
-            "message": create_message_with_user_properties(fake_message_body, is_multiple=True)
+            "message": create_message_with_user_properties(fake_message_body, is_multiple=True),
+            "callback": None,
         },
         # For more than 1 user property the order could be different, creating 2 different topics
         "topic1": "devices/{}/messages/events/{}&{}&{}&{}".format(
@@ -724,7 +733,8 @@ publish_ops = [
         "op_init_kwargs": {
             "message": create_message_with_system_and_user_properties(
                 fake_message_body, is_multiple=False
-            )
+            ),
+            "callback": None,
         },
         "topic": "devices/{}/messages/events/{}&{}&{}&{}".format(
             fake_device_id,
@@ -742,7 +752,8 @@ publish_ops = [
         "op_init_kwargs": {
             "message": create_message_with_system_and_user_properties(
                 fake_message_body, is_multiple=True
-            )
+            ),
+            "callback": None,
         },
         # For more than 1 user property the order could be different, creating 2 different topics
         "topic1": "devices/{}/messages/events/{}&{}&{}&{}&{}&{}".format(
@@ -772,7 +783,8 @@ publish_ops = [
         "op_init_kwargs": {
             "message": create_security_message_with_system_and_user_properties(
                 fake_message_body, is_multiple=True
-            )
+            ),
+            "callback": None,
         },
         # For more than 1 user property the order could be different, creating 2 different topics
         "topic1": "devices/{}/messages/events/{}&{}&{}&{}&{}&{}&{}".format(
@@ -801,7 +813,10 @@ publish_ops = [
         "name": "send output",
         "stage_type": "module",
         "op_class": pipeline_ops_iothub.SendOutputEventOperation,
-        "op_init_kwargs": {"message": Message(fake_message_body, output_name=fake_output_name)},
+        "op_init_kwargs": {
+            "message": Message(fake_message_body, output_name=fake_output_name),
+            "callback": None,
+        },
         "topic": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}".format(
             fake_device_id,
             fake_module_id,
@@ -821,7 +836,8 @@ publish_ops = [
                 output_name=fake_output_name,
                 content_type=fake_content_type,
                 content_encoding=fake_content_encoding,
-            )
+            ),
+            "callback": None,
         },
         "topic": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}".format(
             fake_device_id,
@@ -839,7 +855,8 @@ publish_ops = [
         "op_init_kwargs": {
             "message": Message(
                 fake_message_body, message_id=fake_message_id, output_name=fake_output_name
-            )
+            ),
+            "callback": None,
         },
         "topic": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}&{}".format(
             fake_device_id,
@@ -858,7 +875,8 @@ publish_ops = [
         "op_init_kwargs": {
             "message": create_message_for_output_with_user_properties(
                 fake_message_body, is_multiple=False
-            )
+            ),
+            "callback": None,
         },
         "topic": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}&{}".format(
             fake_device_id,
@@ -877,7 +895,8 @@ publish_ops = [
         "op_init_kwargs": {
             "message": create_message_for_output_with_user_properties(
                 fake_message_body, is_multiple=True
-            )
+            ),
+            "callback": None,
         },
         "topic1": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}&{}&{}".format(
             fake_device_id,
@@ -906,7 +925,8 @@ publish_ops = [
         "op_init_kwargs": {
             "message": create_message_for_output_with_system_and_user_properties(
                 fake_message_body, is_multiple=False
-            )
+            ),
+            "callback": None,
         },
         "topic": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}&{}&{}".format(
             fake_device_id,
@@ -923,7 +943,7 @@ publish_ops = [
         "name": "send method result",
         "stage_type": "both",
         "op_class": pipeline_ops_iothub.SendMethodResponseOperation,
-        "op_init_kwargs": {"method_response": fake_method_response},
+        "op_init_kwargs": {"method_response": fake_method_response, "callback": None},
         "topic": "$iothub/methods/res/__fake_method_status__/?$rid=__fake_request_id__",
         "publish_payload": json.dumps(fake_method_payload),
     },
@@ -1011,7 +1031,9 @@ class TestIoTHubMQTTConverterWithEnableFeature(object):
         elif topic_parameters["stage_type"] == "module" and not stage.module_id:
             pytest.skip()
         stage.next._execute_op = mocker.Mock()
-        op = op_parameters["op_class"](feature_name=topic_parameters["feature_name"])
+        op = op_parameters["op_class"](
+            feature_name=topic_parameters["feature_name"], callback=mocker.MagicMock()
+        )
         stage.run_op(op)
         new_op = stage.next._execute_op.call_args[0][0]
         assert isinstance(new_op, op_parameters["new_op"])
@@ -1029,10 +1051,7 @@ class TestIoTHubMQTTConverterWithEnableFeature(object):
         op = op_parameters["op_class"](feature_name=invalid_feature_name, callback=callback)
         callback.reset_mock()
         stage.run_op(op)
-        assert callback.call_count == 1
-        callback_arg = op.callback.call_args[0][0]
-        assert callback_arg == op
-        assert isinstance(callback_arg.error, KeyError)
+        assert_callback_failed(op=op, error=KeyError)
 
 
 @pytest.fixture
@@ -1206,23 +1225,22 @@ class TestIotHubMQTTConverterWithSendIotRequest(object):
         assert e_info.value is arbitrary_base_exception
 
     @pytest.mark.it(
-        "Returns op.error as the MQTTPublishOperation error in the op callback if the MQTTPublishOperation returned an error in its operation callback"
+        "Returns error as the MQTTPublishOperation error in the op callback if the MQTTPublishOperation returned an error in its operation callback"
     )
     def test_publish_op_returns_failure(self, stage, op, arbitrary_exception):
         def next_stage_run_op(self, op):
-            op.error = arbitrary_exception
-            op.callback(op)
+            op.callback(op, error=arbitrary_exception)
 
         stage.next.run_op = functools.partial(next_stage_run_op, (stage.next,))
         stage.run_op(op)
         assert_callback_failed(op=op, error=arbitrary_exception)
 
     @pytest.mark.it(
-        "Returns op.error=None in the operation callback if the MQTTPublishOperation returned op.error=None in its operation callback"
+        "Returns error=None in the operation callback if the MQTTPublishOperation returned error=None in its operation callback"
     )
     def test_publish_op_returns_success(self, stage, op):
         def next_stage_run_op(self, op):
-            op.callback(op)
+            op.callback(op, error=None)
 
         stage.next.run_op = functools.partial(next_stage_run_op, (stage.next,))
         stage.run_op(op)

--- a/azure-iot-device/tests/provisioning/pipeline/test_pipeline_ops_provisioning.py
+++ b/azure-iot-device/tests/provisioning/pipeline/test_pipeline_ops_provisioning.py
@@ -14,24 +14,21 @@ this_module = sys.modules[__name__]
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_provisioning.SetSymmetricKeySecurityClientOperation,
     module=this_module,
-    positional_arguments=["security_client"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["security_client", "callback"],
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_provisioning.SetProvisioningClientConnectionArgsOperation,
     module=this_module,
-    positional_arguments=["provisioning_host", "registration_id", "id_scope"],
-    keyword_arguments={"client_cert": None, "sas_token": None, "callback": None},
+    positional_arguments=["provisioning_host", "registration_id", "id_scope", "callback"],
+    keyword_arguments={"client_cert": None, "sas_token": None},
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_provisioning.SendRegistrationRequestOperation,
     module=this_module,
-    positional_arguments=["request_id", "request_payload"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["request_id", "request_payload", "callback"],
 )
 pipeline_data_object_test.add_operation_test(
     cls=pipeline_ops_provisioning.SendQueryRequestOperation,
     module=this_module,
-    positional_arguments=["request_id", "operation_id", "request_payload"],
-    keyword_arguments={"callback": None},
+    positional_arguments=["request_id", "operation_id", "request_payload", "callback"],
 )

--- a/azure-iot-device/tests/provisioning/pipeline/test_pipeline_stages_provisioning.py
+++ b/azure-iot-device/tests/provisioning/pipeline/test_pipeline_stages_provisioning.py
@@ -114,9 +114,8 @@ def set_security_client(callback, params_security_ops):
     # Create new security client every time to pass into fixture to avoid re-use of old security client
     # Otherwise the exception/failure raised by one test is makes the next test fail.
     op = params_security_ops["current_op_class"](
-        security_client=params_security_ops["security_client_function_name"]()
+        security_client=params_security_ops["security_client_function_name"](), callback=callback
     )
-    op.callback = callback
     return op
 
 

--- a/azure-iot-device/tests/provisioning/pipeline/test_pipeline_stages_provisioning_mqtt.py
+++ b/azure-iot-device/tests/provisioning/pipeline/test_pipeline_stages_provisioning_mqtt.py
@@ -234,8 +234,7 @@ basic_ops = [
 
 @pytest.fixture
 def op(params, callback):
-    op = params["op_class"](**params["op_init_kwargs"])
-    op.callback = callback
+    op = params["op_class"](callback=callback, **params["op_init_kwargs"])
     return op
 
 
@@ -343,7 +342,7 @@ class TestProvisioningMQTTConverterWithEnable(object):
         topic = "$dps/registrations/res/#"
         mock_stage.next._execute_op = mocker.Mock()
 
-        op = op_parameters["op_class"](feature_name=None)
+        op = op_parameters["op_class"](feature_name=None, callback=mocker.MagicMock())
         mock_stage.run_op(op)
         new_op = mock_stage.next._execute_op.call_args[0][0]
         assert isinstance(new_op, op_parameters["new_op"])

--- a/azure-iot-device/tests/provisioning/pipeline/test_provisioning_pipeline.py
+++ b/azure-iot-device/tests/provisioning/pipeline/test_provisioning_pipeline.py
@@ -7,7 +7,7 @@
 import pytest
 import logging
 from azure.iot.device.common.models import X509
-from azure.iot.device.common.pipeline import pipeline_stages_base, operation_flow
+from azure.iot.device.common.pipeline import pipeline_stages_base
 from azure.iot.device.provisioning.security.sk_security_client import SymmetricKeySecurityClient
 from azure.iot.device.provisioning.security.x509_security_client import X509SecurityClient
 from azure.iot.device.provisioning.pipeline.provisioning_pipeline import ProvisioningPipeline
@@ -142,8 +142,7 @@ class TestInit(object):
 
         def fail_set_auth_provider(self, op):
             if isinstance(op, params_security_clients["set_args_op_class"]):
-                op.error = arbitrary_exception
-                operation_flow.complete_op(stage=self, op=op)
+                self._complete_op(op, error=arbitrary_exception)
             else:
                 old_execute_op(self, op)
 


### PR DESCRIPTION
This is part of the retry changes factored out as it's own PR.  I did this for 2 reasons:
1. it made retry easier and cleaner
2. these things have been bothering me

This has 3 major changes:
1. I moved the error from an operation attribute into a callback parameter.  This is because the idea of an operation failing is becoming more transient with retry.  An error is not an integral part of an operation.  Rather, it's a temporary status that represents what happened to the operation most recently.  
2. The operation_flow.py methods are not part of the PipelineStage objects, which is sort-of what they were before.  I also renamed these to (I hope) make more sense.  
3. I added the idea that an op could be marked as "completed" and separated the concepts of `complete_op()` and `send_completed_op_up()`.  This way, we don't have code that completes an op and then completes it again.  The `_send_op_down_and_intercept_return` function was also added for stages that need to keep track of operation (like `EnsureConnectionStage `and `TimeoutStage`)