### PR TITLE
Cancel timeout stage timer when op is complete

### DIFF
--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
@@ -758,7 +758,9 @@ class TimeoutStage(PipelineStage):
     @pipeline_thread.runs_on_pipeline_thread
     def _on_intercepted_return(self, op, error):
         # When an op comes back, delete the timer and pass it right up.
-        op.timeout_timer = None
+        if op.timeout_timer:
+            op.timeout_timer.cancel()
+            op.timeout_timer = None
         logger.debug("{}({}): Op completed".format(self.name, op.name))
         self.send_completed_op_up(op, error)
 

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
@@ -802,6 +802,7 @@ class TestTimeoutStageRunOp(StageTestBase):
     @pytest.mark.it("Clears the timer when the op completes successfully")
     def test_clears_timer_on_success(self, stage, mock_timer, yes_timeout_op, next_stage_succeeds):
         stage.run_op(yes_timeout_op)
+        assert mock_timer.return_value.cancel.call_count == 1
         assert getattr(yes_timeout_op, "timeout_timer", None) is None
 
     @pytest.mark.it("Clears the timer when the op fails with an arbitrary exception")
@@ -809,6 +810,7 @@ class TestTimeoutStageRunOp(StageTestBase):
         self, stage, mock_timer, yes_timeout_op, next_stage_raises_arbitrary_exception
     ):
         stage.run_op(yes_timeout_op)
+        assert mock_timer.return_value.cancel.call_count == 1
         assert getattr(yes_timeout_op, "timeout_timer", None) is None
 
     @pytest.mark.it("Does not clear the timer when the op fails with an arbitrary base exception")
@@ -822,6 +824,7 @@ class TestTimeoutStageRunOp(StageTestBase):
     ):
         with pytest.raises(arbitrary_base_exception.__class__):
             stage.run_op(yes_timeout_op)
+        assert mock_timer.return_value.cancel.call_count == 0
         assert yes_timeout_op.timeout_timer == mock_timer.return_value
 
     @pytest.mark.it("Clears the timer when the op times out")


### PR DESCRIPTION
I hit this in E2E tests where old timers would hang around because they weren't cancelled.  Nothing bad happened, but we did leak objects when this happened and Horton flagged that as an error.