### PR TITLE
fix: Removed tests and samples from package distributions

### DIFF
--- a/azure-iot-device/setup.py
+++ b/azure-iot-device/setup.py
@@ -95,7 +95,9 @@ setup(
     packages=find_packages(
         exclude=[
             "tests",
+            "tests.*",
             "samples",
+            "samples.*",
             # Exclude packages that will be covered by PEP420 or nspkg
             "azure",
             "azure.iot",

--- a/azure-iot-hub/setup.py
+++ b/azure-iot-hub/setup.py
@@ -75,7 +75,9 @@ setup(
     packages=find_packages(
         exclude=[
             "tests",
+            "tests.*",
             "samples",
+            "samples.*",
             # Exclude packages that will be covered by PEP420 or nspkg
             "azure",
             "azure.iot",


### PR DESCRIPTION
* For both `azure-iot-device` and `azure-iot-hub`:
    * Prevented tests from accidentally being included in package distributions
    * Removed the ability for samples to also be accidentally included