### PR TITLE
feature(azure-iot-device):Support proxy via mqtt

### DIFF
--- a/azure-iot-device/azure/iot/device/common/__init__.py
+++ b/azure-iot-device/azure/iot/device/common/__init__.py
@@ -5,6 +5,6 @@ This package provides shared modules for use with various Azure IoT device-side 
 INTERNAL USAGE ONLY
 """
 
-from .models import X509
+from .models import X509, ProxyOptions
 
-__all__ = ["X509"]
+__all__ = ["X509", "ProxyOptions"]

--- a/azure-iot-device/azure/iot/device/common/models/__init__.py
+++ b/azure-iot-device/azure/iot/device/common/models/__init__.py
@@ -4,3 +4,4 @@ This package provides object models for use within the Azure Provisioning Device
 """
 
 from .x509 import X509
+from .proxy_options import ProxyOptions

--- a/azure-iot-device/azure/iot/device/common/models/proxy_options.py
+++ b/azure-iot-device/azure/iot/device/common/models/proxy_options.py
@@ -1,0 +1,53 @@
+# --------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""
+This module represents proxy options to enable sending traffic through proxy servers.
+"""
+
+
+class ProxyOptions(object):
+    """
+    A class containing various options to send traffic through proxy servers by enabling
+    proxying of MQTT connection.
+    """
+
+    def __init__(
+        self, proxy_type, proxy_addr, proxy_port, proxy_username=None, proxy_password=None
+    ):
+        """
+        Initializer for proxy options.
+        :param proxy_type: The type of the proxy server. This can be one of three possible choices:socks.HTTP, socks.SOCKS4, or socks.SOCKS5
+        :param proxy_addr: IP address or DNS name of proxy server
+        :param proxy_port: The port of the proxy server. Defaults to 1080 for socks and 8080 for http.
+        :param proxy_username: (optional) username for SOCKS5 proxy, or userid for SOCKS4 proxy.This parameter is ignored if an HTTP server is being used.
+         If it is not provided, authentication will not be used (servers may accept unauthenticated requests).
+        :param proxy_password: (optional) This parameter is valid only for SOCKS5 servers and specifies the respective password for the username provided.
+        """
+        self._proxy_type = proxy_type
+        self._proxy_addr = proxy_addr
+        self._proxy_port = proxy_port
+        self._proxy_username = proxy_username
+        self._proxy_password = proxy_password
+
+    @property
+    def proxy_type(self):
+        return self._proxy_type
+
+    @property
+    def proxy_address(self):
+        return self._proxy_addr
+
+    @property
+    def proxy_port(self):
+        return self._proxy_port
+
+    @property
+    def proxy_username(self):
+        return self._proxy_username
+
+    @property
+    def proxy_password(self):
+        return self._proxy_password

--- a/azure-iot-device/azure/iot/device/common/mqtt_transport.py
+++ b/azure-iot-device/azure/iot/device/common/mqtt_transport.py
@@ -13,6 +13,7 @@ import traceback
 import weakref
 import socket
 from . import transport_exceptions as exceptions
+import socks
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +100,7 @@ class MQTTTransport(object):
         x509_cert=None,
         websockets=False,
         cipher=None,
+        proxy_options=None,
     ):
         """
         Constructor to instantiate an MQTT protocol wrapper.
@@ -109,6 +111,7 @@ class MQTTTransport(object):
         :param x509_cert: Certificate which can be used to authenticate connection to a server in lieu of a password (optional).
         :param bool websockets: Indicates whether or not to enable a websockets connection in the Transport.
         :param str cipher: Cipher string in OpenSSL cipher list format
+        :param proxy_options: Options for sending traffic through proxy servers.
         """
         self._client_id = client_id
         self._hostname = hostname
@@ -118,6 +121,7 @@ class MQTTTransport(object):
         self._x509_cert = x509_cert
         self._websockets = websockets
         self._cipher = cipher
+        self._proxy_options = proxy_options
 
         self.on_mqtt_connected_handler = None
         self.on_mqtt_disconnected_handler = None
@@ -148,6 +152,15 @@ class MQTTTransport(object):
             logger.info("Creating client for connecting using MQTT over TCP")
             mqtt_client = mqtt.Client(
                 client_id=self._client_id, clean_session=False, protocol=mqtt.MQTTv311
+            )
+
+        if self._proxy_options:
+            mqtt_client.proxy_set(
+                proxy_type=self._proxy_options.proxy_type,
+                proxy_addr=self._proxy_options.proxy_address,
+                proxy_port=self._proxy_options.proxy_port,
+                proxy_username=self._proxy_options.proxy_username,
+                proxy_password=self._proxy_options.proxy_password,
             )
 
         mqtt_client.enable_logger(logging.getLogger("paho"))
@@ -328,6 +341,9 @@ class MQTTTransport(object):
 
         The password is not required if the transport was instantiated with an x509 certificate.
 
+        If MQTT connection has been proxied, connection will take a bit longer to allow negotiation
+        with the proxy server. Any errors in the proxy connection process will trigger exceptions
+
         :param str password: The password for connecting with the MQTT broker (Optional).
 
         :raises: ConnectionFailedError if connection could not be established.
@@ -359,10 +375,22 @@ class MQTTTransport(object):
                 and "CERTIFICATE_VERIFY_FAILED" in e.strerror
             ):
                 raise exceptions.TlsExchangeAuthError(cause=e)
+            elif isinstance(e, socks.ProxyError):
+                if isinstance(e, socks.SOCKS5AuthError):
+                    # TODO This is the only I felt like specializing
+                    raise exceptions.UnauthorizedError(cause=e)
+                else:
+                    raise exceptions.ProtocolProxyError(cause=e)
             else:
                 # If the socket can't open (e.g. using iptables REJECT), we get a
                 # socket.error.  Convert this into ConnectionFailedError so we can retry
                 raise exceptions.ConnectionFailedError(cause=e)
+
+        except socks.ProxyError as pe:
+            if isinstance(pe, socks.SOCKS5AuthError):
+                raise exceptions.UnauthorizedError(cause=pe)
+            else:
+                raise exceptions.ProtocolProxyError(cause=pe)
         except Exception as e:
             raise exceptions.ProtocolClientError(
                 message="Unexpected Paho failure during connect", cause=e

--- a/azure-iot-device/azure/iot/device/common/pipeline/config.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/config.py
@@ -18,7 +18,7 @@ class BasePipelineConfig(object):
     config files.
     """
 
-    def __init__(self, websockets=False, cipher=""):
+    def __init__(self, websockets=False, cipher="", proxy_options=None):
         """Initializer for BasePipelineConfig
 
         :param bool websockets: Enabling/disabling websockets in MQTT. This feature is relevant
@@ -29,6 +29,7 @@ class BasePipelineConfig(object):
         """
         self.websockets = websockets
         self.cipher = self._sanitize_cipher(cipher)
+        self.proxy_options = proxy_options
 
     @staticmethod
     def _sanitize_cipher(cipher):

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
@@ -74,6 +74,7 @@ class MQTTTransportStage(PipelineStage):
                 x509_cert=op.client_cert,
                 websockets=self.pipeline_root.pipeline_configuration.websockets,
                 cipher=self.pipeline_root.pipeline_configuration.cipher,
+                proxy_options=self.pipeline_root.pipeline_configuration.proxy_options,
             )
             self.transport.on_mqtt_connected_handler = CallableWeakMethod(
                 self, "_on_mqtt_connected"

--- a/azure-iot-device/azure/iot/device/common/transport_exceptions.py
+++ b/azure-iot-device/azure/iot/device/common/transport_exceptions.py
@@ -47,3 +47,12 @@ class TlsExchangeAuthError(ChainableException):
     """
 
     pass
+
+
+class ProtocolProxyError(ChainableException):
+    """
+    All proxy-related errors.
+    TODO : Not sure what to name it here. There is a class called Proxy Error already in Pysocks
+    """
+
+    pass

--- a/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
@@ -30,7 +30,13 @@ logger = logging.getLogger(__name__)
 def _validate_kwargs(**kwargs):
     """Helper function to validate user provided kwargs.
     Raises TypeError if an invalid option has been provided"""
-    valid_kwargs = ["product_info", "websockets", "cipher", "server_verification_cert"]
+    valid_kwargs = [
+        "product_info",
+        "websockets",
+        "cipher",
+        "server_verification_cert",
+        "proxy_options",
+    ]
 
     for kwarg in kwargs:
         if kwarg not in valid_kwargs:
@@ -46,6 +52,8 @@ def _get_pipeline_config_kwargs(**kwargs):
         new_kwargs["websockets"] = kwargs["websockets"]
     if "cipher" in kwargs:
         new_kwargs["cipher"] = kwargs["cipher"]
+    if "proxy_options" in kwargs:
+        new_kwargs["proxy_options"] = kwargs["proxy_options"]
     return new_kwargs
 
 
@@ -81,6 +89,8 @@ class AbstractIoTHubClient(object):
         :type cipher: str or list(str)
         :param str product_info: Configuration Option. Default is empty string. The string contains
             arbitrary product info which is appended to the user agent string.
+        :param proxy_options: Options for sending traffic through proxy servers.
+        :type ProxyOptions: :class:`azure.iot.device.common.proxy_options`
 
         :raises: ValueError if given an invalid connection_string.
         :raises: TypeError if given an unrecognized parameter.
@@ -175,6 +185,8 @@ class AbstractIoTHubDeviceClient(AbstractIoTHubClient):
         :type cipher: str or list(str)
         :param str product_info: Configuration Option. Default is empty string. The string contains
             arbitrary product info which is appended to the user agent string.
+        :param proxy_options: Options for sending traffic through proxy servers.
+        :type ProxyOptions: :class:`azure.iot.device.common.proxy_options`
 
         :raises: TypeError if given an unrecognized parameter.
 

--- a/azure-iot-device/azure/iot/device/iothub/aio/async_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/aio/async_clients.py
@@ -40,6 +40,10 @@ async def handle_result(callback):
         raise exceptions.ClientError(
             message="Error in the IoTHub client due to TLS exchanges.", cause=e
         )
+    except pipeline_exceptions.ProtocolProxyError as e:
+        raise exceptions.ClientError(
+            message="Error in the IoTHub client raised due to proxy connections.", cause=e
+        )
     except Exception as e:
         raise exceptions.ClientError(message="Unexpected failure", cause=e)
 

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/exceptions.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/exceptions.py
@@ -18,4 +18,5 @@ from azure.iot.device.common.transport_exceptions import (
     UnauthorizedError,
     ProtocolClientError,
     TlsExchangeAuthError,
+    ProtocolProxyError,
 )

--- a/azure-iot-device/azure/iot/device/iothub/sync_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/sync_clients.py
@@ -42,6 +42,10 @@ def handle_result(callback):
         raise exceptions.ClientError(
             message="Error in the IoTHub client due to TLS exchanges.", cause=e
         )
+    except pipeline_exceptions.ProtocolProxyError as e:
+        raise exceptions.ClientError(
+            message="Error in the IoTHub client raised due to proxy connections.", cause=e
+        )
     except Exception as e:
         raise exceptions.ClientError(message="Unexpected failure", cause=e)
 

--- a/azure-iot-device/samples/async-hub-scenarios/send_message_via_proxy.py
+++ b/azure-iot-device/samples/async-hub-scenarios/send_message_via_proxy.py
@@ -1,0 +1,55 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import os
+import asyncio
+import uuid
+from azure.iot.device.aio import IoTHubDeviceClient
+from azure.iot.device import Message, ProxyOptions
+import socks
+
+messages_to_send = 10
+
+
+async def main():
+    # The connection string for a device should never be stored in code. For the sake of simplicity we're using an environment variable here.
+    conn_str = os.getenv("IOTHUB_DEVICE_CONNECTION_STRING")
+
+    proxy_opts = ProxyOptions(
+        proxy_type=socks.HTTP, proxy_addr="127.0.0.1", proxy_port=8888  # localhost
+    )
+
+    # The client object is used to interact with your Azure IoT hub.
+    device_client = IoTHubDeviceClient.create_from_connection_string(
+        conn_str, websockets=True, proxy_options=proxy_opts
+    )
+
+    # Connect the client.
+    await device_client.connect()
+
+    async def send_test_message(i):
+        print("sending message #" + str(i))
+        msg = Message("test wind speed " + str(i))
+        msg.message_id = uuid.uuid4()
+        msg.correlation_id = "correlation-1234"
+        msg.custom_properties["tornado-warning"] = "yes"
+        await device_client.send_message(msg)
+        print("done sending message #" + str(i))
+
+    # send `messages_to_send` messages in parallel
+    await asyncio.gather(*[send_test_message(i) for i in range(1, messages_to_send + 1)])
+
+    # finally, disconnect
+    await device_client.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+    # If using Python 3.6 or below, use the following code instead of asyncio.run(main()):
+    # loop = asyncio.get_event_loop()
+    # loop.run_until_complete(main())
+    # loop.close()

--- a/azure-iot-device/samples/sync-samples/send_message_via_proxy.py
+++ b/azure-iot-device/samples/sync-samples/send_message_via_proxy.py
@@ -1,0 +1,75 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import os
+import time
+import uuid
+from azure.iot.device import IoTHubDeviceClient, Message, ProxyOptions
+import socks
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+# The connection string for a device should never be stored in code. For the sake of simplicity we're using an environment variable here.
+conn_str = os.getenv("IOTHUB_DEVICE_CONNECTION_STRING")
+
+# Create proxy options when trying to send via proxy
+proxy_opts = ProxyOptions(
+    proxy_type=socks.HTTP, proxy_addr="127.0.0.1", proxy_port=8888  # localhost
+)
+# The client object is used to interact with your Azure IoT hub.
+device_client = IoTHubDeviceClient.create_from_connection_string(
+    conn_str, websockets=True, proxy_options=proxy_opts
+)
+
+# Connect the client.
+device_client.connect()
+
+# send 2 messages with 2 system properties & 1 custom property with a 1 second pause between each message
+for i in range(1, 3):
+    print("sending message #" + str(i))
+    msg = Message("test wind speed " + str(i))
+    msg.message_id = uuid.uuid4()
+    msg.correlation_id = "correlation-1234"
+    msg.custom_properties["tornado-warning"] = "yes"
+    device_client.send_message(msg)
+    time.sleep(1)
+
+# send 2 messages with only custom property with a 1 second pause between each message
+for i in range(3, 5):
+    print("sending message #" + str(i))
+    msg = Message("test wind speed " + str(i))
+    msg.custom_properties["tornado-warning"] = "yes"
+    device_client.send_message(msg)
+    time.sleep(1)
+
+# send 2 messages with only system properties with a 1 second pause between each message
+for i in range(5, 7):
+    print("sending message #" + str(i))
+    msg = Message("test wind speed " + str(i))
+    msg.message_id = uuid.uuid4()
+    msg.correlation_id = "correlation-1234"
+    device_client.send_message(msg)
+    time.sleep(1)
+
+# send 2 messages with 1 system property and 1 custom property with a 1 second pause between each message
+for i in range(7, 9):
+    print("sending message #" + str(i))
+    msg = Message("test wind speed " + str(i))
+    msg.message_id = uuid.uuid4()
+    msg.custom_properties["tornado-warning"] = "yes"
+    device_client.send_message(msg)
+    time.sleep(1)
+
+# send only string messages
+for i in range(9, 11):
+    print("sending message #" + str(i))
+    device_client.send_message("test payload message " + str(i))
+    time.sleep(1)
+
+
+# finally, disconnect
+device_client.disconnect()

--- a/azure-iot-device/setup.py
+++ b/azure-iot-device/setup.py
@@ -72,6 +72,8 @@ setup(
         "requests-unixsocket>=0.1.5,<1.0.0",
         "janus>=0.4.0,<1.0.0;python_version>='3.5'",
         "futures;python_version == '2.7'",
+        "PySocks",
+        "win-inet-pton;python_version == '2.7'",
     ],
     extras_require={":python_version<'3.0'": ["azure-iot-nspkg>=1.0.1"]},
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3*, <4",

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_mqtt.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_mqtt.py
@@ -136,10 +136,21 @@ class TestMQTTTransportStageRunOpCalledWithSetMQTTConnectionArgsOperation(
             pytest.param("", id="Pipeline NOT configured for custom cipher(s)"),
         ],
     )
-    def test_creates_transport(self, mocker, stage, op, mock_transport, websockets, cipher):
+    @pytest.mark.parametrize(
+        "proxy_options",
+        [
+            pytest.param("FAKE-PROXY", id="Proxy present"),
+            pytest.param(None, id="Proxy None"),
+            pytest.param("", id="Proxy Absent"),
+        ],
+    )
+    def test_creates_transport(
+        self, mocker, stage, op, mock_transport, websockets, cipher, proxy_options
+    ):
         # Configure websockets & cipher
         stage.pipeline_root.pipeline_configuration.websockets = websockets
         stage.pipeline_root.pipeline_configuration.cipher = cipher
+        stage.pipeline_root.pipeline_configuration.proxy_options = proxy_options
 
         assert stage.transport is None
 
@@ -154,6 +165,7 @@ class TestMQTTTransportStageRunOpCalledWithSetMQTTConnectionArgsOperation(
             x509_cert=op.client_cert,
             websockets=websockets,
             cipher=cipher,
+            proxy_options=proxy_options,
         )
         assert stage.transport is mock_transport.return_value
 

--- a/azure-iot-device/tests/iothub/aio/test_async_clients.py
+++ b/azure-iot-device/tests/iothub/aio/test_async_clients.py
@@ -349,6 +349,11 @@ class SharedClientConnectTests(object):
                 client_exceptions.ClientError,
                 id="TlsExchangeAuthError->ClientError",
             ),
+            pytest.param(
+                pipeline_exceptions.ProtocolProxyError,
+                client_exceptions.ClientError,
+                id="ProtocolProxyError->ClientError",
+            ),
             pytest.param(Exception, client_exceptions.ClientError, id="Exception->ClientError"),
         ],
     )

--- a/azure-iot-device/tests/iothub/test_sync_clients.py
+++ b/azure-iot-device/tests/iothub/test_sync_clients.py
@@ -349,6 +349,11 @@ class SharedClientConnectTests(WaitsForEventCompletion):
                 client_exceptions.ClientError,
                 id="TlsExchangeAuthError->ClientError",
             ),
+            pytest.param(
+                pipeline_exceptions.ProtocolProxyError,
+                client_exceptions.ClientError,
+                id="ProtocolProxyError->ClientError",
+            ),
             pytest.param(Exception, client_exceptions.ClientError, id="Exception->ClientError"),
         ],
     )

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,5 +7,3 @@ pytest-timeout
 mock #remove this as soon as no references to it remain in the code
 flake8
 azure-iothub-provisioningserviceclient >= 1.2.0  # Only needed for end to end tests for DPS
-PySocks
-win-inet-pton; python_version == '2.7'  # Only needed for python 2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,3 +7,5 @@ pytest-timeout
 mock #remove this as soon as no references to it remain in the code
 flake8
 azure-iothub-provisioningserviceclient >= 1.2.0  # Only needed for end to end tests for DPS
+PySocks
+win-inet-pton; python_version == '2.7'  # Only needed for python 2


### PR DESCRIPTION
Proxy is only working for MQTT via web-sockets with HTTP proxy servers. Hence the samples have been defined accordingly to show case these specific scenarios. We are only going to support proxy via the above option.

However the implementation is general and we are not going to disallow usage of SOCK proxy servers with normal MQTT as well as MQTT web-sockets , but this is left to the user as an exercise.
