### PR TITLE
change urllib3 versions to avoid warnings

### DIFF
--- a/azure-iot-device/setup.py
+++ b/azure-iot-device/setup.py
@@ -77,9 +77,7 @@ setup(
         # https://github.com/pypa/pip/issues/988
         # ---requests dependencies---
         # requests 2.22+ does not support urllib3 1.25.0 or 1.25.1 (https://github.com/psf/requests/pull/5092)
-        # requests 2.22+ is not compatible with python34, so we must use 2.20 which is only compat w/ urllib < 1.25
-        "urllib3>1.21.1,<1.26,!=1.25.0,!=1.25.1;python_version!='3.4'",
-        "urllib3>1.21.1,<1.25;python_version=='3.4'",
+        "urllib3>1.21.1,<1.27,!=1.25.0,!=1.25.1",
         # Actual project dependencies
         "deprecation>=2.1.0,<3.0.0",
         "six>=1.12.0,<2.0.0",


### PR DESCRIPTION
requests can support urllib3 1.26.x.  This change avoids a warning since we say that we don't support 1.26, when we don't really care.