### PR TITLE
release(azure-iot-device): Release 2021-02-16 Version Bump (2.5.1)

### DIFF
--- a/azure-iot-device/.bumpverion.cfg
+++ b/azure-iot-device/.bumpverion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.0
+current_version = 2.5.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 

--- a/azure-iot-device/azure/iot/device/constant.py
+++ b/azure-iot-device/azure/iot/device/constant.py
@@ -6,7 +6,7 @@
 """This module defines constants for use across the azure-iot-device package
 """
 
-VERSION = "2.5.0"
+VERSION = "2.5.1"
 IOTHUB_IDENTIFIER = "azure-iot-device-iothub-py"
 PROVISIONING_IDENTIFIER = "azure-iot-device-provisioning-py"
 IOTHUB_API_VERSION = "2019-10-01"


### PR DESCRIPTION
* Bump versions for azure-iot-device 2.5.1