### PR TITLE
fix (azure-iot-device): Patching script adjustments for properties

### DIFF
--- a/azure-iot-device/azure/iot/device/aio/patch_documentation.py
+++ b/azure-iot-device/azure/iot/device/aio/patch_documentation.py
@@ -121,6 +121,19 @@ def execute_patch_for_async():
         "create_from_x509_certificate",
         classmethod(create_from_x509_certificate),
     )
+
+    setattr(IoTHubDeviceClient_, "connected", IoTHubDeviceClient_.connected)
+    setattr(
+        IoTHubDeviceClient_,
+        "on_method_request_received",
+        IoTHubDeviceClient_.on_method_request_received,
+    )
+    setattr(
+        IoTHubDeviceClient_,
+        "on_twin_desired_properties_patch_received",
+        IoTHubDeviceClient_.on_twin_desired_properties_patch_received,
+    )
+
     from azure.iot.device.iothub.aio.async_clients import IoTHubModuleClient as IoTHubModuleClient_
 
     async def shutdown(self):
@@ -234,6 +247,19 @@ def execute_patch_for_async():
         "create_from_x509_certificate",
         classmethod(create_from_x509_certificate),
     )
+
+    setattr(IoTHubModuleClient_, "connected", IoTHubModuleClient_.connected)
+    setattr(
+        IoTHubModuleClient_,
+        "on_method_request_received",
+        IoTHubModuleClient_.on_method_request_received,
+    )
+    setattr(
+        IoTHubModuleClient_,
+        "on_twin_desired_properties_patch_received",
+        IoTHubModuleClient_.on_twin_desired_properties_patch_received,
+    )
+
     from azure.iot.device.provisioning.aio.async_provisioning_device_client import (
         ProvisioningDeviceClient as ProvisioningDeviceClient_,
     )

--- a/azure-iot-device/azure/iot/device/aio/patch_documentation.py
+++ b/azure-iot-device/azure/iot/device/aio/patch_documentation.py
@@ -10,6 +10,12 @@ Currently we have to do like this so that we don't use exec anywhere"""
 def execute_patch_for_async():
     from azure.iot.device.iothub.aio.async_clients import IoTHubDeviceClient as IoTHubDeviceClient_
 
+    async def shutdown(self):
+        return await super(IoTHubDeviceClient_, self).shutdown()
+
+    shutdown.__doc__ = IoTHubDeviceClient_.shutdown.__doc__
+    setattr(IoTHubDeviceClient_, "shutdown", shutdown)
+
     async def connect(self):
         return await super(IoTHubDeviceClient_, self).connect()
 
@@ -116,6 +122,12 @@ def execute_patch_for_async():
         classmethod(create_from_x509_certificate),
     )
     from azure.iot.device.iothub.aio.async_clients import IoTHubModuleClient as IoTHubModuleClient_
+
+    async def shutdown(self):
+        return await super(IoTHubModuleClient_, self).shutdown()
+
+    shutdown.__doc__ = IoTHubModuleClient_.shutdown.__doc__
+    setattr(IoTHubModuleClient_, "shutdown", shutdown)
 
     async def connect(self):
         return await super(IoTHubModuleClient_, self).connect()

--- a/azure-iot-device/azure/iot/device/patch.py
+++ b/azure-iot-device/azure/iot/device/patch.py
@@ -40,6 +40,9 @@ def add_shims_for_inherited_methods(target_class):
     class_methods = inspect.getmembers(target_class, predicate=inspect.ismethod)
     all_methods = class_functions + class_methods
 
+    # Also get properties
+    class_properties = inspect.getmembers(target_class, predicate=inspect.isdatadescriptor)
+
     # This list of attributes gives us a lot of information, but we only are using it to get
     # the defining class of a given method.
     class_attributes = inspect.classify_class_attrs(target_class)
@@ -140,3 +143,18 @@ def add_shims_for_inherited_methods(target_class):
     # NOTE: the __qualname__ attributes of these new shim methods are merely the method name,
     # rather than <class_name>.<method_name>, due to the scoping of the definition.
     # This shouldn't matter, but in case it does, I am documenting that fact here.
+
+    for prop in class_properties:
+        property_name = prop[0]
+        # We can index on 0 here because the list comprehension will always be exactly 1 element
+        property_attribute = [att for att in class_attributes if att.name == property_name][0]
+        # The object of the class where the property was originally defined.
+        originating_class_obj = property_attribute.defining_class
+
+        # Simply redefine the same property on the leaf class if it was defined on a parent
+        if property_name[0] != "_" and originating_class_obj != target_class:
+            attach_property_cmdstr = "setattr({leaf_class}, '{property_name}', {leaf_class}.{property_name})".format(
+                leaf_class=classname_alias, property_name=property_name
+            )
+            logger.debug("exec: " + attach_property_cmdstr)
+            # exec(attach_property_cmdstr, shim_scope)

--- a/azure-iot-device/azure/iot/device/patch.py
+++ b/azure-iot-device/azure/iot/device/patch.py
@@ -40,9 +40,6 @@ def add_shims_for_inherited_methods(target_class):
     class_methods = inspect.getmembers(target_class, predicate=inspect.ismethod)
     all_methods = class_functions + class_methods
 
-    # Also get properties
-    class_properties = inspect.getmembers(target_class, predicate=inspect.isdatadescriptor)
-
     # This list of attributes gives us a lot of information, but we only are using it to get
     # the defining class of a given method.
     class_attributes = inspect.classify_class_attrs(target_class)
@@ -144,6 +141,14 @@ def add_shims_for_inherited_methods(target_class):
     # rather than <class_name>.<method_name>, due to the scoping of the definition.
     # This shouldn't matter, but in case it does, I am documenting that fact here.
 
+    # For properties, we have a different strategy. While with methods we dynamically created
+    # redefinitions for each inherited method that called the parent class' implementation of the
+    # method, here we simply set the inherited property attribute directly onto the child.
+    # This will carry over all docstrings implicitly.
+    # We do this because properties, while defined syntactically via methods, actually are not
+    # methods directly on a class, but form a "property" object, which itself contains the
+    # get and set logic. Thus our strategy for methods can't really work here.
+    class_properties = inspect.getmembers(target_class, predicate=inspect.isdatadescriptor)
     for prop in class_properties:
         property_name = prop[0]
         # We can index on 0 here because the list comprehension will always be exactly 1 element

--- a/azure-iot-device/azure/iot/device/patch_documentation.py
+++ b/azure-iot-device/azure/iot/device/patch_documentation.py
@@ -10,6 +10,12 @@ Currently we have to do like this so that we don't use exec anywhere"""
 def execute_patch_for_sync():
     from azure.iot.device.iothub.sync_clients import IoTHubDeviceClient as IoTHubDeviceClient
 
+    def shutdown(self):
+        return super(IoTHubDeviceClient, self).shutdown()
+
+    shutdown.__doc__ = IoTHubDeviceClient.shutdown.__doc__
+    setattr(IoTHubDeviceClient, "shutdown", shutdown)
+
     def connect(self):
         return super(IoTHubDeviceClient, self).connect()
 
@@ -112,6 +118,12 @@ def execute_patch_for_sync():
         classmethod(create_from_x509_certificate),
     )
     from azure.iot.device.iothub.sync_clients import IoTHubModuleClient as IoTHubModuleClient
+
+    def shutdown(self):
+        return super(IoTHubModuleClient, self).shutdown()
+
+    shutdown.__doc__ = IoTHubModuleClient.shutdown.__doc__
+    setattr(IoTHubModuleClient, "shutdown", shutdown)
 
     def connect(self):
         return super(IoTHubModuleClient, self).connect()

--- a/azure-iot-device/azure/iot/device/patch_documentation.py
+++ b/azure-iot-device/azure/iot/device/patch_documentation.py
@@ -117,6 +117,19 @@ def execute_patch_for_sync():
         "create_from_x509_certificate",
         classmethod(create_from_x509_certificate),
     )
+
+    setattr(IoTHubDeviceClient, "connected", IoTHubDeviceClient.connected)
+    setattr(
+        IoTHubDeviceClient,
+        "on_method_request_received",
+        IoTHubDeviceClient.on_method_request_received,
+    )
+    setattr(
+        IoTHubDeviceClient,
+        "on_twin_desired_properties_patch_received",
+        IoTHubDeviceClient.on_twin_desired_properties_patch_received,
+    )
+
     from azure.iot.device.iothub.sync_clients import IoTHubModuleClient as IoTHubModuleClient
 
     def shutdown(self):
@@ -228,6 +241,19 @@ def execute_patch_for_sync():
         "create_from_x509_certificate",
         classmethod(create_from_x509_certificate),
     )
+
+    setattr(IoTHubModuleClient, "connected", IoTHubModuleClient.connected)
+    setattr(
+        IoTHubModuleClient,
+        "on_method_request_received",
+        IoTHubModuleClient.on_method_request_received,
+    )
+    setattr(
+        IoTHubModuleClient,
+        "on_twin_desired_properties_patch_received",
+        IoTHubModuleClient.on_twin_desired_properties_patch_received,
+    )
+
     from azure.iot.device.provisioning.provisioning_device_client import (
         ProvisioningDeviceClient as ProvisioningDeviceClient,
     )


### PR DESCRIPTION
* Adjusted patching scripts so client properties (incl. handlers) are dynamically moved to leaf classes from parents, so that online API documentation can correctly ingest
* Adjusted patching scripts for correct ingestion of the .shutdown() method as well
* Fixes GitHub issue #725 