### PR TITLE
feature(azure-iot-device): DisconnectOperation now cancels in-flight operations in MQTTTransport

### DIFF
--- a/azure-iot-device/azure/iot/device/common/mqtt_transport.py
+++ b/azure-iot-device/azure/iot/device/common/mqtt_transport.py
@@ -436,7 +436,7 @@ class MQTTTransport(object):
             raise _create_error_from_rc_code(rc)
         self._mqtt_client.loop_start()
 
-    def disconnect(self):
+    def disconnect(self, clear_pending=False):
         """
         Disconnect from the MQTT broker.
 
@@ -464,9 +464,12 @@ class MQTTTransport(object):
             err = _create_error_from_rc_code(rc)
             raise err
         else:
-            # Clear all pending items in operation manager
-            # TODO: should this be here, or in on_disconnect handler
-            self._op_manager.cancel_all_operations()
+            # Clear pending ops if instructed, but only if the disconnect was successful.
+            # Technically the disconnect could still fail upon response, however that would then
+            # cause a force disconnect via the on_disconnect handler, thus it is safe to clear
+            # ops here and now.
+            if clear_pending:
+                self._op_manager.cancel_all_operations()
 
     def subscribe(self, topic, qos=1, callback=None):
         """

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
@@ -840,7 +840,7 @@ class RetryStage(PipelineStage):
         Return True if this op needs to be retried.  This must be called after
         the op completes.
         """
-        if error:
+        if error and not isinstance(error, pipeline_exceptions.OperationCancelled):
             if self._should_watch_for_retry(op):
                 if isinstance(error, pipeline_exceptions.PipelineTimeoutError):
                     return True

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
@@ -198,10 +198,25 @@ class MQTTTransportStage(PipelineStage):
                 self._pending_connection_op = None
                 op.complete(error=e)
 
-        elif isinstance(op, pipeline_ops_base.DisconnectOperation) or isinstance(
-            op, pipeline_ops_base.ReauthorizeConnectionOperation
-        ):
-            logger.debug("{}({}): disconnecting or reauthorizing".format(self.name, op.name))
+        elif isinstance(op, pipeline_ops_base.DisconnectOperation):
+            logger.debug("{}({}): disconnecting".format(self.name, op.name))
+
+            self._cancel_pending_connection_op()
+            self._pending_connection_op = op
+            # We don't need a watchdog on disconnect because there's no callback to wait for
+            # and we respond to a watchdog timeout by calling disconnect, which is what we're
+            # already doing.
+
+            try:
+                self.transport.disconnect(clear_pending=True)
+            except Exception as e:
+                logger.info("transport.disconnect raised error while disconnecting")
+                logger.info(traceback.format_exc())
+                self._pending_connection_op = None
+                op.complete(error=e)
+
+        elif isinstance(op, pipeline_ops_base.ReauthorizeConnectionOperation):
+            logger.debug("{}({}): reauthorizing".format(self.name, op.name))
 
             self._cancel_pending_connection_op()
             self._pending_connection_op = op
@@ -212,7 +227,7 @@ class MQTTTransportStage(PipelineStage):
             try:
                 self.transport.disconnect()
             except Exception as e:
-                logger.info("transport.disconnect raised error")
+                logger.info("transport.disconnect raised error while reauthorizing")
                 logger.info(traceback.format_exc())
                 self._pending_connection_op = None
                 op.complete(error=e)
@@ -267,7 +282,7 @@ class MQTTTransportStage(PipelineStage):
             logger.debug("{}({}): unsubscribing from {}".format(self.name, op.name, op.topic))
 
             @pipeline_thread.invoke_on_pipeline_thread_nowait
-            def on_complete(cancelled):
+            def on_complete(cancelled=False):
                 if cancelled:
                     op.complete(
                         error=pipeline_exceptions.OperationCancelled(

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_mqtt.py
@@ -221,12 +221,21 @@ class MQTTTransportStage(PipelineStage):
             logger.debug("{}({}): publishing on {}".format(self.name, op.name, op.topic))
 
             @pipeline_thread.invoke_on_pipeline_thread_nowait
-            def on_published():
-                logger.debug("{}({}): PUBACK received. completing op.".format(self.name, op.name))
-                op.complete()
+            def on_complete(cancelled=False):
+                if cancelled:
+                    op.complete(
+                        error=pipeline_exceptions.OperationCancelled(
+                            "Operation cancelled before PUBACK received"
+                        )
+                    )
+                else:
+                    logger.debug(
+                        "{}({}): PUBACK received. completing op.".format(self.name, op.name)
+                    )
+                    op.complete()
 
             try:
-                self.transport.publish(topic=op.topic, payload=op.payload, callback=on_published)
+                self.transport.publish(topic=op.topic, payload=op.payload, callback=on_complete)
             except transport_exceptions.ConnectionDroppedError:
                 self.send_event_up(pipeline_events_base.DisconnectedEvent())
                 raise
@@ -235,12 +244,21 @@ class MQTTTransportStage(PipelineStage):
             logger.debug("{}({}): subscribing to {}".format(self.name, op.name, op.topic))
 
             @pipeline_thread.invoke_on_pipeline_thread_nowait
-            def on_subscribed():
-                logger.debug("{}({}): SUBACK received. completing op.".format(self.name, op.name))
-                op.complete()
+            def on_complete(cancelled=False):
+                if cancelled:
+                    op.complete(
+                        error=pipeline_exceptions.OperationCancelled(
+                            "Operation cancelled before SUBACK received"
+                        )
+                    )
+                else:
+                    logger.debug(
+                        "{}({}): SUBACK received. completing op.".format(self.name, op.name)
+                    )
+                    op.complete()
 
             try:
-                self.transport.subscribe(topic=op.topic, callback=on_subscribed)
+                self.transport.subscribe(topic=op.topic, callback=on_complete)
             except transport_exceptions.ConnectionDroppedError:
                 self.send_event_up(pipeline_events_base.DisconnectedEvent())
                 raise
@@ -249,14 +267,21 @@ class MQTTTransportStage(PipelineStage):
             logger.debug("{}({}): unsubscribing from {}".format(self.name, op.name, op.topic))
 
             @pipeline_thread.invoke_on_pipeline_thread_nowait
-            def on_unsubscribed():
-                logger.debug(
-                    "{}({}): UNSUBACK received.  completing op.".format(self.name, op.name)
-                )
-                op.complete()
+            def on_complete(cancelled):
+                if cancelled:
+                    op.complete(
+                        error=pipeline_exceptions.OperationCancelled(
+                            "Operation cancelled before UNSUBACK received"
+                        )
+                    )
+                else:
+                    logger.debug(
+                        "{}({}): UNSUBACK received.  completing op.".format(self.name, op.name)
+                    )
+                    op.complete()
 
             try:
-                self.transport.unsubscribe(topic=op.topic, callback=on_unsubscribed)
+                self.transport.unsubscribe(topic=op.topic, callback=on_complete)
             except transport_exceptions.ConnectionDroppedError:
                 self.send_event_up(pipeline_events_base.DisconnectedEvent())
                 raise


### PR DESCRIPTION
* DisconnectOperations now will clear other pending operations from the OperationManager in the MQTTTransport
* The cleared operations will be completed with an OperationCancelled exception
* This does NOT change ReauthorizeConnectionOperation behavior