### PR TITLE
fix(azure-iot-device): Revert changes for default content type and default content encoding

### DIFF
--- a/azure-iot-device/azure/iot/device/iothub/models/message.py
+++ b/azure-iot-device/azure/iot/device/iothub/models/message.py
@@ -30,20 +30,15 @@ class Message(object):
     """
 
     def __init__(
-        self,
-        data,
-        message_id=None,
-        content_encoding="utf-8",
-        content_type="application/json",
-        output_name=None,
+        self, data, message_id=None, content_encoding=None, content_type=None, output_name=None
     ):
         """
         Initializer for Message
 
         :param data: The  data that constitutes the payload
         :param str message_id: A user-settable identifier for the message used for request-reply patterns. Format: A case-sensitive string (up to 128 characters long) of ASCII 7-bit alphanumeric characters + {'-', ':', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '$', '''}
-        :param str content_encoding: Content encoding of the message data. Default is 'utf-8'. Other values can be utf-16' or 'utf-32'
-        :param str content_type: Content type property used to routes with the message body. Default value is 'application/json'
+        :param str content_encoding: Content encoding of the message data. Other values can be utf-16' or 'utf-32'
+        :param str content_type: Content type property used to routes with the message body.
         :param str output_name: Name of the output that the is being sent to.
         """
         self.data = data

--- a/azure-iot-device/tests/iothub/aio/test_async_clients.py
+++ b/azure-iot-device/tests/iothub/aio/test_async_clients.py
@@ -534,7 +534,7 @@ class SharedClientSendD2CMessageTests(object):
 
     @pytest.mark.it("Does not raises error when message data size is equal to 256 KB")
     async def test_raises_error_when_message_data_equal_to_256(self, client, iothub_pipeline):
-        data_input = "a" * 261976
+        data_input = "a" * 262095
         message = Message(data_input)
         # This check was put as message class may undergo the default content type encoding change
         # and the above calculation will change.
@@ -2054,7 +2054,7 @@ class TestIoTHubModuleClientSendToOutput(IoTHubModuleClientTestsConfig):
         self, client, iothub_pipeline
     ):
         output_name = "some_output"
-        data_input = "a" * 261976
+        data_input = "a" * 262095
         message = Message(data_input)
         # This check was put as message class may undergo the default content type encoding change
         # and the above calculation will change.

--- a/azure-iot-device/tests/iothub/pipeline/test_pipeline_stages_iothub_mqtt.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_pipeline_stages_iothub_mqtt.py
@@ -627,13 +627,11 @@ publish_ops = [
         "stage_type": "device",
         "op_class": pipeline_ops_iothub.SendD2CMessageOperation,
         "op_init_kwargs": {"message": Message(fake_message_body), "callback": None},
-        "topic": "devices/{}/messages/events/{}&{}".format(
-            fake_device_id, default_content_type_encoded, default_content_encoding_encoded
-        ),
+        "topic": "devices/{}/messages/events/".format(fake_device_id),
         "publish_payload": fake_message_body,
     },
     {
-        "name": "send telemetry overriding the content type and content encoding",
+        "name": "send telemetry with content type and content encoding",
         "stage_type": "device",
         "op_class": pipeline_ops_iothub.SendD2CMessageOperation,
         "op_init_kwargs": {
@@ -657,9 +655,7 @@ publish_ops = [
             "message": Message(fake_message_body, content_type=fake_content_type),
             "callback": None,
         },
-        "topic": "devices/{}/messages/events/{}&{}".format(
-            fake_device_id, fake_content_type_encoded, default_content_encoding_encoded
-        ),
+        "topic": "devices/{}/messages/events/{}".format(fake_device_id, fake_content_type_encoded),
         "publish_payload": fake_message_body,
     },
     {
@@ -670,12 +666,7 @@ publish_ops = [
             "message": Message(fake_message_body, output_name=fake_output_name),
             "callback": None,
         },
-        "topic": "devices/{}/messages/events/{}&{}&{}".format(
-            fake_device_id,
-            fake_output_name_encoded,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
-        ),
+        "topic": "devices/{}/messages/events/{}".format(fake_device_id, fake_output_name_encoded),
         "publish_payload": fake_message_body,
     },
     {
@@ -683,11 +674,8 @@ publish_ops = [
         "stage_type": "device",
         "op_class": pipeline_ops_iothub.SendD2CMessageOperation,
         "op_init_kwargs": {"message": create_security_message(fake_message_body), "callback": None},
-        "topic": "devices/{}/messages/events/{}&{}&{}".format(
-            fake_device_id,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
-            security_message_interface_id_encoded,
+        "topic": "devices/{}/messages/events/{}".format(
+            fake_device_id, security_message_interface_id_encoded
         ),
         "publish_payload": fake_message_body,
     },
@@ -701,12 +689,8 @@ publish_ops = [
             ),
             "callback": None,
         },
-        "topic": "devices/{}/messages/events/{}&{}&{}&{}".format(
-            fake_device_id,
-            fake_output_name_encoded,
-            fake_message_id_encoded,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
+        "topic": "devices/{}/messages/events/{}&{}".format(
+            fake_device_id, fake_output_name_encoded, fake_message_id_encoded
         ),
         "publish_payload": fake_message_body,
     },
@@ -718,11 +702,8 @@ publish_ops = [
             "message": create_message_with_user_properties(fake_message_body, is_multiple=False),
             "callback": None,
         },
-        "topic": "devices/{}/messages/events/{}&{}&{}".format(
-            fake_device_id,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
-            fake_message_user_property_1_encoded,
+        "topic": "devices/{}/messages/events/{}".format(
+            fake_device_id, fake_message_user_property_1_encoded
         ),
         "publish_payload": fake_message_body,
     },
@@ -735,17 +716,13 @@ publish_ops = [
             "callback": None,
         },
         # For more than 1 user property the order could be different, creating 2 different topics
-        "topic1": "devices/{}/messages/events/{}&{}&{}&{}".format(
+        "topic1": "devices/{}/messages/events/{}&{}".format(
             fake_device_id,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
             fake_message_user_property_1_encoded,
             fake_message_user_property_2_encoded,
         ),
-        "topic2": "devices/{}/messages/events/{}&{}&{}&{}".format(
+        "topic2": "devices/{}/messages/events/{}&{}".format(
             fake_device_id,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
             fake_message_user_property_2_encoded,
             fake_message_user_property_1_encoded,
         ),
@@ -761,12 +738,8 @@ publish_ops = [
             ),
             "callback": None,
         },
-        "topic": "devices/{}/messages/events/{}&{}&{}&{}".format(
-            fake_device_id,
-            fake_message_id_encoded,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
-            fake_message_user_property_1_encoded,
+        "topic": "devices/{}/messages/events/{}&{}".format(
+            fake_device_id, fake_message_id_encoded, fake_message_user_property_1_encoded
         ),
         "publish_payload": fake_message_body,
     },
@@ -781,21 +754,17 @@ publish_ops = [
             "callback": None,
         },
         # For more than 1 user property the order could be different, creating 2 different topics
-        "topic1": "devices/{}/messages/events/{}&{}&{}&{}&{}&{}".format(
+        "topic1": "devices/{}/messages/events/{}&{}&{}&{}".format(
             fake_device_id,
             fake_output_name_encoded,
             fake_message_id_encoded,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
             fake_message_user_property_1_encoded,
             fake_message_user_property_2_encoded,
         ),
-        "topic2": "devices/{}/messages/events/{}&{}&{}&{}&{}&{}".format(
+        "topic2": "devices/{}/messages/events/{}&{}&{}&{}".format(
             fake_device_id,
             fake_output_name_encoded,
             fake_message_id_encoded,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
             fake_message_user_property_2_encoded,
             fake_message_user_property_1_encoded,
         ),
@@ -812,22 +781,18 @@ publish_ops = [
             "callback": None,
         },
         # For more than 1 user property the order could be different, creating 2 different topics
-        "topic1": "devices/{}/messages/events/{}&{}&{}&{}&{}&{}&{}".format(
+        "topic1": "devices/{}/messages/events/{}&{}&{}&{}&{}".format(
             fake_device_id,
             fake_output_name_encoded,
             fake_message_id_encoded,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
             security_message_interface_id_encoded,
             fake_message_user_property_1_encoded,
             fake_message_user_property_2_encoded,
         ),
-        "topic2": "devices/{}/messages/events/{}&{}&{}&{}&{}&{}&{}".format(
+        "topic2": "devices/{}/messages/events/{}&{}&{}&{}&{}".format(
             fake_device_id,
             fake_output_name_encoded,
             fake_message_id_encoded,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
             security_message_interface_id_encoded,
             fake_message_user_property_2_encoded,
             fake_message_user_property_1_encoded,
@@ -842,17 +807,13 @@ publish_ops = [
             "message": Message(fake_message_body, output_name=fake_output_name),
             "callback": None,
         },
-        "topic": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}".format(
-            fake_device_id,
-            fake_module_id,
-            fake_output_name,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
+        "topic": "devices/{}/modules/{}/messages/events/%24.on={}".format(
+            fake_device_id, fake_module_id, fake_output_name
         ),
         "publish_payload": fake_message_body,
     },
     {
-        "name": "send output overriding content type and content encoding",
+        "name": "send output with content type and content encoding",
         "stage_type": "module",
         "op_class": pipeline_ops_iothub.SendOutputEventOperation,
         "op_init_kwargs": {
@@ -883,13 +844,8 @@ publish_ops = [
             ),
             "callback": None,
         },
-        "topic": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}&{}".format(
-            fake_device_id,
-            fake_module_id,
-            fake_output_name,
-            fake_message_id_encoded,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
+        "topic": "devices/{}/modules/{}/messages/events/%24.on={}&{}".format(
+            fake_device_id, fake_module_id, fake_output_name, fake_message_id_encoded
         ),
         "publish_payload": fake_message_body,
     },
@@ -903,13 +859,8 @@ publish_ops = [
             ),
             "callback": None,
         },
-        "topic": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}&{}".format(
-            fake_device_id,
-            fake_module_id,
-            fake_output_name,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
-            fake_message_user_property_1_encoded,
+        "topic": "devices/{}/modules/{}/messages/events/%24.on={}&{}".format(
+            fake_device_id, fake_module_id, fake_output_name, fake_message_user_property_1_encoded
         ),
         "publish_payload": fake_message_body,
     },
@@ -923,21 +874,17 @@ publish_ops = [
             ),
             "callback": None,
         },
-        "topic1": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}&{}&{}".format(
+        "topic1": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}".format(
             fake_device_id,
             fake_module_id,
             fake_output_name,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
             fake_message_user_property_1_encoded,
             fake_message_user_property_2_encoded,
         ),
-        "topic2": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}&{}&{}".format(
+        "topic2": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}".format(
             fake_device_id,
             fake_module_id,
             fake_output_name,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
             fake_message_user_property_2_encoded,
             fake_message_user_property_1_encoded,
         ),
@@ -953,13 +900,11 @@ publish_ops = [
             ),
             "callback": None,
         },
-        "topic": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}&{}&{}".format(
+        "topic": "devices/{}/modules/{}/messages/events/%24.on={}&{}&{}".format(
             fake_device_id,
             fake_module_id,
             fake_output_name,
             fake_message_id_encoded,
-            default_content_type_encoded,
-            default_content_encoding_encoded,
             fake_message_user_property_1_encoded,
         ),
         "publish_payload": fake_message_body,

--- a/azure-iot-device/tests/iothub/test_sync_clients.py
+++ b/azure-iot-device/tests/iothub/test_sync_clients.py
@@ -529,7 +529,7 @@ class SharedClientSendD2CMessageTests(WaitsForEventCompletion):
 
     @pytest.mark.it("Does not raises error when message data size is equal to 256 KB")
     def test_raises_error_when_message_data_equal_to_256(self, client, iothub_pipeline):
-        data_input = "a" * 261976
+        data_input = "a" * 262095
         message = Message(data_input)
         # This check was put as message class may undergo the default content type encoding change
         # and the above calculation will change.
@@ -2322,7 +2322,7 @@ class TestIoTHubModuleClientSendToOutput(IoTHubModuleClientTestsConfig, WaitsFor
     @pytest.mark.it("Does not raises error when message data size is equal to 256 KB")
     def test_raises_error_when_message_to_output_data_equal_to_256(self, client, iothub_pipeline):
         output_name = "some_output"
-        data_input = "a" * 261976
+        data_input = "a" * 262095
         message = Message(data_input)
         # This check was put as message class may undergo the default content type encoding change
         # and the above calculation will change.


### PR DESCRIPTION
Reverting the changes that was done here.

https://github.com/Azure/azure-iot-sdk-python/pull/315