### PR TITLE
docs(azure-iot-device): Updating samples to support running as IoT Edge modules

### DIFF
--- a/azure-iot-device/samples/async-edge-scenarios/receive_twin_desired_properties_patch.py
+++ b/azure-iot-device/samples/async-edge-scenarios/receive_twin_desired_properties_patch.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 
 import asyncio
+import time
 from six.moves import input
 from azure.iot.device.aio import IoTHubModuleClient
 
@@ -27,10 +28,14 @@ async def main():
     # define behavior for halting the application
     def stdin_listener():
         while True:
-            selection = input("Press Q to quit\n")
-            if selection == "Q" or selection == "q":
-                print("Quitting...")
-                break
+            try:
+                selection = input("Press Q to quit\n")
+                if selection == "Q" or selection == "q":
+                    print("Quitting...")
+                    break
+            except EOFError as err:
+                print("Unexpcted error occured", str(err))
+                time.sleep(100)
 
     # Run the stdin listener in the event loop
     loop = asyncio.get_running_loop()

--- a/azure-iot-device/samples/async-hub-scenarios/receive_direct_method.py
+++ b/azure-iot-device/samples/async-hub-scenarios/receive_direct_method.py
@@ -7,6 +7,7 @@
 import os
 import asyncio
 import threading
+import time
 from six.moves import input
 from azure.iot.device.aio import IoTHubDeviceClient
 from azure.iot.device import MethodResponse
@@ -48,10 +49,14 @@ async def main():
     # Define behavior for halting the application
     def stdin_listener():
         while True:
-            selection = input("Press Q to quit\n")
-            if selection == "Q" or selection == "q":
-                print("Quitting...")
-                break
+            try:
+                selection = input("Press Q to quit\n")
+                if selection == "Q" or selection == "q":
+                    print("Quitting...")
+                    break
+            except EOFError as err:
+                print("Unexpcted error occured", str(err))
+                time.sleep(100)
 
     # Run the stdin listener in the event loop
     loop = asyncio.get_running_loop()

--- a/azure-iot-device/samples/async-hub-scenarios/receive_message.py
+++ b/azure-iot-device/samples/async-hub-scenarios/receive_message.py
@@ -6,6 +6,7 @@
 
 import os
 import asyncio
+import time
 from six.moves import input
 import threading
 from azure.iot.device.aio import IoTHubDeviceClient
@@ -36,10 +37,14 @@ async def main():
     # define behavior for halting the application
     def stdin_listener():
         while True:
-            selection = input("Press Q to quit\n")
-            if selection == "Q" or selection == "q":
-                print("Quitting...")
-                break
+            try:
+                selection = input("Press Q to quit\n")
+                if selection == "Q" or selection == "q":
+                    print("Quitting...")
+                    break
+            except EOFError as err:
+                print("Unexpcted error occured", str(err))
+                time.sleep(100)
 
     # Run the stdin listener in the event loop
     loop = asyncio.get_running_loop()

--- a/azure-iot-device/samples/async-hub-scenarios/receive_message_x509.py
+++ b/azure-iot-device/samples/async-hub-scenarios/receive_message_x509.py
@@ -6,6 +6,7 @@
 
 import os
 import asyncio
+import time
 from six.moves import input
 from azure.iot.device.aio import IoTHubDeviceClient
 from azure.iot.device import X509
@@ -43,10 +44,14 @@ async def main():
     # Define behavior for halting the application
     def stdin_listener():
         while True:
-            selection = input("Press Q to quit\n")
-            if selection == "Q" or selection == "q":
-                print("Quitting...")
-                break
+            try:
+                selection = input("Press Q to quit\n")
+                if selection == "Q" or selection == "q":
+                    print("Quitting...")
+                    break
+            except EOFError as err:
+                print("Unexpcted error occured", str(err))
+                time.sleep(100)
 
     # Run the stdin listener in the event loop
     loop = asyncio.get_running_loop()

--- a/azure-iot-device/samples/async-hub-scenarios/receive_twin_desired_properties_patch.py
+++ b/azure-iot-device/samples/async-hub-scenarios/receive_twin_desired_properties_patch.py
@@ -6,6 +6,7 @@
 
 import os
 import asyncio
+import time
 from six.moves import input
 import threading
 from azure.iot.device.aio import IoTHubDeviceClient
@@ -31,10 +32,14 @@ async def main():
     # define behavior for halting the application
     def stdin_listener():
         while True:
-            selection = input("Press Q to quit\n")
-            if selection == "Q" or selection == "q":
-                print("Quitting...")
-                break
+            try:
+                selection = input("Press Q to quit\n")
+                if selection == "Q" or selection == "q":
+                    print("Quitting...")
+                    break
+            except EOFError as err:
+                print("Unexpcted error occured", str(err))
+                time.sleep(100)
 
     # Run the stdin listener in the event loop
     loop = asyncio.get_running_loop()

--- a/azure-iot-device/samples/async-hub-scenarios/use_custom_sastoken.py
+++ b/azure-iot-device/samples/async-hub-scenarios/use_custom_sastoken.py
@@ -47,10 +47,14 @@ async def main():
     # define behavior for halting the application
     def stdin_listener():
         while True:
-            selection = input("Press Q to quit\n")
-            if selection == "Q" or selection == "q":
-                print("Quitting...")
-                break
+            try:
+                selection = input("Press Q to quit\n")
+                if selection == "Q" or selection == "q":
+                    print("Quitting...")
+                    break
+            except EOFError as err:
+                print("Unexpcted error occured", str(err))
+                time.sleep(100)
 
     # define behavior for providing new sastokens to prevent expiry
     async def sastoken_keepalive():

--- a/azure-iot-device/samples/pnp/simple_thermostat.py
+++ b/azure-iot-device/samples/pnp/simple_thermostat.py
@@ -8,6 +8,7 @@ import asyncio
 import random
 import logging
 import json
+import time
 
 from azure.iot.device.aio import IoTHubDeviceClient
 from azure.iot.device.aio import ProvisioningDeviceClient
@@ -181,15 +182,17 @@ async def execute_property_listener(device_client):
 # An # END KEYBOARD INPUT LISTENER to quit application
 
 
+
 def stdin_listener():
-    """
-    Listener for quitting the sample
-    """
     while True:
-        selection = input("Press Q to quit\n")
-        if selection == "Q" or selection == "q":
-            print("Quitting...")
-            break
+        try:
+            selection = input("Press Q to quit\n")
+            if selection == "Q" or selection == "q":
+                print("Quitting...")
+                break
+        except EOFError as err:
+            print("Unexpcted error occured", str(err))
+            time.sleep(100)
 
 
 # END KEYBOARD INPUT LISTENER

--- a/azure-iot-device/samples/pnp/temp_controller_with_thermostats.py
+++ b/azure-iot-device/samples/pnp/temp_controller_with_thermostats.py
@@ -8,6 +8,7 @@ import asyncio
 import random
 import logging
 import json
+import time
 
 from azure.iot.device.aio import IoTHubDeviceClient
 from azure.iot.device.aio import ProvisioningDeviceClient
@@ -232,14 +233,15 @@ async def execute_property_listener(device_client):
 
 
 def stdin_listener():
-    """
-    Listener for quitting the sample
-    """
     while True:
-        selection = input("Press Q to quit\n")
-        if selection == "Q" or selection == "q":
-            print("Quitting...")
-            break
+        try:
+            selection = input("Press Q to quit\n")
+            if selection == "Q" or selection == "q":
+                print("Quitting...")
+                break
+        except EOFError as err:
+            print("Unexpcted error occured", str(err))
+            time.sleep(100)
 
 
 # END KEYBOARD INPUT LISTENER


### PR DESCRIPTION
## Description of the problem

Running any sample under azure-iot-device that prompts for user input from stdin directly as modules in IoT Edge will throw an EOF error. Since these modules are executed as non-interactive containers, stdin will not be attached which causes the input method to throw an EOF error and the module to exit prematurely.

## Description of the solution

Placing a try except around the input method for the EOF error and forcing the stdin_listener method to sleep instead fixes this issue. Please let me know if there is a better way to get around this issue or if I should make any updates to this PR.