### PR TITLE
fix(azure-iot-device): Correction to formatting of docstrings re: proxy_options

### DIFF
--- a/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
@@ -90,7 +90,7 @@ class AbstractIoTHubClient(object):
         :param str product_info: Configuration Option. Default is empty string. The string contains
             arbitrary product info which is appended to the user agent string.
         :param proxy_options: Options for sending traffic through proxy servers.
-        :type ProxyOptions: :class:`azure.iot.device.ProxyOptions`
+        :type proxy_options: :class:`azure.iot.device.ProxyOptions`
 
         :raises: ValueError if given an invalid connection_string.
         :raises: TypeError if given an unrecognized parameter.
@@ -186,7 +186,7 @@ class AbstractIoTHubDeviceClient(AbstractIoTHubClient):
         :param str product_info: Configuration Option. Default is empty string. The string contains
             arbitrary product info which is appended to the user agent string.
         :param proxy_options: Options for sending traffic through proxy servers.
-        :type ProxyOptions: :class:`azure.iot.device.ProxyOptions`
+        :type proxy_options: :class:`azure.iot.device.ProxyOptions`
 
         :raises: TypeError if given an unrecognized parameter.
 
@@ -232,7 +232,7 @@ class AbstractIoTHubDeviceClient(AbstractIoTHubClient):
         :param str product_info: Configuration Option. Default is empty string. The string contains
             arbitrary product info which is appended to the user agent string.
         :param proxy_options: Options for sending traffic through proxy servers.
-        :type ProxyOptions: :class:`azure.iot.device.ProxyOptions`
+        :type proxy_options: :class:`azure.iot.device.ProxyOptions`
 
         :raises: TypeError if given an unrecognized parameter.
 
@@ -288,7 +288,7 @@ class AbstractIoTHubModuleClient(AbstractIoTHubClient):
         :param str product_info: Configuration Option. Default is empty string. The string contains
             arbitrary product info which is appended to the user agent string.
         :param proxy_options: Options for sending traffic through proxy servers.
-        :type ProxyOptions: :class:`azure.iot.device.ProxyOptions`
+        :type proxy_options: :class:`azure.iot.device.ProxyOptions`
 
         :raises: OSError if the IoT Edge container is not configured correctly.
         :raises: ValueError if debug variables are invalid.
@@ -402,7 +402,7 @@ class AbstractIoTHubModuleClient(AbstractIoTHubClient):
         :param str product_info: Configuration Option. Default is empty string. The string contains
             arbitrary product info which is appended to the user agent string.
         :param proxy_options: Options for sending traffic through proxy servers.
-        :type ProxyOptions: :class:`azure.iot.device.ProxyOptions`
+        :type proxy_options: :class:`azure.iot.device.ProxyOptions`
 
         :raises: TypeError if given an unrecognized parameter.
 

--- a/azure-iot-device/azure/iot/device/provisioning/abstract_provisioning_device_client.py
+++ b/azure-iot-device/azure/iot/device/provisioning/abstract_provisioning_device_client.py
@@ -77,7 +77,7 @@ class AbstractProvisioningDeviceClient(object):
             "OpenSSL cipher list format" or as a list of cipher suite strings.
         :type cipher: str or list(str)
         :param proxy_options: Options for sending traffic through proxy servers.
-        :type ProxyOptions: :class:`azure.iot.device.ProxyOptions`
+        :type proxy_options: :class:`azure.iot.device.ProxyOptions`
 
         :raises: TypeError if given an unrecognized parameter.
 
@@ -125,7 +125,7 @@ class AbstractProvisioningDeviceClient(object):
             "OpenSSL cipher list format" or as a list of cipher suite strings.
         :type cipher: str or list(str)
         :param proxy_options: Options for sending traffic through proxy servers.
-        :type ProxyOptions: :class:`azure.iot.device.ProxyOptions`
+        :type proxy_options: :class:`azure.iot.device.ProxyOptions`
 
         :raises: TypeError if given an unrecognized parameter.
 


### PR DESCRIPTION
Type for `proxy_options` was formatted wrong.