### PR TITLE
fix(azure-iot-device): Spaces can not be part of topic.

### DIFF
--- a/azure-iot-device/azure/iot/device/iothub/pipeline/mqtt_topic_iothub.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/mqtt_topic_iothub.py
@@ -265,7 +265,7 @@ def encode_properties(message_to_send, topic):
         user_properties_encoded = urllib.parse.urlencode(message_to_send.custom_properties)
         topic += user_properties_encoded
 
-    return topic
+    return topic.replace("+", "%2B")
 
 
 def get_twin_response_topic_for_subscribe():


### PR DESCRIPTION
unfortunately urlencode does not encode spaces. And keeps them as `+`.
But `+` is not allowed in our topics.

An issue was raised regarding this.