### PR TITLE
fix : pre-commit error

### DIFF
--- a/env_setup.py
+++ b/env_setup.py
@@ -69,4 +69,4 @@ if __name__ == "__main__":
         # These are not compatible on all platforms.
         pip_command("install -U -r requirements_dev.txt")
         print("Installing pre-commit")
-        check_call("pre-commit install")
+        check_call("pre-commit install", shell=True)


### PR DESCRIPTION
`os.system(command)` is one way to use running terminal commands.
Since we are using `check_call` here to achieve the same `shell=True` is one way to tell that call that we are trying to run a terminal command.