### PR TITLE
fix(azure-iot-hub): Fix support for AAD authentication in Fairfax hubs

### DIFF
--- a/azure-iot-hub/azure/iot/hub/auth.py
+++ b/azure-iot-hub/azure/iot/hub/auth.py
@@ -65,12 +65,23 @@ class ConnectionStringAuthentication(ConnectionString, Authentication):
 
 
 class AzureIdentityCredentialAdapter(BasicTokenAuthentication):
-    def __init__(self, credential, resource_id="https://iothubs.azure.net/.default", **kwargs):
+    def __init__(self, credential, resource_id=None, service_endpoint=None, **kwargs):
         """Adapt any azure-identity credential to work with SDK that needs azure.common.credentials or msrestazure.
         Default resource is ARM (syntax of endpoint v2)
         :param credential: Any azure-identity credential (DefaultAzureCredential by default)
         :param str resource_id: The scope to use to get the token (default ARM)
+        :param str service_endpont: The endpoint of the IoT Hub
         """
+        if (
+            resource_id is None
+            and service_endpoint is not None
+            and service_endpoint.lower().endswith("azure-devices.us")
+        ):
+            # The US government cloud (Fairfax) has a different audience.
+            resource_id = "https://iothubs.azure.us"
+        elif resource_id is None:
+            resource_id = "https://iothubs.azure.net/.default"
+
         super(AzureIdentityCredentialAdapter, self).__init__(None)
         self._policy = BearerTokenCredentialPolicy(credential, resource_id, **kwargs)
 

--- a/azure-iot-hub/azure/iot/hub/digital_twin_client.py
+++ b/azure-iot-hub/azure/iot/hub/digital_twin_client.py
@@ -64,7 +64,7 @@ class DigitalTwinClient(object):
         :rtype: :class:`azure.iot.hub.DigitalTwinClient`
         """
         host = url
-        auth = AzureIdentityCredentialAdapter(token_credential)
+        auth = AzureIdentityCredentialAdapter(token_credential, None, host)
         return cls(host=host, auth=auth)
 
     def get_digital_twin(self, digital_twin_id):

--- a/azure-iot-hub/azure/iot/hub/iothub_configuration_manager.py
+++ b/azure-iot-hub/azure/iot/hub/iothub_configuration_manager.py
@@ -66,7 +66,7 @@ class IoTHubConfigurationManager(object):
         :rtype: :class:`azure.iot.hub.IoTHubConfigurationManager`
         """
         host = url
-        auth = AzureIdentityCredentialAdapter(token_credential)
+        auth = AzureIdentityCredentialAdapter(token_credential, None, host)
         return cls(host=host, auth=auth)
 
     def get_configuration(self, configuration_id):

--- a/azure-iot-hub/azure/iot/hub/iothub_http_runtime_manager.py
+++ b/azure-iot-hub/azure/iot/hub/iothub_http_runtime_manager.py
@@ -65,7 +65,7 @@ class IoTHubHttpRuntimeManager(object):
         :rtype: :class:`azure.iot.hub.IoTHubHttpRuntimeManager`
         """
         host = url
-        auth = AzureIdentityCredentialAdapter(token_credential)
+        auth = AzureIdentityCredentialAdapter(token_credential, None, host)
         return cls(host=host, auth=auth)
 
     def receive_feedback_notification(self):

--- a/azure-iot-hub/azure/iot/hub/iothub_job_manager.py
+++ b/azure-iot-hub/azure/iot/hub/iothub_job_manager.py
@@ -65,7 +65,7 @@ class IoTHubJobManager(object):
         :rtype: :class:`azure.iot.hub.IoTHubJobManager`
         """
         host = url
-        auth = AzureIdentityCredentialAdapter(token_credential)
+        auth = AzureIdentityCredentialAdapter(token_credential, None, host)
         return cls(host=host, auth=auth)
 
     def create_import_export_job(self, job_properties):

--- a/azure-iot-hub/azure/iot/hub/iothub_registry_manager.py
+++ b/azure-iot-hub/azure/iot/hub/iothub_registry_manager.py
@@ -114,7 +114,7 @@ class IoTHubRegistryManager(object):
         :rtype: :class:`azure.iot.hub.IoTHubRegistryManager`
         """
         host = url
-        auth = AzureIdentityCredentialAdapter(token_credential)
+        auth = AzureIdentityCredentialAdapter(token_credential, None, host)
         return cls(host=host, auth=auth)
 
     def __del__(self):


### PR DESCRIPTION
The token audience for hubs in Fairfax needs to be different from from other hubs. 