### PR TITLE
refactor(azure-iot-device): ca_cert parameter renamed to server_verification_cert

### DIFF
--- a/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
@@ -46,13 +46,15 @@ class AbstractIoTHubClient(object):
         self._http_pipeline = http_pipeline
 
     @classmethod
-    def create_from_connection_string(cls, connection_string, ca_cert=None, **kwargs):
+    def create_from_connection_string(
+        cls, connection_string, server_verification_cert=None, **kwargs
+    ):
         """
         Instantiate the client from a IoTHub device or module connection string.
 
         :param str connection_string: The connection string for the IoTHub you wish to connect to.
-        :param str ca_cert: The trusted certificate chain. Only necessary when using a
-            connection string with a GatewayHostName parameter.
+        :param str server_verification_cert: The trusted certificate chain. Only necessary when
+            using a connection string with a GatewayHostName parameter.
 
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT over websockets.
         :param str product_info: Configuration Option. Default is empty string. The string contains arbitrary product info which is appended to the user agent string.
@@ -68,7 +70,7 @@ class AbstractIoTHubClient(object):
         if cls.__name__ == "IoTHubDeviceClient":
             pipeline_configuration.blob_upload = True
         authentication_provider = auth.SymmetricKeyAuthenticationProvider.parse(connection_string)
-        authentication_provider.ca_cert = ca_cert  # TODO: make this part of the instantiation
+        authentication_provider.ca_cert = server_verification_cert
         http_pipeline = pipeline.HTTPPipeline(authentication_provider, pipeline_configuration)
         iothub_pipeline = pipeline.IoTHubPipeline(authentication_provider, pipeline_configuration)
         return cls(iothub_pipeline, http_pipeline)

--- a/azure-iot-device/tests/iothub/aio/test_async_clients.py
+++ b/azure-iot-device/tests/iothub/aio/test_async_clients.py
@@ -164,16 +164,18 @@ class ConfigurationSharedClientCreateFromConnectionStringTests(object):
 
 class SharedClientCreateFromConnectionStringTests(object):
     @pytest.mark.it(
-        "Uses the connection string and CA certificate combination to create a SymmetricKeyAuthenticationProvider"
+        "Uses the connection string and server verification certificate combination to create a SymmetricKeyAuthenticationProvider"
     )
     @pytest.mark.parametrize(
-        "ca_cert",
+        "server_verification_cert",
         [
-            pytest.param(None, id="No CA certificate"),
-            pytest.param("some-certificate", id="With CA certificate"),
+            pytest.param(None, id="No Server Verification Certificate"),
+            pytest.param("some-certificate", id="With Server Verification Certificate"),
         ],
     )
-    async def test_auth_provider_creation(self, mocker, client_class, connection_string, ca_cert):
+    async def test_auth_provider_creation(
+        self, mocker, client_class, connection_string, server_verification_cert
+    ):
         mock_auth_parse = mocker.patch(
             "azure.iot.device.iothub.auth.SymmetricKeyAuthenticationProvider"
         ).parse
@@ -181,24 +183,29 @@ class SharedClientCreateFromConnectionStringTests(object):
 
         args = (connection_string,)
         kwargs = {}
-        if ca_cert:
-            kwargs["ca_cert"] = ca_cert
+        if server_verification_cert:
+            kwargs["server_verification_cert"] = server_verification_cert
         client_class.create_from_connection_string(*args, **kwargs)
 
         assert mock_auth_parse.call_count == 1
         assert mock_auth_parse.call_args == mocker.call(connection_string)
-        assert mock_auth_parse.return_value.ca_cert is ca_cert
+        assert mock_auth_parse.return_value.ca_cert is server_verification_cert
 
     @pytest.mark.it("Uses the SymmetricKeyAuthenticationProvider to create an IoTHubPipeline")
     @pytest.mark.parametrize(
-        "ca_cert",
+        "server_verification_cert",
         [
-            pytest.param(None, id="No CA certificate"),
-            pytest.param("some-certificate", id="With CA certificate"),
+            pytest.param(None, id="No Server Verification Certificate"),
+            pytest.param("some-certificate", id="With Server Verification Certificate"),
         ],
     )
     async def test_pipeline_creation(
-        self, mocker, client_class, connection_string, ca_cert, mock_iothub_pipeline_init
+        self,
+        mocker,
+        client_class,
+        connection_string,
+        server_verification_cert,
+        mock_iothub_pipeline_init,
     ):
         mock_auth = mocker.patch(
             "azure.iot.device.iothub.auth.SymmetricKeyAuthenticationProvider"
@@ -210,8 +217,8 @@ class SharedClientCreateFromConnectionStringTests(object):
 
         args = (connection_string,)
         kwargs = {}
-        if ca_cert:
-            kwargs["ca_cert"] = ca_cert
+        if server_verification_cert:
+            kwargs["server_verification_cert"] = server_verification_cert
         client_class.create_from_connection_string(*args, **kwargs)
 
         assert mock_iothub_pipeline_init.call_count == 1
@@ -221,13 +228,15 @@ class SharedClientCreateFromConnectionStringTests(object):
 
     @pytest.mark.it("Uses the IoTHubPipeline to instantiate the client")
     @pytest.mark.parametrize(
-        "ca_cert",
+        "server_verification_cert",
         [
-            pytest.param(None, id="No CA certificate"),
-            pytest.param("some-certificate", id="With CA certificate"),
+            pytest.param(None, id="No Server Verification Certificate"),
+            pytest.param("some-certificate", id="With Server Verification Certificate"),
         ],
     )
-    async def test_client_instantiation(self, mocker, client_class, connection_string, ca_cert):
+    async def test_client_instantiation(
+        self, mocker, client_class, connection_string, server_verification_cert
+    ):
         mock_pipeline = mocker.patch("azure.iot.device.iothub.pipeline.IoTHubPipeline").return_value
         mock_pipeline_http = mocker.patch(
             "azure.iot.device.iothub.pipeline.HTTPPipeline"
@@ -235,8 +244,8 @@ class SharedClientCreateFromConnectionStringTests(object):
         spy_init = mocker.spy(client_class, "__init__")
         args = (connection_string,)
         kwargs = {}
-        if ca_cert:
-            kwargs["ca_cert"] = ca_cert
+        if server_verification_cert:
+            kwargs["server_verification_cert"] = server_verification_cert
         client_class.create_from_connection_string(*args, **kwargs)
 
         assert spy_init.call_count == 1
@@ -244,17 +253,17 @@ class SharedClientCreateFromConnectionStringTests(object):
 
     @pytest.mark.it("Returns the instantiated client")
     @pytest.mark.parametrize(
-        "ca_cert",
+        "server_verification_cert",
         [
-            pytest.param(None, id="No CA certificate"),
-            pytest.param("some-certificate", id="With CA certificate"),
+            pytest.param(None, id="No Server Verification Certificate"),
+            pytest.param("some-certificate", id="With Server Verification Certificate"),
         ],
     )
-    async def test_returns_client(self, client_class, connection_string, ca_cert):
+    async def test_returns_client(self, client_class, connection_string, server_verification_cert):
         args = (connection_string,)
         kwargs = {}
-        if ca_cert:
-            kwargs["ca_cert"] = ca_cert
+        if server_verification_cert:
+            kwargs["server_verification_cert"] = server_verification_cert
         client = client_class.create_from_connection_string(*args, **kwargs)
 
         assert isinstance(client, client_class)

--- a/azure-iot-device/tests/iothub/test_sync_clients.py
+++ b/azure-iot-device/tests/iothub/test_sync_clients.py
@@ -153,40 +153,42 @@ class ConfigurationSharedClientCreateFromConnectionStringTests(object):
 
 class SharedClientCreateFromConnectionStringTests(object):
     @pytest.mark.it(
-        "Uses the connection string and CA certificate combination to create a SymmetricKeyAuthenticationProvider"
+        "Uses the connection string and server verification certificate combination to create a SymmetricKeyAuthenticationProvider"
     )
     @pytest.mark.parametrize(
-        "ca_cert",
+        "server_verification_cert",
         [
-            pytest.param(None, id=" No CA certificate"),
-            pytest.param("some-certificate", id=" With CA certificate"),
+            pytest.param(None, id=" No Server Verification Certificate"),
+            pytest.param("some-certificate", id=" With Server Verification Certificate"),
         ],
     )
-    def test_auth_provider_creation(self, mocker, client_class, connection_string, ca_cert):
+    def test_auth_provider_creation(
+        self, mocker, client_class, connection_string, server_verification_cert
+    ):
         mock_auth_parse = mocker.patch(
             "azure.iot.device.iothub.auth.SymmetricKeyAuthenticationProvider"
         ).parse
 
         args = (connection_string,)
         kwargs = {}
-        if ca_cert:
-            kwargs["ca_cert"] = ca_cert
+        if server_verification_cert:
+            kwargs["server_verification_cert"] = server_verification_cert
         client_class.create_from_connection_string(*args, **kwargs)
 
         assert mock_auth_parse.call_count == 1
         assert mock_auth_parse.call_args == mocker.call(connection_string)
-        assert mock_auth_parse.return_value.ca_cert is ca_cert
+        assert mock_auth_parse.return_value.ca_cert is server_verification_cert
 
     @pytest.mark.it("Uses the SymmetricKeyAuthenticationProvider to create an IoTHubPipeline")
     @pytest.mark.parametrize(
-        "ca_cert",
+        "server_verification_cert",
         [
-            pytest.param(None, id=" No CA certificate"),
-            pytest.param("some-certificate", id=" With CA certificate"),
+            pytest.param(None, id=" No Server Verification Certificate"),
+            pytest.param("some-certificate", id=" With Server Verification Certificate"),
         ],
     )
     def test_pipeline_creation(
-        self, mocker, client_class, connection_string, ca_cert, mock_pipeline_init
+        self, mocker, client_class, connection_string, server_verification_cert, mock_pipeline_init
     ):
         mock_auth = mocker.patch(
             "azure.iot.device.iothub.auth.SymmetricKeyAuthenticationProvider"
@@ -198,8 +200,8 @@ class SharedClientCreateFromConnectionStringTests(object):
 
         args = (connection_string,)
         kwargs = {}
-        if ca_cert:
-            kwargs["ca_cert"] = ca_cert
+        if server_verification_cert:
+            kwargs["server_verification_cert"] = server_verification_cert
         client_class.create_from_connection_string(*args, **kwargs)
 
         assert mock_pipeline_init.call_count == 1
@@ -207,13 +209,15 @@ class SharedClientCreateFromConnectionStringTests(object):
 
     @pytest.mark.it("Uses the IoTHubPipeline to instantiate the client")
     @pytest.mark.parametrize(
-        "ca_cert",
+        "server_verification_cert",
         [
-            pytest.param(None, id=" No CA certificate"),
-            pytest.param("some-certificate", id=" With CA certificate"),
+            pytest.param(None, id=" No Server Verification Certificate"),
+            pytest.param("some-certificate", id=" With Server Verification Certificate"),
         ],
     )
-    def test_client_instantiation(self, mocker, client_class, connection_string, ca_cert):
+    def test_client_instantiation(
+        self, mocker, client_class, connection_string, server_verification_cert
+    ):
         mock_pipeline = mocker.patch("azure.iot.device.iothub.pipeline.IoTHubPipeline").return_value
         mock_pipeline_http = mocker.patch(
             "azure.iot.device.iothub.pipeline.HTTPPipeline"
@@ -221,25 +225,25 @@ class SharedClientCreateFromConnectionStringTests(object):
         spy_init = mocker.spy(client_class, "__init__")
         args = (connection_string,)
         kwargs = {}
-        if ca_cert:
-            kwargs["ca_cert"] = ca_cert
+        if server_verification_cert:
+            kwargs["server_verification_cert"] = server_verification_cert
         client_class.create_from_connection_string(*args, **kwargs)
         assert spy_init.call_count == 1
         assert spy_init.call_args == mocker.call(mocker.ANY, mock_pipeline, mock_pipeline_http)
 
     @pytest.mark.it("Returns the instantiated client")
     @pytest.mark.parametrize(
-        "ca_cert",
+        "server_verification_cert",
         [
-            pytest.param(None, id=" No CA certificate"),
-            pytest.param("some-certificate", id=" With CA certificate"),
+            pytest.param(None, id=" No Server Verification Certificate"),
+            pytest.param("some-certificate", id=" With Server Verification Certificate"),
         ],
     )
-    def test_returns_client(self, client_class, connection_string, ca_cert):
+    def test_returns_client(self, client_class, connection_string, server_verification_cert):
         args = (connection_string,)
         kwargs = {}
-        if ca_cert:
-            kwargs["ca_cert"] = ca_cert
+        if server_verification_cert:
+            kwargs["server_verification_cert"] = server_verification_cert
         client = client_class.create_from_connection_string(*args, **kwargs)
 
         assert isinstance(client, client_class)


### PR DESCRIPTION
* This has only renamed ca_cert at API level - it still must be renamed throughout the stack