### PR TITLE
fix(azure-iot-device): file and not data for server verification cert

### DIFF
--- a/azure-iot-device/azure/iot/device/common/http_transport.py
+++ b/azure-iot-device/azure/iot/device/common/http_transport.py
@@ -26,7 +26,7 @@ class HTTPTransport(object):
         Constructor to instantiate an HTTP protocol wrapper.
 
         :param str hostname: Hostname or IP address of the remote host.
-        :param str server_verification_cert: The path to the certificate which can be used to validate a server-side TLS connection (optional).
+        :param str server_verification_cert: The full path to the certificate which can be used to validate a server-side TLS connection (optional).
         :param str cipher: Cipher string in OpenSSL cipher list format (optional)
         :param x509_cert: Certificate which can be used to authenticate connection to a server in lieu of a password (optional).
         """

--- a/azure-iot-device/azure/iot/device/common/http_transport.py
+++ b/azure-iot-device/azure/iot/device/common/http_transport.py
@@ -26,7 +26,7 @@ class HTTPTransport(object):
         Constructor to instantiate an HTTP protocol wrapper.
 
         :param str hostname: Hostname or IP address of the remote host.
-        :param str server_verification_cert: Certificate which can be used to validate a server-side TLS connection (optional).
+        :param str server_verification_cert: The path to the certificate which can be used to validate a server-side TLS connection (optional).
         :param str cipher: Cipher string in OpenSSL cipher list format (optional)
         :param x509_cert: Certificate which can be used to authenticate connection to a server in lieu of a password (optional).
         """
@@ -44,7 +44,7 @@ class HTTPTransport(object):
         ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLSv1_2)
 
         if self._server_verification_cert:
-            ssl_context.load_verify_locations(cadata=self._server_verification_cert)
+            ssl_context.load_verify_locations(cafile=self._server_verification_cert)
         else:
             ssl_context.load_default_certs()
 

--- a/azure-iot-device/azure/iot/device/common/mqtt_transport.py
+++ b/azure-iot-device/azure/iot/device/common/mqtt_transport.py
@@ -107,7 +107,7 @@ class MQTTTransport(object):
         :param str client_id: The id of the client connecting to the broker.
         :param str hostname: Hostname or IP address of the remote broker.
         :param str username: Username for login to the remote broker.
-        :param str server_verification_cert: Certificate which can be used to validate a server-side TLS connection (optional).
+        :param str server_verification_cert: The path to the certificate which can be used to validate a server-side TLS connection (optional).
         :param x509_cert: Certificate which can be used to authenticate connection to a server in lieu of a password (optional).
         :param bool websockets: Indicates whether or not to enable a websockets connection in the Transport.
         :param str cipher: Cipher string in OpenSSL cipher list format
@@ -309,7 +309,7 @@ class MQTTTransport(object):
         ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLSv1_2)
 
         if self._server_verification_cert:
-            ssl_context.load_verify_locations(cadata=self._server_verification_cert)
+            ssl_context.load_verify_locations(cafile=self._server_verification_cert)
         else:
             ssl_context.load_default_certs()
 

--- a/azure-iot-device/azure/iot/device/common/mqtt_transport.py
+++ b/azure-iot-device/azure/iot/device/common/mqtt_transport.py
@@ -107,7 +107,7 @@ class MQTTTransport(object):
         :param str client_id: The id of the client connecting to the broker.
         :param str hostname: Hostname or IP address of the remote broker.
         :param str username: Username for login to the remote broker.
-        :param str server_verification_cert: The path to the certificate which can be used to validate a server-side TLS connection (optional).
+        :param str server_verification_cert: The full path to the certificate which can be used to validate a server-side TLS connection (optional).
         :param x509_cert: Certificate which can be used to authenticate connection to a server in lieu of a password (optional).
         :param bool websockets: Indicates whether or not to enable a websockets connection in the Transport.
         :param str cipher: Cipher string in OpenSSL cipher list format

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_http.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_http.py
@@ -19,7 +19,7 @@ class SetHTTPConnectionArgsOperation(PipelineOperation):
         """
         Initializer for SetHTTPConnectionArgsOperation objects.
         :param str hostname: The hostname of the HTTP server we will eventually connect to
-        :param str server_verification_cert: (Optional) The server verification certificate to use
+        :param str server_verification_cert: (Optional) The path to the server verification certificate to use
             if the HTTP server that we're going to connect to uses server-side TLS
         :param X509 client_cert: (Optional) The x509 object containing a client certificate and key used to connect
             to the HTTP service

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_http.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_http.py
@@ -19,7 +19,7 @@ class SetHTTPConnectionArgsOperation(PipelineOperation):
         """
         Initializer for SetHTTPConnectionArgsOperation objects.
         :param str hostname: The hostname of the HTTP server we will eventually connect to
-        :param str server_verification_cert: (Optional) The path to the server verification certificate to use
+        :param str server_verification_cert: (Optional) The full path to the server verification certificate to use
             if the HTTP server that we're going to connect to uses server-side TLS
         :param X509 client_cert: (Optional) The x509 object containing a client certificate and key used to connect
             to the HTTP service

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_mqtt.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_mqtt.py
@@ -29,7 +29,7 @@ class SetMQTTConnectionArgsOperation(PipelineOperation):
         :param str client_id: The client identifier to use when connecting to the MQTT server
         :param str hostname: The hostname of the MQTT server we will eventually connect to
         :param str username: The username to use when connecting to the MQTT server
-        :param str server_verification_cert: (Optional) The path to the server verification certificate to use
+        :param str server_verification_cert: (Optional) The full path to the server verification certificate to use
           if the MQTT server that we're going to connect to uses server-side TLS
         :param X509 client_cert: (Optional) The x509 object containing a client certificate and key used to connect
           to the MQTT service

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_mqtt.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_mqtt.py
@@ -29,7 +29,7 @@ class SetMQTTConnectionArgsOperation(PipelineOperation):
         :param str client_id: The client identifier to use when connecting to the MQTT server
         :param str hostname: The hostname of the MQTT server we will eventually connect to
         :param str username: The username to use when connecting to the MQTT server
-        :param str server_verification_cert: (Optional) The server verification certificate to use
+        :param str server_verification_cert: (Optional) The path to the server verification certificate to use
           if the MQTT server that we're going to connect to uses server-side TLS
         :param X509 client_cert: (Optional) The x509 object containing a client certificate and key used to connect
           to the MQTT service

--- a/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
@@ -79,7 +79,7 @@ class AbstractIoTHubClient(object):
 
         :param str connection_string: The connection string for the IoTHub you wish to connect to.
 
-        :param str server_verification_cert: Configuration Option. The path to the trusted certificate chain.
+        :param str server_verification_cert: Configuration Option. The full path to the trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT
@@ -175,7 +175,7 @@ class AbstractIoTHubDeviceClient(AbstractIoTHubClient):
         :type x509: :class:`azure.iot.device.X509`
         :param str device_id: The ID used to uniquely identify a device in the IoTHub
 
-        :param str server_verification_cert: Configuration Option. The path to the trusted certificate chain.
+        :param str server_verification_cert: Configuration Option. The full path to the trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT
@@ -221,7 +221,7 @@ class AbstractIoTHubDeviceClient(AbstractIoTHubClient):
             Can be found in the Azure portal in the Overview tab as the string hostname.
         :param device_id: The device ID
 
-        :param str server_verification_cert: Configuration Option. The path to the trusted certificate chain.
+        :param str server_verification_cert: Configuration Option. The full path to the trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT
@@ -391,7 +391,7 @@ class AbstractIoTHubModuleClient(AbstractIoTHubClient):
         :param str device_id: The ID used to uniquely identify a device in the IoTHub
         :param str module_id: The ID used to uniquely identify a module on a device on the IoTHub.
 
-        :param str server_verification_cert: Configuration Option. The path to the trusted certificate chain.
+        :param str server_verification_cert: Configuration Option. The full path to the trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT

--- a/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
@@ -79,7 +79,7 @@ class AbstractIoTHubClient(object):
 
         :param str connection_string: The connection string for the IoTHub you wish to connect to.
 
-        :param str server_verification_cert: Configuration Option. The trusted certificate chain.
+        :param str server_verification_cert: Configuration Option. The path to the trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT
@@ -175,7 +175,7 @@ class AbstractIoTHubDeviceClient(AbstractIoTHubClient):
         :type x509: :class:`azure.iot.device.X509`
         :param str device_id: The ID used to uniquely identify a device in the IoTHub
 
-        :param str server_verification_cert: Configuration Option. The trusted certificate chain.
+        :param str server_verification_cert: Configuration Option. The path to the trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT
@@ -221,7 +221,7 @@ class AbstractIoTHubDeviceClient(AbstractIoTHubClient):
             Can be found in the Azure portal in the Overview tab as the string hostname.
         :param device_id: The device ID
 
-        :param str server_verification_cert: Configuration Option. The trusted certificate chain.
+        :param str server_verification_cert: Configuration Option. The path to the trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT
@@ -391,7 +391,7 @@ class AbstractIoTHubModuleClient(AbstractIoTHubClient):
         :param str device_id: The ID used to uniquely identify a device in the IoTHub
         :param str module_id: The ID used to uniquely identify a module on a device on the IoTHub.
 
-        :param str server_verification_cert: Configuration Option. The trusted certificate chain.
+        :param str server_verification_cert: Configuration Option. The path to the trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_ops_iothub.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_ops_iothub.py
@@ -85,7 +85,7 @@ class SetIoTHubConnectionArgsOperation(PipelineOperation):
           for the module we are connecting.
         :param str gateway_hostname: (optional) If we are going through a gateway host, this is the
           hostname for the gateway
-        :param str server_verification_cert: (Optional) The server verification certificate to use
+        :param str server_verification_cert: (Optional) The path to the the server verification certificate to use
           if the server that we're going to connect to uses server-side TLS
         :param X509 client_cert: (Optional) The x509 object containing a client certificate and key used to connect
           to the service

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_ops_iothub.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_ops_iothub.py
@@ -85,7 +85,7 @@ class SetIoTHubConnectionArgsOperation(PipelineOperation):
           for the module we are connecting.
         :param str gateway_hostname: (optional) If we are going through a gateway host, this is the
           hostname for the gateway
-        :param str server_verification_cert: (Optional) The path to the the server verification certificate to use
+        :param str server_verification_cert: (Optional) The full path to the the server verification certificate to use
           if the server that we're going to connect to uses server-side TLS
         :param X509 client_cert: (Optional) The x509 object containing a client certificate and key used to connect
           to the service

--- a/azure-iot-device/tests/common/test_http_transport.py
+++ b/azure-iot-device/tests/common/test_http_transport.py
@@ -82,7 +82,7 @@ class TestInstantiation(object):
 
         assert mock_ssl_context.load_verify_locations.call_count == 1
         assert mock_ssl_context.load_verify_locations.call_args == mocker.call(
-            cadata=fake_server_verification_cert
+            cafile=fake_server_verification_cert
         )
 
     @pytest.mark.it(

--- a/azure-iot-device/tests/common/test_mqtt_transport.py
+++ b/azure-iot-device/tests/common/test_mqtt_transport.py
@@ -229,7 +229,7 @@ class TestInstantiation(object):
 
         assert mock_ssl_context.load_verify_locations.call_count == 1
         assert mock_ssl_context.load_verify_locations.call_args == mocker.call(
-            cadata=server_verification_cert
+            cafile=server_verification_cert
         )
 
     @pytest.mark.it(


### PR DESCRIPTION
# Description of the problem
We are talking a path for the kwarg `server_verification_cert` and eventually that translates to `cadata`.  `cadata` actually represents the data in the file. 

# Description of the solution
It should be `cafile` which represents a path to a file.
