### PR TITLE
Add watchdog timer for MQTT connect and reconnect operations

### DIFF
--- a/azure-iot-device/azure/iot/device/common/mqtt_transport.py
+++ b/azure-iot-device/azure/iot/device/common/mqtt_transport.py
@@ -210,7 +210,7 @@ class MQTTTransport(object):
             if rc:  # i.e. if there is an error
                 logger.debug("".join(traceback.format_stack()))
                 cause = _create_error_from_rc_code(rc)
-                this._stop_automatic_reconnect()
+                this._cleanup_transport_on_error()
 
             if this.on_mqtt_disconnected_handler:
                 try:
@@ -264,14 +264,20 @@ class MQTTTransport(object):
         mqtt_client.on_publish = on_publish
         mqtt_client.on_message = on_message
 
+        # Set paho automatic-reconnect delay to 2 hours.  Ideally we would turn
+        # paho auto-reconnect off entirely, but this is the best we can do.  Without
+        # this, we run the risk of our auto-reconnect code and the paho auto-reconnect
+        # code conflicting with each other.
+        mqtt_client.reconnect_delay_set(120 * 60)
+
         logger.debug("Created MQTT protocol client, assigned callbacks")
         return mqtt_client
 
-    def _stop_automatic_reconnect(self):
+    def _cleanup_transport_on_error(self):
         """
-        After disconnecting because of an error, Paho will attempt to reconnect (some of the time --
-        this isn't 100% reliable).  We don't want Paho to reconnect because we want to control the
-        timing of the reconnect, so we force the connection closed.
+        After disconnecting because of an error, Paho was designed to keep the loop running and
+        to try reconnecting after the reconnect interval. We don't want Paho to reconnect because
+        we want to control the timing of the reconnect, so we force the loop to stop.
 
         We are relying on intimite knowledge of Paho behavior here.  If this becomes a problem,
         it may be necessary to write our own Paho thread and stop using thread_start()/thread_stop().
@@ -281,7 +287,7 @@ class MQTTTransport(object):
 
         logger.info("Forcing paho disconnect to prevent it from automatically reconnecting")
 
-        # Note: We are calling this inside our on_disconnect() handler, so we are inside the
+        # Note: We are calling this inside our on_disconnect() handler, so we might be inside the
         # Paho thread at this point. This is perfectly valid.  Comments in Paho's client.py
         # loop_forever() function recomment calling disconnect() from a callback to exit the
         # Paho thread/loop.
@@ -297,8 +303,10 @@ class MQTTTransport(object):
         # Finally, because of a bug in Paho, we need to null out the _thread pointer.  This
         # is necessary because the code that sets _thread to None only gets called if you
         # call loop_stop from an external thread (and we're still inside the Paho thread here).
+        if threading.current_thread() == self._mqtt_client._thread:
+            logger.debug("in paho thread.  nulling _thread")
+            self._mqtt_client._thread = None
 
-        self._mqtt_client._thread = None
         logger.debug("Done forcing paho disconnect")
 
     def _create_ssl_context(self):
@@ -367,6 +375,8 @@ class MQTTTransport(object):
                     host=self._hostname, port=8883, keepalive=DEFAULT_KEEPALIVE
                 )
         except socket.error as e:
+            self._cleanup_transport_on_error()
+
             # Only this type will raise a special error
             # To stop it from retrying.
             if (
@@ -387,14 +397,20 @@ class MQTTTransport(object):
                 raise exceptions.ConnectionFailedError(cause=e)
 
         except socks.ProxyError as pe:
+            self._cleanup_transport_on_error()
+
             if isinstance(pe, socks.SOCKS5AuthError):
                 raise exceptions.UnauthorizedError(cause=pe)
             else:
                 raise exceptions.ProtocolProxyError(cause=pe)
+
         except Exception as e:
+            self._cleanup_transport_on_error()
+
             raise exceptions.ProtocolClientError(
                 message="Unexpected Paho failure during connect", cause=e
             )
+
         logger.debug("_mqtt_client.connect returned rc={}".format(rc))
         if rc:
             raise _create_error_from_rc_code(rc)
@@ -421,7 +437,7 @@ class MQTTTransport(object):
             rc = self._mqtt_client.reconnect()
         except Exception as e:
             logger.info("reconnect raised {}".format(e))
-            self._stop_automatic_reconnect()
+            self._cleanup_transport_on_error()
             raise exceptions.ConnectionDroppedError(
                 message="Unexpected Paho failure during reconnect", cause=e
             )
@@ -444,8 +460,14 @@ class MQTTTransport(object):
             raise exceptions.ProtocolClientError(
                 message="Unexpected Paho failure during disconnect", cause=e
             )
+        finally:
+            self._mqtt_client.loop_stop()
+
+            if threading.current_thread() == self._mqtt_client._thread:
+                logger.debug("in paho thread.  nulling _thread")
+                self._mqtt_client._thread = None
+
         logger.debug("_mqtt_client.disconnect returned rc={}".format(rc))
-        self._mqtt_client.loop_stop()
         if rc:
             # This could result in ConnectionDroppedError or ProtocolClientError
             # No matter what, we always raise here to give upper layers a chance to respond

--- a/azure-iot-device/azure/iot/device/common/mqtt_transport.py
+++ b/azure-iot-device/azure/iot/device/common/mqtt_transport.py
@@ -268,6 +268,7 @@ class MQTTTransport(object):
         # paho auto-reconnect off entirely, but this is the best we can do.  Without
         # this, we run the risk of our auto-reconnect code and the paho auto-reconnect
         # code conflicting with each other.
+        # The choice of 2 hours is completely arbitrary
         mqtt_client.reconnect_delay_set(120 * 60)
 
         logger.debug("Created MQTT protocol client, assigned callbacks")

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_base.py
@@ -227,7 +227,7 @@ class ConnectOperation(PipelineOperation):
     """
 
     def __init__(self, callback):
-        self.watchdog = None
+        self.watchdog_timer = None
         super(ConnectOperation, self).__init__(callback)
 
 
@@ -244,7 +244,7 @@ class ReauthorizeConnectionOperation(PipelineOperation):
     """
 
     def __init__(self, callback):
-        self.watchdog = None
+        self.watchdog_timer = None
         super(ReauthorizeConnectionOperation, self).__init__(callback)
 
     pass

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_ops_base.py
@@ -227,7 +227,7 @@ class ConnectOperation(PipelineOperation):
     """
 
     def __init__(self, callback):
-        self.retry_timer = None
+        self.watchdog = None
         super(ConnectOperation, self).__init__(callback)
 
 
@@ -242,6 +242,10 @@ class ReauthorizeConnectionOperation(PipelineOperation):
 
     Even though this is an base operation, it will most likely be handled by a more specific stage (such as an IoTHub or MQTT stage).
     """
+
+    def __init__(self, callback):
+        self.watchdog = None
+        super(ReauthorizeConnectionOperation, self).__init__(callback)
 
     pass
 

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
@@ -95,17 +95,17 @@ class MQTTTransportStage(PipelineStage):
                     )
                 )
 
-        connection_op.watchdog = threading.Timer(WATCHDOG_INTERVAL, watchdog_function)
-        connection_op.watchdog.daemon = True
-        connection_op.watchdog.start()
+        connection_op.watchdog_timer = threading.Timer(WATCHDOG_INTERVAL, watchdog_function)
+        connection_op.watchdog_timer.daemon = True
+        connection_op.watchdog_timer.start()
 
     @pipeline_thread.runs_on_pipeline_thread
     def _cancel_connection_watchdog(self, op):
         try:
-            if op.watchdog:
+            if op.watchdog_timer:
                 logger.debug("{}({}): cancelling watchdog".format(self.name, op.name))
-                op.watchdog.cancel()
-                op.watchdog = None
+                op.watchdog_timer.cancel()
+                op.watchdog_timer = None
         except AttributeError:
             pass
 

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
@@ -7,6 +7,8 @@
 import logging
 import six
 import traceback
+import threading
+import weakref
 from . import (
     pipeline_ops_base,
     PipelineStage,
@@ -21,6 +23,9 @@ from azure.iot.device.common import handle_exceptions, transport_exceptions
 from azure.iot.device.common.callable_weak_method import CallableWeakMethod
 
 logger = logging.getLogger(__name__)
+
+# Maximum amount of time we wait for ConnectOperation or ReauthorizeConnectionOperation to complete
+WATCHDOG_INTERVAL = 10
 
 
 class MQTTTransportStage(PipelineStage):
@@ -42,7 +47,7 @@ class MQTTTransportStage(PipelineStage):
         self._pending_connection_op = None
 
     @pipeline_thread.runs_on_pipeline_thread
-    def _cancel_pending_connection_op(self):
+    def _cancel_pending_connection_op(self, error=None):
         """
         Cancel any running connect, disconnect or reauthorize_connection op. Since our ability to "cancel" is fairly limited,
         all this does (for now) is to fail the operation
@@ -53,11 +58,56 @@ class MQTTTransportStage(PipelineStage):
             # NOTE: This code path should NOT execute in normal flow. There should never already be a pending
             # connection op when another is added, due to the SerializeConnectOps stage.
             # If this block does execute, there is a bug in the codebase.
-            error = pipeline_exceptions.OperationCancelled(
-                "Cancelling because new ConnectOperation, DisconnectOperation, or ReauthorizeConnectionOperation was issued"
-            )  # TODO: should this actually somehow cancel the operation?
+            if not error:
+                error = pipeline_exceptions.OperationCancelled(
+                    "Cancelling because new ConnectOperation, DisconnectOperation, or ReauthorizeConnectionOperation was issued"
+                )
+            self._cancel_connection_watchdog(op)
             op.complete(error=error)
             self._pending_connection_op = None
+
+    @pipeline_thread.runs_on_pipeline_thread
+    def _start_connection_watchdog(self, connection_op):
+        logger.debug("{}({}): Starting watchdog".format(self.name, connection_op.name))
+
+        self_weakref = weakref.ref(self)
+        op_weakref = weakref.ref(connection_op)
+
+        @pipeline_thread.invoke_on_pipeline_thread
+        def watchdog_function():
+            this = self_weakref()
+            op = op_weakref()
+            if this and op and this._pending_connection_op is op:
+                logger.info(
+                    "{}({}): Connection watchdog expired.  Cancelling op".format(this.name, op.name)
+                )
+                this.transport.disconnect()
+                if this.pipeline_root.connected:
+                    logger.info(
+                        "{}({}): Pipeline is still connected on watchdog expiration.  Sending DisconnectedEvent".format(
+                            this.name, op.name
+                        )
+                    )
+                    this.send_event_up(pipeline_events_base.DisconnectedEvent())
+                this._cancel_pending_connection_op(
+                    error=pipeline_exceptions.OperationCancelled(
+                        "Transport timeout on connection operation"
+                    )
+                )
+
+        connection_op.watchdog = threading.Timer(WATCHDOG_INTERVAL, watchdog_function)
+        connection_op.watchdog.daemon = True
+        connection_op.watchdog.start()
+
+    @pipeline_thread.runs_on_pipeline_thread
+    def _cancel_connection_watchdog(self, op):
+        try:
+            if op.watchdog:
+                logger.debug("{}({}): cancelling watchdog".format(self.name, op.name))
+                op.watchdog.cancel()
+                op.watchdog = None
+        except AttributeError:
+            pass
 
     @pipeline_thread.runs_on_pipeline_thread
     def _run_op(self, op):
@@ -113,11 +163,13 @@ class MQTTTransportStage(PipelineStage):
 
             self._cancel_pending_connection_op()
             self._pending_connection_op = op
+            self._start_connection_watchdog(op)
             try:
                 self.transport.connect(password=self.sas_token)
             except Exception as e:
                 logger.error("transport.connect raised error")
                 logger.error(traceback.format_exc())
+                self._cancel_connection_watchdog(op)
                 self._pending_connection_op = None
                 op.complete(error=e)
 
@@ -127,11 +179,13 @@ class MQTTTransportStage(PipelineStage):
             # We set _active_connect_op here because reauthorizing the connection is the same as a connect for "active operation" tracking purposes.
             self._cancel_pending_connection_op()
             self._pending_connection_op = op
+            self._start_connection_watchdog(op)
             try:
                 self.transport.reauthorize_connection(password=self.sas_token)
             except Exception as e:
                 logger.error("transport.reauthorize_connection raised error")
                 logger.error(traceback.format_exc())
+                self._cancel_connection_watchdog(op)
                 self._pending_connection_op = None
                 # Send up a DisconenctedEvent.  If we ran a ReauthorizeConnectionOperatoin,
                 # some code must think we're still connected.  If we got an exception here,
@@ -148,6 +202,10 @@ class MQTTTransportStage(PipelineStage):
 
             self._cancel_pending_connection_op()
             self._pending_connection_op = op
+            # We don't need a watchdog on disconnect because there's no callback to wait for
+            # and we respond to a watchdog timeout by calling disconnect, which is what we're
+            # already doing.
+
             try:
                 self.transport.disconnect()
             except Exception as e:
@@ -232,6 +290,7 @@ class MQTTTransportStage(PipelineStage):
         ):
             logger.debug("completing connect op")
             op = self._pending_connection_op
+            self._cancel_connection_watchdog(op)
             self._pending_connection_op = None
             op.complete()
         else:
@@ -257,6 +316,7 @@ class MQTTTransportStage(PipelineStage):
         ):
             logger.debug("{}: failing connect op".format(self.name))
             op = self._pending_connection_op
+            self._cancel_connection_watchdog(op)
             self._pending_connection_op = None
             op.complete(error=cause)
         else:
@@ -289,6 +349,7 @@ class MQTTTransportStage(PipelineStage):
                 "{}: completing pending {} op".format(self.name, self._pending_connection_op.name)
             )
             op = self._pending_connection_op
+            self._cancel_connection_watchdog(op)
             self._pending_connection_op = None
 
             if isinstance(op, pipeline_ops_base.DisconnectOperation):

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_ops_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_ops_base.py
@@ -25,10 +25,18 @@ class ConnectOperationTestConfig(object):
         return kwargs
 
 
+class ConnectOperationInstantiationTests(ConnectOperationTestConfig):
+    @pytest.mark.it("Initializes 'watchdog' attribute to 'None'")
+    def test_retry_timer(self, cls_type, init_kwargs):
+        op = cls_type(**init_kwargs)
+        assert op.watchdog is None
+
+
 pipeline_ops_test.add_operation_tests(
     test_module=this_module,
     op_class_under_test=pipeline_ops_base.ConnectOperation,
     op_test_config_class=ConnectOperationTestConfig,
+    extended_op_instantiation_test_class=ConnectOperationInstantiationTests,
 )
 
 
@@ -61,10 +69,18 @@ class ReauthorizeConnectionOperationTestConfig(object):
         return kwargs
 
 
+class ReauthorizeConnectionOperationInstantiationTests(ReauthorizeConnectionOperationTestConfig):
+    @pytest.mark.it("Initializes 'watchdog' attribute to 'None'")
+    def test_retry_timer(self, cls_type, init_kwargs):
+        op = cls_type(**init_kwargs)
+        assert op.watchdog is None
+
+
 pipeline_ops_test.add_operation_tests(
     test_module=this_module,
     op_class_under_test=pipeline_ops_base.ReauthorizeConnectionOperation,
     op_test_config_class=ReauthorizeConnectionOperationTestConfig,
+    extended_op_instantiation_test_class=ReauthorizeConnectionOperationInstantiationTests,
 )
 
 

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_ops_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_ops_base.py
@@ -26,10 +26,10 @@ class ConnectOperationTestConfig(object):
 
 
 class ConnectOperationInstantiationTests(ConnectOperationTestConfig):
-    @pytest.mark.it("Initializes 'watchdog' attribute to 'None'")
+    @pytest.mark.it("Initializes 'watchdog_timer' attribute to 'None'")
     def test_retry_timer(self, cls_type, init_kwargs):
         op = cls_type(**init_kwargs)
-        assert op.watchdog is None
+        assert op.watchdog_timer is None
 
 
 pipeline_ops_test.add_operation_tests(
@@ -70,10 +70,10 @@ class ReauthorizeConnectionOperationTestConfig(object):
 
 
 class ReauthorizeConnectionOperationInstantiationTests(ReauthorizeConnectionOperationTestConfig):
-    @pytest.mark.it("Initializes 'watchdog' attribute to 'None'")
+    @pytest.mark.it("Initializes 'watchdog_timer' attribute to 'None'")
     def test_retry_timer(self, cls_type, init_kwargs):
         op = cls_type(**init_kwargs)
-        assert op.watchdog is None
+        assert op.watchdog_timer is None
 
 
 pipeline_ops_test.add_operation_tests(

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_mqtt.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_mqtt.py
@@ -7,6 +7,7 @@ import logging
 import pytest
 import sys
 import six
+import threading
 from azure.iot.device.common import transport_exceptions, handle_exceptions
 from azure.iot.device.common.pipeline import (
     pipeline_ops_base,
@@ -37,6 +38,11 @@ def mock_transport(mocker):
     )
 
 
+@pytest.fixture
+def mock_timer(mocker):
+    return mocker.patch.object(threading, "Timer")
+
+
 # Not a fixture, but used in parametrization
 def fake_callback():
     pass
@@ -45,6 +51,8 @@ def fake_callback():
 ########################
 # MQTT TRANSPORT STAGE #
 ########################
+
+WATCHDOG_INTERVAL = 10
 
 
 class MQTTTransportStageTestConfig(object):
@@ -300,6 +308,15 @@ class TestMQTTTransportStageRunOpCalledWithConnectOperation(
         # New operation is now the pending operation
         assert stage._pending_connection_op is op
 
+    @pytest.mark.it("Starts the connection watchdog")
+    def test_starts_watchdog(self, mocker, stage, op, mock_timer):
+        stage.run_op(op)
+
+        assert mock_timer.call_count == 1
+        assert mock_timer.call_args == mocker.call(WATCHDOG_INTERVAL, mocker.ANY)
+        assert mock_timer.return_value.daemon is True
+        assert mock_timer.return_value.start.call_count == 1
+
     @pytest.mark.it("Performs an MQTT connect via the MQTTTransport")
     def test_mqtt_connect(self, mocker, stage, op):
         stage.run_op(op)
@@ -322,6 +339,23 @@ class TestMQTTTransportStageRunOpCalledWithConnectOperation(
         stage.transport.connect.side_effect = arbitrary_exception
         stage.run_op(op)
         assert stage._pending_connection_op is None
+
+    @pytest.mark.it(
+        "Leaves the watchdog running while waiting for the connect operation to complete"
+    )
+    def test_leaves_watchdog_running(self, mocker, stage, op, arbitrary_exception, mock_timer):
+        stage.run_op(op)
+        assert mock_timer.return_value.cancel.call_count == 0
+        assert op.watchdog is mock_timer.return_value
+
+    @pytest.mark.it(
+        "Cancels the connection watchdog if the MQTTTransport connect operation raises an exception"
+    )
+    def test_cancels_watchdog(self, mocker, stage, op, arbitrary_exception, mock_timer):
+        stage.transport.connect.side_effect = arbitrary_exception
+        stage.run_op(op)
+        assert mock_timer.return_value.cancel.call_count == 1
+        assert op.watchdog is None
 
 
 @pytest.mark.describe(
@@ -372,6 +406,15 @@ class TestMQTTTransportStageRunOpCalledWithReauthorizeConnectionOperation(
         # New operation is now the pending operation
         assert stage._pending_connection_op is op
 
+    @pytest.mark.it("Starts the connection watchdog")
+    def test_starts_watchdog(self, mocker, stage, op, mock_timer):
+        stage.run_op(op)
+
+        assert mock_timer.call_count == 1
+        assert mock_timer.call_args == mocker.call(WATCHDOG_INTERVAL, mocker.ANY)
+        assert mock_timer.return_value.daemon is True
+        assert mock_timer.return_value.start.call_count == 1
+
     @pytest.mark.it("Performs an MQTT reconnect via the MQTTTransport")
     def test_mqtt_connect(self, mocker, stage, op):
         stage.run_op(op)
@@ -413,6 +456,23 @@ class TestMQTTTransportStageRunOpCalledWithReauthorizeConnectionOperation(
         stage.transport.reauthorize_connection.side_effect = arbitrary_exception
         stage.run_op(op)
         assert stage.send_event_up.call_count == 0
+
+    @pytest.mark.it(
+        "Leaves the watchdog running while waiting for the reconnect operation to complete"
+    )
+    def test_leaves_watchdog_running(self, mocker, stage, op, arbitrary_exception, mock_timer):
+        stage.run_op(op)
+        assert mock_timer.return_value.cancel.call_count == 0
+        assert op.watchdog is mock_timer.return_value
+
+    @pytest.mark.it(
+        "Cancels the connection watchdog if the MQTTTransport reconnect operation raises an exception"
+    )
+    def test_cancels_watchdog(self, mocker, stage, op, arbitrary_exception, mock_timer):
+        stage.transport.reauthorize_connection.side_effect = arbitrary_exception
+        stage.run_op(op)
+        assert mock_timer.return_value.cancel.call_count == 1
+        assert op.watchdog is None
 
 
 @pytest.mark.describe("MQTTTransportStage - .run_op() -- Called with DisconnectOperation")
@@ -748,6 +808,62 @@ class TestMQTTTransportStageOnConnected(MQTTTransportStageTestConfigComplex):
         assert not op.completed
         assert stage._pending_connection_op is op
 
+    @pytest.mark.it(
+        "Cancels the connection watchdog if the pending operation is a ConnectOperation"
+    )
+    def test_cancels_watchdog_on_pending_connect(self, mocker, stage, mock_timer):
+        # Set a pending connect operation
+        op = pipeline_ops_base.ConnectOperation(callback=mocker.MagicMock())
+        stage.run_op(op)
+
+        # assert watchdog is running
+        assert op.watchdog is mock_timer.return_value
+        assert op.watchdog.start.call_count == 1
+
+        # Trigger connect completion
+        stage.transport.on_mqtt_connected_handler()
+
+        # assert watchdog was cancelled
+        assert op.watchdog is None
+        assert mock_timer.return_value.cancel.call_count == 1
+
+    @pytest.mark.it(
+        "Cancels the connection watchdog if the pending operation is a ReauthorizeConnectionOperation"
+    )
+    def test_cancels_watchdog_on_pending_reauthorize(self, mocker, stage, mock_timer):
+        # Set a pending reconnect operation
+        op = pipeline_ops_base.ReauthorizeConnectionOperation(callback=mocker.MagicMock())
+        stage.run_op(op)
+
+        # assert watchdog is running
+        assert op.watchdog is mock_timer.return_value
+        assert op.watchdog.start.call_count == 1
+
+        # Trigger connect completion
+        stage.transport.on_mqtt_connected_handler()
+
+        # assert watchdog was cancelled
+        assert op.watchdog is None
+        assert mock_timer.return_value.cancel.call_count == 1
+
+    @pytest.mark.it(
+        "Does not cancels the connection watchdog if the pending operation is DisconnectOperation"
+    )
+    def test_does_not_cancel_watchdog_on_pending_disconnect(self, mocker, stage, mock_timer):
+        # Set a pending disconnect operation
+        op = pipeline_ops_base.DisconnectOperation(callback=mocker.MagicMock())
+        stage.run_op(op)
+
+        # assert no timers are running
+        assert mock_timer.return_value.start.call_count == 0
+
+        # Trigger connect completion
+        stage.transport.on_mqtt_connected_handler()
+
+        # assert no timers are still running
+        assert mock_timer.return_value.start.call_count == 0
+        assert mock_timer.return_value.cancel.call_count == 0
+
 
 @pytest.mark.describe("MQTTTransportStage - OCCURANCE: MQTT connection failure")
 class TestMQTTTransportStageOnConnectionFailure(MQTTTransportStageTestConfigComplex):
@@ -852,6 +968,68 @@ class TestMQTTTransportStageOnConnectionFailure(MQTTTransportStageTestConfigComp
         assert mock_handler.call_args == mocker.call(
             arbitrary_exception, log_msg=mocker.ANY, log_lvl="info"
         )
+
+    @pytest.mark.it(
+        "Cancels the connection watchdog if the pending operation is a ConnectOperation"
+    )
+    def test_cancels_watchdog_on_pending_connect(
+        self, mocker, stage, mock_timer, arbitrary_exception
+    ):
+        # Set a pending connect operation
+        op = pipeline_ops_base.ConnectOperation(callback=mocker.MagicMock())
+        stage.run_op(op)
+
+        # assert watchdog is running
+        assert op.watchdog is mock_timer.return_value
+        assert op.watchdog.start.call_count == 1
+
+        # Trigger connection failure with arbitrary cause
+        stage.transport.on_mqtt_connection_failure_handler(arbitrary_exception)
+
+        # assert watchdog was cancelled
+        assert op.watchdog is None
+        assert mock_timer.return_value.cancel.call_count == 1
+
+    @pytest.mark.it(
+        "Cancels the connection watchdog if the pending operation is a ReauthorizeConnectionOperation"
+    )
+    def test_cancels_watchdog_on_pending_reauthorize(
+        self, mocker, stage, mock_timer, arbitrary_exception
+    ):
+        # Set a pending reconnect operation
+        op = pipeline_ops_base.ReauthorizeConnectionOperation(callback=mocker.MagicMock())
+        stage.run_op(op)
+
+        # assert watchdog is running
+        assert op.watchdog is mock_timer.return_value
+        assert op.watchdog.start.call_count == 1
+
+        # Trigger connection failure with arbitrary cause
+        stage.transport.on_mqtt_connection_failure_handler(arbitrary_exception)
+
+        # assert watchdog was cancelled
+        assert op.watchdog is None
+        assert mock_timer.return_value.cancel.call_count == 1
+
+    @pytest.mark.it(
+        "Does not cancels the connection watchdog if the pending operation is DisconnectOperation"
+    )
+    def test_does_not_cancel_watchdog_on_pending_disconnect(
+        self, mocker, stage, mock_timer, arbitrary_exception
+    ):
+        # Set a pending disconnect operation
+        op = pipeline_ops_base.DisconnectOperation(callback=mocker.MagicMock())
+        stage.run_op(op)
+
+        # assert no timers are running
+        assert mock_timer.return_value.start.call_count == 0
+
+        # Trigger connection failure with arbitrary cause
+        stage.transport.on_mqtt_connection_failure_handler(arbitrary_exception)
+
+        # assert no timers are still running
+        assert mock_timer.return_value.start.call_count == 0
+        assert mock_timer.return_value.cancel.call_count == 0
 
 
 @pytest.mark.describe("MQTTTransportStage - OCCURANCE: MQTT disconnected")
@@ -1022,3 +1200,186 @@ class TestMQTTTransportStageOnDisconnected(MQTTTransportStageTestConfigComplex):
         stage.transport.on_mqtt_disconnected_handler(cause)
 
         assert stage._pending_connection_op is None
+
+    @pytest.mark.it(
+        "Cancels the connection watchdog if the pending operation is a ConnectOperation"
+    )
+    def test_cancels_watchdog_on_pending_connect(self, mocker, stage, mock_timer, cause):
+        # Set a pending connect operation
+        op = pipeline_ops_base.ConnectOperation(callback=mocker.MagicMock())
+        stage.run_op(op)
+
+        # assert watchdog is running
+        assert op.watchdog is mock_timer.return_value
+        assert op.watchdog.start.call_count == 1
+
+        # Trigger disconnect
+        stage.transport.on_mqtt_disconnected_handler(cause)
+
+        # assert watchdog was cancelled
+        assert op.watchdog is None
+        assert mock_timer.return_value.cancel.call_count == 1
+
+    @pytest.mark.it(
+        "Cancels the connection watchdog if the pending operation is a ReauthorizeConnectionOperation"
+    )
+    def test_cancels_watchdog_on_pending_reauthorize(self, mocker, stage, mock_timer, cause):
+        # Set a pending reconnect operation
+        op = pipeline_ops_base.ReauthorizeConnectionOperation(callback=mocker.MagicMock())
+        stage.run_op(op)
+
+        # assert watchdog is running
+        assert op.watchdog is mock_timer.return_value
+        assert op.watchdog.start.call_count == 1
+
+        # Trigger disconnect
+        stage.transport.on_mqtt_disconnected_handler(cause)
+
+        # assert watchdog was cancelled
+        assert op.watchdog is None
+        assert mock_timer.return_value.cancel.call_count == 1
+
+    @pytest.mark.it(
+        "Does not cancels the connection watchdog if the pending operation is DisconnectOperation"
+    )
+    def test_does_not_cancel_watchdog_on_pending_disconnect(self, mocker, stage, mock_timer, cause):
+        # Set a pending disconnect operation
+        op = pipeline_ops_base.DisconnectOperation(callback=mocker.MagicMock())
+        stage.run_op(op)
+
+        # assert no timers are running
+        assert mock_timer.return_value.start.call_count == 0
+
+        # Trigger disconnect
+        stage.transport.on_mqtt_disconnected_handler(cause)
+
+        # assert no timers are still running
+        assert mock_timer.return_value.start.call_count == 0
+        assert mock_timer.return_value.cancel.call_count == 0
+
+
+@pytest.mark.describe("MQTTTransportStage - OCCURANCE: Connection watchdog expired")
+class TestMQTTTransportStageWatchdogExpired(MQTTTransportStageTestConfigComplex):
+    @pytest.fixture(
+        params=[
+            pipeline_ops_base.ConnectOperation,
+            pipeline_ops_base.ReauthorizeConnectionOperation,
+        ],
+        ids=["Pending ConnectOperation", "Pending ReauthorizeConnectionOperation"],
+    )
+    def pending_op(self, request, mocker):
+        return request.param(callback=mocker.MagicMock())
+
+    @pytest.mark.it(
+        "Performs an MQTT disconnect via the MQTTTransport if the op that started the watchdog is still pending"
+    )
+    def test_calls_disconnect(self, mocker, stage, pending_op, mock_timer):
+        stage.run_op(pending_op)
+
+        watchdog_expiration = mock_timer.call_args[0][1]
+        watchdog_expiration()
+
+        assert stage.transport.disconnect.call_count == 1
+
+    @pytest.mark.it(
+        "Does not perform an MQTT disconnect via the MQTTTransport if the op that started the watchdog is no longer pending"
+    )
+    def test_does_not_call_disconnect_if_no_longer_pending(
+        self, mocker, stage, pending_op, mock_timer
+    ):
+        stage.run_op(pending_op)
+        stage._pending_connection_op = None
+
+        watchdog_expiration = mock_timer.call_args[0][1]
+        watchdog_expiration()
+
+        assert stage.transport.disconnect.call_count == 0
+
+    @pytest.mark.it(
+        "Completes the op that started the watchdog with an OperationCancelled error if that op is still pending"
+    )
+    def test_completes_with_operation_cancelled(self, mocker, stage, pending_op, mock_timer):
+        callback = pending_op.callback_stack[0]
+
+        stage.run_op(pending_op)
+
+        watchdog_expiration = mock_timer.call_args[0][1]
+        watchdog_expiration()
+
+        assert callback.call_count == 1
+        assert isinstance(callback.call_args[1]["error"], pipeline_exceptions.OperationCancelled)
+
+    @pytest.mark.it(
+        "Does not complete the op that started the watchdog with an OperationCancelled error if that op is no longer pending"
+    )
+    def test_does_not_complete_op_if_no_longer_pending(self, mocker, stage, pending_op, mock_timer):
+        callback = pending_op.callback_stack[0]
+
+        stage.run_op(pending_op)
+        stage._pending_connection_op = None
+
+        watchdog_expiration = mock_timer.call_args[0][1]
+        watchdog_expiration()
+
+        assert callback.call_count == 0
+
+    @pytest.mark.it(
+        "Sends a DisconnectedEvent if the op that started the watchdog is still pending and the pipeline_root connected flag is True"
+    )
+    def test_sends_disconnected_event_if_still_pendin_and_connected(
+        self, mocker, stage, pending_op, mock_timer
+    ):
+        stage.pipeline_root.connected = True
+        stage.run_op(pending_op)
+
+        watchdog_expiration = mock_timer.call_args[0][1]
+        watchdog_expiration()
+
+        assert stage.send_event_up.call_count == 1
+        assert isinstance(
+            stage.send_event_up.call_args[0][0], pipeline_events_base.DisconnectedEvent
+        )
+
+    @pytest.mark.it(
+        "Does not send a DisconnectedEvent if the op that started the watchdog is still pending and the pipeline_root connected flag is False"
+    )
+    def test_does_not_send_disconnected_event_if_still_pending_and_not_connected(
+        self, mocker, stage, pending_op, mock_timer
+    ):
+        stage.pipeline_root.connected = False
+        stage.run_op(pending_op)
+
+        watchdog_expiration = mock_timer.call_args[0][1]
+        watchdog_expiration()
+
+        assert stage.send_event_up.call_count == 0
+
+    @pytest.mark.it(
+        "Does not send a DisconnectedEvent if the op that started the watchdog is no longer pending and the pipeline connected flag is True"
+    )
+    def test_does_not_send_disconnected_event_if_no_longer_pending_and_connected(
+        self, mocker, stage, pending_op, mock_timer
+    ):
+        stage.pipeline_root.connected = True
+        stage.run_op(pending_op)
+        stage._pending_connection_op = None
+
+        watchdog_expiration = mock_timer.call_args[0][1]
+        watchdog_expiration()
+
+        assert stage.send_event_up.call_count == 0
+
+    @pytest.mark.it(
+        "Does not send a DisconnectedEvent if the op that started the watchdog is no longer pending and the pipeline connected flag is False"
+    )
+    def test_does_not_send_disconnected_evfent_if_no_longer_pending_and_not_connected(
+        self, mocker, stage, pending_op, mock_timer
+    ):
+        stage.pipeline_root.connected = False
+        stage.run_op(pending_op)
+        stage._pending_connection_op = None
+
+        watchdog_expiration = mock_timer.call_args[0][1]
+        watchdog_expiration()
+
+        assert stage.send_event_up.call_count == 0

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_mqtt.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_mqtt.py
@@ -346,7 +346,7 @@ class TestMQTTTransportStageRunOpCalledWithConnectOperation(
     def test_leaves_watchdog_running(self, mocker, stage, op, arbitrary_exception, mock_timer):
         stage.run_op(op)
         assert mock_timer.return_value.cancel.call_count == 0
-        assert op.watchdog is mock_timer.return_value
+        assert op.watchdog_timer is mock_timer.return_value
 
     @pytest.mark.it(
         "Cancels the connection watchdog if the MQTTTransport connect operation raises an exception"
@@ -355,7 +355,7 @@ class TestMQTTTransportStageRunOpCalledWithConnectOperation(
         stage.transport.connect.side_effect = arbitrary_exception
         stage.run_op(op)
         assert mock_timer.return_value.cancel.call_count == 1
-        assert op.watchdog is None
+        assert op.watchdog_timer is None
 
 
 @pytest.mark.describe(
@@ -463,7 +463,7 @@ class TestMQTTTransportStageRunOpCalledWithReauthorizeConnectionOperation(
     def test_leaves_watchdog_running(self, mocker, stage, op, arbitrary_exception, mock_timer):
         stage.run_op(op)
         assert mock_timer.return_value.cancel.call_count == 0
-        assert op.watchdog is mock_timer.return_value
+        assert op.watchdog_timer is mock_timer.return_value
 
     @pytest.mark.it(
         "Cancels the connection watchdog if the MQTTTransport reconnect operation raises an exception"
@@ -472,7 +472,7 @@ class TestMQTTTransportStageRunOpCalledWithReauthorizeConnectionOperation(
         stage.transport.reauthorize_connection.side_effect = arbitrary_exception
         stage.run_op(op)
         assert mock_timer.return_value.cancel.call_count == 1
-        assert op.watchdog is None
+        assert op.watchdog_timer is None
 
 
 @pytest.mark.describe("MQTTTransportStage - .run_op() -- Called with DisconnectOperation")
@@ -817,14 +817,14 @@ class TestMQTTTransportStageOnConnected(MQTTTransportStageTestConfigComplex):
         stage.run_op(op)
 
         # assert watchdog is running
-        assert op.watchdog is mock_timer.return_value
-        assert op.watchdog.start.call_count == 1
+        assert op.watchdog_timer is mock_timer.return_value
+        assert op.watchdog_timer.start.call_count == 1
 
         # Trigger connect completion
         stage.transport.on_mqtt_connected_handler()
 
         # assert watchdog was cancelled
-        assert op.watchdog is None
+        assert op.watchdog_timer is None
         assert mock_timer.return_value.cancel.call_count == 1
 
     @pytest.mark.it(
@@ -836,14 +836,14 @@ class TestMQTTTransportStageOnConnected(MQTTTransportStageTestConfigComplex):
         stage.run_op(op)
 
         # assert watchdog is running
-        assert op.watchdog is mock_timer.return_value
-        assert op.watchdog.start.call_count == 1
+        assert op.watchdog_timer is mock_timer.return_value
+        assert op.watchdog_timer.start.call_count == 1
 
         # Trigger connect completion
         stage.transport.on_mqtt_connected_handler()
 
         # assert watchdog was cancelled
-        assert op.watchdog is None
+        assert op.watchdog_timer is None
         assert mock_timer.return_value.cancel.call_count == 1
 
     @pytest.mark.it(
@@ -980,14 +980,14 @@ class TestMQTTTransportStageOnConnectionFailure(MQTTTransportStageTestConfigComp
         stage.run_op(op)
 
         # assert watchdog is running
-        assert op.watchdog is mock_timer.return_value
-        assert op.watchdog.start.call_count == 1
+        assert op.watchdog_timer is mock_timer.return_value
+        assert op.watchdog_timer.start.call_count == 1
 
         # Trigger connection failure with arbitrary cause
         stage.transport.on_mqtt_connection_failure_handler(arbitrary_exception)
 
         # assert watchdog was cancelled
-        assert op.watchdog is None
+        assert op.watchdog_timer is None
         assert mock_timer.return_value.cancel.call_count == 1
 
     @pytest.mark.it(
@@ -1001,14 +1001,14 @@ class TestMQTTTransportStageOnConnectionFailure(MQTTTransportStageTestConfigComp
         stage.run_op(op)
 
         # assert watchdog is running
-        assert op.watchdog is mock_timer.return_value
-        assert op.watchdog.start.call_count == 1
+        assert op.watchdog_timer is mock_timer.return_value
+        assert op.watchdog_timer.start.call_count == 1
 
         # Trigger connection failure with arbitrary cause
         stage.transport.on_mqtt_connection_failure_handler(arbitrary_exception)
 
         # assert watchdog was cancelled
-        assert op.watchdog is None
+        assert op.watchdog_timer is None
         assert mock_timer.return_value.cancel.call_count == 1
 
     @pytest.mark.it(
@@ -1210,14 +1210,14 @@ class TestMQTTTransportStageOnDisconnected(MQTTTransportStageTestConfigComplex):
         stage.run_op(op)
 
         # assert watchdog is running
-        assert op.watchdog is mock_timer.return_value
-        assert op.watchdog.start.call_count == 1
+        assert op.watchdog_timer is mock_timer.return_value
+        assert op.watchdog_timer.start.call_count == 1
 
         # Trigger disconnect
         stage.transport.on_mqtt_disconnected_handler(cause)
 
         # assert watchdog was cancelled
-        assert op.watchdog is None
+        assert op.watchdog_timer is None
         assert mock_timer.return_value.cancel.call_count == 1
 
     @pytest.mark.it(
@@ -1229,14 +1229,14 @@ class TestMQTTTransportStageOnDisconnected(MQTTTransportStageTestConfigComplex):
         stage.run_op(op)
 
         # assert watchdog is running
-        assert op.watchdog is mock_timer.return_value
-        assert op.watchdog.start.call_count == 1
+        assert op.watchdog_timer is mock_timer.return_value
+        assert op.watchdog_timer.start.call_count == 1
 
         # Trigger disconnect
         stage.transport.on_mqtt_disconnected_handler(cause)
 
         # assert watchdog was cancelled
-        assert op.watchdog is None
+        assert op.watchdog_timer is None
         assert mock_timer.return_value.cancel.call_count == 1
 
     @pytest.mark.it(


### PR DESCRIPTION
There are conditions where connect and reconnect operations can timeout and we have no control.  These are very uncommon, but reproducable with the right stress scripts.  

# How did I fix this?

To work around these conditions, I've added a watchdog timer to connect and reconnect operations.  If these operations don't complete within some interval (I picked 10 seconds), the watchdog cancels the operation and disconnects the transport.  This gives the transport a "clean slate" and the pipeline retry/reconnect logic is able to recover.

# Problem 1: Paho conect never returns

In some cases, the call into paho's mqtt_client.connect() never returns or takes a really long time to return.  (this has been seen in the field, but I haven't been able to reproduce this).  This is likely a bug in TLS  negotiation or the network stack.

We have no way to fix this.

# Problem 2: Paho connect succeeds, but CONACK never comes back.

In other cases, connect returns success, but the CONACK never returns and we never get an on_mqtt_disconneted event.  I can reproduce this under stress situations, and it has to do with the fact that paho's loop isn't really entirely 100% thread safe, especially if you're intermixing bad network conditions with sas token renewal and DeviceClient opreations.

We could fix this, but it would involve some combination of replacing Paho's thread with our own and submitting PRs to Paho.  Both of these are really expensive.

# Why add the code here?

I did this in the MQTT stage because I wanted to keep the recovery code as close to the transport as possible.  

I could have used TimeoutStage to detect the timeout, but I would have needed to add a recovery stage to disconnect when timeouts occur.  This is working around behaviors of Paho, so it seemed silly to put into a generic stage.

I could have created a new stage to add watchdog functionality to these 2 ops, but this seemed like overkill.  Stages aren't complex, the the logic of ordering stages is complex because of implied inter-stage dependencies.

