### PR TITLE
docs: Further changes for correct API doc generation

### DIFF
--- a/azure-iot-device/azure/iot/device/iothub/aio/async_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/aio/async_clients.py
@@ -50,8 +50,10 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         This initializer should not be called directly.
         Instead, use one of the 'create_from_' classmethods to instantiate
 
-        TODO: How to document kwargs?
-        Possible values: iothub_pipeline, edge_pipeline
+        :param iothub_pipeline: The IoTHubPipeline used for the client
+        :type iothub_pipeline: :class:`azure.iot.device.iothub.pipeline.IoTHubPipeline`
+        :param edge_pipeline: The EdgePipeline used for the client
+        :type edge_pipeline: :class:`azure.iot.device.iothub.pipeline.EdgePipeline`
         """
         # Depending on the subclass calling this __init__, there could be different arguments,
         # and the super() call could call a different class, due to the different MROs
@@ -121,6 +123,7 @@ class GenericIoTHubClient(AbstractIoTHubClient):
 
         :param message: The actual message to send. Anything passed that is not an instance of the
             Message class will be converted to Message object.
+        :type message: :class:`azure.iot.device.Message` or str
 
         :raises: :class:`azure.iot.device.exceptions.CredentialError` if credentials are invalid
             and a connection cannot be established.
@@ -215,7 +218,8 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         """
         Gets the device or module twin from the Azure IoT Hub or Azure IoT Edge Hub service.
 
-        :returns: Twin object which was retrieved from the hub
+        :returns: Complete Twin as a JSON dict
+        :rtype: dict
 
         :raises: :class:`azure.iot.device.exceptions.CredentialError` if credentials are invalid
             and a connection cannot be established.
@@ -246,8 +250,8 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         If the service returns an error on the patch operation, this function will raise the
         appropriate error.
 
-        :param reported_properties_patch:
-        :type reported_properties_patch: dict, str, int, float, bool, or None (JSON compatible values)
+        :param reported_properties_patch: Twin Reported Properties patch as a JSON dict
+        :type reported_properties_patch: dict
 
         :raises: :class:`azure.iot.device.exceptions.CredentialError` if credentials are invalid
             and a connection cannot be established.
@@ -279,7 +283,8 @@ class GenericIoTHubClient(AbstractIoTHubClient):
 
         If no method request is yet available, will wait until it is available.
 
-        :returns: desired property patch. This can be dict, str, int, float, bool, or None (JSON compatible values)
+        :returns: Twin Desired Properties patch as a JSON dict
+        :rtype: dict
         """
         if not self._iothub_pipeline.feature_enabled[constant.TWIN_PATCHES]:
             await self._enable_feature(constant.TWIN_PATCHES)
@@ -340,9 +345,9 @@ class IoTHubModuleClient(GenericIoTHubClient, AbstractIoTHubModuleClient):
         Instead, use one of the 'create_from_' classmethods to instantiate
 
         :param iothub_pipeline: The pipeline used to connect to the IoTHub endpoint.
-        :type iothub_pipeline: IoTHubPipeline
+        :type iothub_pipeline: :class:`azure.iot.device.iothub.pipeline.IoTHubPipeline`
         :param edge_pipeline: The pipeline used to connect to the Edge endpoint.
-        :type edge_pipeline: EdgePipeline
+        :type edge_pipeline: :class:`azure.iot.device.iothub.pipeline.EdgePipeline`
         """
         super().__init__(iothub_pipeline=iothub_pipeline, edge_pipeline=edge_pipeline)
         self._iothub_pipeline.on_input_message_received = self._inbox_manager.route_input_message
@@ -355,8 +360,9 @@ class IoTHubModuleClient(GenericIoTHubClient, AbstractIoTHubModuleClient):
         If the connection to the service has not previously been opened by a call to connect, this
         function will open the connection before sending the event.
 
-        :param message: Message to send to the given output. Anything passed that is not an instance of the
-            Message class will be converted to Message object.
+        :param message: Message to send to the given output. Anything passed that is not an
+            instance of the Message class will be converted to Message object.
+        :type message: :class:`azure.iot.device.Message` or str
         :param str output_name: Name of the output to send the event to.
 
         :raises: :class:`azure.iot.device.exceptions.CredentialError` if credentials are invalid

--- a/azure-iot-device/azure/iot/device/iothub/sync_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/sync_clients.py
@@ -51,8 +51,10 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         This initializer should not be called directly.
         Instead, use one of the 'create_from_' classmethods to instantiate
 
-        TODO: How to document kwargs?
-        Possible values: iothub_pipeline, edge_pipeline
+        :param iothub_pipeline: The IoTHubPipeline used for the client
+        :type iothub_pipeline: :class:`azure.iot.device.iothub.pipeline.IoTHubPipeline`
+        :param edge_pipeline: The EdgePipeline used for the client
+        :type edge_pipeline: :class:`azure.iot.device.iothub.pipeline.EdgePipeline`
         """
         # Depending on the subclass calling this __init__, there could be different arguments,
         # and the super() call could call a different class, due to the different MROs
@@ -133,6 +135,7 @@ class GenericIoTHubClient(AbstractIoTHubClient):
 
         :param message: The actual message to send. Anything passed that is not an instance of the
             Message class will be converted to Message object.
+        :type message: :class:`azure.iot.device.Message` or str
 
         :raises: :class:`azure.iot.device.exceptions.CredentialError` if credentials are invalid
             and a connection cannot be established.
@@ -232,6 +235,9 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         This is a synchronous call, meaning that this function will not return until the twin
         has been retrieved from the service.
 
+        :returns: Complete Twin as a JSON dict
+        :rtype: dict
+
         :raises: :class:`azure.iot.device.exceptions.CredentialError` if credentials are invalid
             and a connection cannot be established.
         :raises: :class:`azure.iot.device.exceptions.ConnectionFailedError` if a establishing a
@@ -240,8 +246,6 @@ class GenericIoTHubClient(AbstractIoTHubClient):
             during execution.
         :raises: :class:`azure.iot.device.exceptions.ClientError` if there is an unexpected failure
             during execution.
-
-        :returns: Twin object which was retrieved from the hub
         """
         if not self._iothub_pipeline.feature_enabled[pipeline_constant.TWIN]:
             self._enable_feature(pipeline_constant.TWIN)
@@ -263,8 +267,8 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         If the service returns an error on the patch operation, this function will raise the
         appropriate error.
 
-        :param reported_properties_patch:
-        :type reported_properties_patch: dict, str, int, float, bool, or None (JSON compatible values)
+        :param reported_properties_patch: Twin Reported Properties patch as a JSON dict
+        :type reported_properties_patch: dict
 
         :raises: :class:`azure.iot.device.exceptions.CredentialError` if credentials are invalid
             and a connection cannot be established.
@@ -303,8 +307,9 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         :param bool block: Indicates if the operation should block until a request is received.
         :param int timeout: Optionally provide a number of seconds until blocking times out.
 
-        :returns: desired property patch.  This can be dict, str, int, float, bool, or None (JSON compatible values).
-            Also returns None if no patch has been received by the end of the blocking period.
+        :returns: Twin Desired Properties patch as a JSON dict, or None if no patch has been
+            received by the end of the blocking period
+        :rtype: dict or None
         """
         if not self._iothub_pipeline.feature_enabled[pipeline_constant.TWIN_PATCHES]:
             self._enable_feature(pipeline_constant.TWIN_PATCHES)
@@ -347,6 +352,7 @@ class IoTHubDeviceClient(GenericIoTHubClient, AbstractIoTHubDeviceClient):
 
         :returns: Message that was sent from the Azure IoT Hub, or None if
             no method request has been received by the end of the blocking period.
+        :rtype: :class:`azure.iot.device.Message` or None
         """
         if not self._iothub_pipeline.feature_enabled[pipeline_constant.C2D_MSG]:
             self._enable_feature(pipeline_constant.C2D_MSG)
@@ -374,9 +380,9 @@ class IoTHubModuleClient(GenericIoTHubClient, AbstractIoTHubModuleClient):
         Instead, use one of the 'create_from_' classmethods to instantiate
 
         :param iothub_pipeline: The pipeline used to connect to the IoTHub endpoint.
-        :type iothub_pipeline: IoTHubPipeline
-        :param edge_pipeline: (OPTIONAL) The pipeline used to connect to the Edge endpoint.
-        :type edge_pipeline: EdgePipeline
+        :type iothub_pipeline: :class:`azure.iot.device.iothub.pipeline.IoTHubPipeline`
+        :param edge_pipeline: The pipeline used to connect to the Edge endpoint.
+        :type edge_pipeline: :class:`azure.iot.device.iothub.pipeline.EdgePipeline`
         """
         super(IoTHubModuleClient, self).__init__(
             iothub_pipeline=iothub_pipeline, edge_pipeline=edge_pipeline
@@ -398,6 +404,7 @@ class IoTHubModuleClient(GenericIoTHubClient, AbstractIoTHubModuleClient):
 
         :param message: Message to send to the given output. Anything passed that is not an instance of the
             Message class will be converted to Message object.
+        :type message: :class:`azure.iot.device.Message` or str
         :param str output_name: Name of the output to send the event to.
 
         :raises: :class:`azure.iot.device.exceptions.CredentialError` if credentials are invalid

--- a/azure-iot-device/azure/iot/device/provisioning/abstract_provisioning_device_client.py
+++ b/azure-iot-device/azure/iot/device/provisioning/abstract_provisioning_device_client.py
@@ -34,9 +34,7 @@ class AbstractProvisioningDeviceClient(object):
         self._provisioning_pipeline = provisioning_pipeline
 
     @classmethod
-    def create_from_symmetric_key(
-        cls, provisioning_host, registration_id, id_scope, symmetric_key, protocol_choice=None
-    ):
+    def create_from_symmetric_key(cls, provisioning_host, registration_id, id_scope, symmetric_key):
         """
         Create a client which can be used to run the registration of a device with provisioning service
         using Symmetric Key authentication.
@@ -56,31 +54,17 @@ class AbstractProvisioningDeviceClient(object):
             32 bytes when new enrollments are saved with the Auto-generate keys option enabled.
             Users can provide their own symmetric keys for enrollments by disabling this option
             within 16 bytes and 64 bytes and in valid Base64 format.
-        :param str protocol_choice: The choice for the protocol to be used. This is optional and
-            will default to protocol MQTT currently.
 
-        :returns: An ProvisioningDeviceClient instance which can register via Symmetric Key.
+        :returns: A ProvisioningDeviceClient instance which can register via Symmetric Key.
         """
-        if protocol_choice is not None:
-            protocol_name = protocol_choice.lower()
-        else:
-            protocol_name = "mqtt"
-        if protocol_name == "mqtt":
-            security_client = SymmetricKeySecurityClient(
-                provisioning_host, registration_id, id_scope, symmetric_key
-            )
-            mqtt_provisioning_pipeline = ProvisioningPipeline(security_client)
-            return cls(mqtt_provisioning_pipeline)
-        else:
-            raise NotImplementedError(
-                "A symmetric key can only create symmetric key security client which is compatible "
-                "only with MQTT protocol.Any other protocol has not been implemented."
-            )
+        security_client = SymmetricKeySecurityClient(
+            provisioning_host, registration_id, id_scope, symmetric_key
+        )
+        mqtt_provisioning_pipeline = ProvisioningPipeline(security_client)
+        return cls(mqtt_provisioning_pipeline)
 
     @classmethod
-    def create_from_x509_certificate(
-        cls, provisioning_host, registration_id, id_scope, x509, protocol_choice=None
-    ):
+    def create_from_x509_certificate(cls, provisioning_host, registration_id, id_scope, x509):
         """
         Create a client which can be used to run the registration of a device with
         provisioning service using X509 certificate authentication.
@@ -98,24 +82,12 @@ class AbstractProvisioningDeviceClient(object):
             contain cert (either the root certificate or one of the intermediate CA certificates).
             If the cert comes from a CER file, it needs to be base64 encoded.
         :type x509: :class:`azure.iot.device.X509`
-        :param str protocol_choice: The choice for the protocol to be used. This is optional and
-            will default to protocol MQTT currently.
 
         :returns: A ProvisioningDeviceClient which can register via Symmetric Key.
         """
-        if protocol_choice is None:
-            protocol_name = "mqtt"
-        else:
-            protocol_name = protocol_choice.lower()
-        if protocol_name == "mqtt":
-            security_client = X509SecurityClient(provisioning_host, registration_id, id_scope, x509)
-            mqtt_provisioning_pipeline = ProvisioningPipeline(security_client)
-            return cls(mqtt_provisioning_pipeline)
-        else:
-            raise NotImplementedError(
-                "A x509 certificate can only create x509 security client which is compatible only "
-                "with MQTT protocol.Any other protocol has not been implemented."
-            )
+        security_client = X509SecurityClient(provisioning_host, registration_id, id_scope, x509)
+        mqtt_provisioning_pipeline = ProvisioningPipeline(security_client)
+        return cls(mqtt_provisioning_pipeline)
 
     @abc.abstractmethod
     def register(self):

--- a/azure-iot-device/azure/iot/device/provisioning/aio/async_provisioning_device_client.py
+++ b/azure-iot-device/azure/iot/device/provisioning/aio/async_provisioning_device_client.py
@@ -45,9 +45,13 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
     async def register(self):
         """
         Register the device with the provisioning service.
+
         Before returning the client will also disconnect from the provisioning service.
         If a registration attempt is made while a previous registration is in progress it may
         throw an error.
+
+        :returns: RegistrationResult indicating the result of the registration.
+        :rtype: :class:`azure.iot.device.RegistrationResult`
         """
         logger.info("Registering with Provisioning Service...")
         register_async = async_adapter.emulate_async(self._polling_machine.register)
@@ -61,6 +65,8 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
 
     async def cancel(self):
         """
+        Cancel a registration that is in progress.
+
         Before returning the client will also disconnect from the provisioning service.
 
         In case there is no registration in process it will throw an error as there is

--- a/azure-iot-device/azure/iot/device/provisioning/provisioning_device_client.py
+++ b/azure-iot-device/azure/iot/device/provisioning/provisioning_device_client.py
@@ -46,6 +46,9 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
         Before returning, the client will also disconnect from the provisioning service.
         If a registration attempt is made while a previous registration is in progress it may
         throw an error.
+
+        :returns: RegistrationResult indicating the result of the registration.
+        :rtype: :class:`azure.iot.device.RegistrationResult`
         """
         logger.info("Registering with Provisioning Service...")
 
@@ -58,6 +61,10 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
 
     def cancel(self):
         """
+        Cancel a registration that is in progress.
+
+        Before returning the client will also disconnect from the provisioning service.
+
         This is a synchronous call, meaning that this function will not return until the cancellation
         process has completed successfully or the attempt has resulted in a failure. Before returning
         the client will also disconnect from the provisioning service.

--- a/azure-iot-device/tests/provisioning/test_sync_provisioning_device_client.py
+++ b/azure-iot-device/tests/provisioning/test_sync_provisioning_device_client.py
@@ -58,34 +58,16 @@ def mock_transport(mocker):
 class TestClientCreate(object):
     xfail_notimplemented = pytest.mark.xfail(raises=NotImplementedError, reason="Unimplemented")
 
-    @pytest.mark.it("Is created from a symmetric key and protocol")
-    @pytest.mark.parametrize(
-        "protocol",
-        [
-            pytest.param("mqtt", id="mqtt"),
-            pytest.param(None, id="optional protocol"),
-            pytest.param("amqp", id="amqp", marks=xfail_notimplemented),
-            pytest.param("http", id="http", marks=xfail_notimplemented),
-        ],
-    )
-    def test_create_from_symmetric_key(self, mocker, protocol):
+    @pytest.mark.it("Is created from a symmetric key")
+    def test_create_from_symmetric_key(self, mocker):
         client = ProvisioningDeviceClient.create_from_symmetric_key(
             fake_provisioning_host, fake_symmetric_key, fake_registration_id, fake_id_scope
         )
         assert isinstance(client, ProvisioningDeviceClient)
         assert client._provisioning_pipeline is not None
 
-    @pytest.mark.it("Is created from a x509 certificate key and protocol")
-    @pytest.mark.parametrize(
-        "protocol",
-        [
-            pytest.param("mqtt", id="mqtt"),
-            pytest.param(None, id="optional protocol"),
-            pytest.param("amqp", id="amqp", marks=xfail_notimplemented),
-            pytest.param("http", id="http", marks=xfail_notimplemented),
-        ],
-    )
-    def test_create_from_x509_cert(self, mocker, protocol):
+    @pytest.mark.it("Is created from a x509 certificate key")
+    def test_create_from_x509_cert(self, mocker):
         client = ProvisioningDeviceClient.create_from_x509_certificate(
             fake_provisioning_host, fake_registration_id, fake_id_scope, fake_x509()
         )


### PR DESCRIPTION
* Added missing elements of docstrings needed for correct API docs to IoTHub and DPS clients
* Correct exception docs in DPS will be added when exception surfacing is added.
* Removed `protocol_choice` parameter from DPS clients