### PR TITLE
feature(azure-iot-device): Added internal PNP mode

### DIFF
--- a/azure-iot-device/azure/iot/device/iothub/__init__.py
+++ b/azure-iot-device/azure/iot/device/iothub/__init__.py
@@ -5,6 +5,14 @@ as a Device or Module.
 """
 
 from .sync_clients import IoTHubDeviceClient, IoTHubModuleClient
-from .models import Message, MethodRequest, MethodResponse
+from .models import (
+    Message,
+    MethodRequest,
+    MethodResponse,
+    Command,
+    CommandResponse,
+    WritableProperty,
+    WritablePropertyResponse,
+)
 
 __all__ = ["IoTHubDeviceClient", "IoTHubModuleClient", "Message", "MethodRequest", "MethodResponse"]

--- a/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
@@ -17,6 +17,7 @@ from . import pipeline
 from .pipeline import constant as pipeline_constant
 from azure.iot.device.common.auth import connection_string as cs
 from azure.iot.device.common.auth import sastoken as st
+from azure.iot.device.iothub.models import pnp_translation
 from azure.iot.device.iothub import client_event
 from azure.iot.device import exceptions
 from azure.iot.device.common import auth
@@ -135,6 +136,11 @@ class AbstractIoTHubClient(object):
         self._receive_type = RECEIVE_TYPE_NONE_SET
         self._client_mode = client_mode
         self._client_lock = threading.Lock()
+
+        # Unwrapped PNP handlers. These are not used within the client (we instead use wrapped
+        # versions), but we cache them so we can return them to the user if they ask for them
+        self._on_command_received_unwrapped = None
+        self._on_writable_property_patch_received_unwrapped = None
 
     def _on_connected(self):
         """Helper handler that is called upon an iothub pipeline connect"""
@@ -435,6 +441,31 @@ class AbstractIoTHubClient(object):
     def receive_twin_desired_properties_patch(self):
         pass
 
+    # @abc.abstractmethod
+    # def send_telemetry(self, telemetry_dict, component_name=None):
+    # (dict, str) -> None
+    # pass
+
+    # @abc.abstractmethod
+    # def send_command_response(self, command, payload, status):
+    # (Command, object, int) -> None
+    # pass
+
+    # @abc.abstractmethod
+    # def get_properties(self):
+    # () -> Properties
+    # pass
+
+    # @abc.abstractmethod
+    # def get_writable_properties(self):
+    # () -> WritableProperties
+    # pass
+
+    # @abc.abstractmethod
+    # def send_property_patch(self, property_patch):
+    # (Properties) -> None
+    # pass
+
     @property
     def connected(self):
         """
@@ -477,10 +508,14 @@ class AbstractIoTHubClient(object):
 
         The function or coroutine definition should take one positional argument (the
         :class:`azure.iot.device.MethodRequest` object)"""
-        return self._handler_manager.on_method_request_received
+        if self._client_mode is CLIENT_MODE_BASIC:
+            return self._handler_manager.on_method_request_received
+        else:
+            return None
 
     @on_method_request_received.setter
     def on_method_request_received(self, value):
+        self._check_client_mode_is_basic()
         self._generic_receive_handler_setter(
             "on_method_request_received", pipeline_constant.METHODS, value
         )
@@ -492,48 +527,80 @@ class AbstractIoTHubClient(object):
 
         The function or coroutine definition should take one positional argument (the twin patch
         in the form of a JSON dictionary object)"""
-        return self._handler_manager.on_twin_desired_properties_patch_received
+        if self._client_mode is CLIENT_MODE_BASIC:
+            return self._handler_manager.on_twin_desired_properties_patch_received
+        else:
+            return None
 
     @on_twin_desired_properties_patch_received.setter
     def on_twin_desired_properties_patch_received(self, value):
+        self._check_client_mode_is_basic()
         self._generic_receive_handler_setter(
             "on_twin_desired_properties_patch_received", pipeline_constant.TWIN_PATCHES, value
         )
 
-    # @abc.abstractmethod
-    # def send_telemetry(self, telemetry_dict, component_name=None):
-    # (dict, str) -> None
-    # pass
+    @property
+    def on_command_received(self):
+        """The handler function or coroutine that will be called when a command is received.
 
-    # @abc.abstractproperty
-    # def on_command_received(self):
-    # ((Command) -> None) -> None
-    # pass
+        The function or coroutine definition should take one positional argument (the
+        :class:`azure.iot.device.Command` object)
+        """
+        if self._client_mode is CLIENT_MODE_PNP:
+            return self._on_command_received_unwrapped
+        else:
+            return None
 
-    # @abc.abstractmethod
-    # def send_command_response(self, command, payload, status):
-    # (Command, object, int) -> None
-    # pass
+    @on_command_received.setter
+    def on_command_received(self, value):
+        self._check_client_mode_is_pnp()
 
-    # @abc.abstractmethod
-    # def get_properties(self):
-    # () -> Properties
-    # pass
+        # Generate a wrapper around the user provided handler that will turn a MethodRequest into
+        # a Command, then invoke the user's handler
+        translation_wrapper = self._generate_pnp_handler_translation_wrapper(
+            handler_to_wrap=value, translation_fn=pnp_translation.method_request_to_command
+        )
 
-    # @abc.abstractmethod
-    # def get_writable_properties(self):
-    # () -> WritableProperties
-    # pass
+        # Set this wrapper as a handler on the HandlerManager
+        self._generic_receive_handler_setter(
+            "on_method_request_received", pipeline_constant.METHODS, translation_wrapper
+        )
 
-    # @abc.absractproperty
-    # def on_writable_property_patch_received(self):
-    # ((WritableProperties) -> None) -> None
-    # pass
+        # Cache the unwrapped handler so we can return it to user later
+        self._on_command_received_unwrapped = value
 
-    # @abc.abstractmethod
-    # def send_property_patch(self, property_patch):
-    # (Properties) -> None
-    # pass
+    @property
+    def on_writable_property_patch_received(self):
+        """The handler function or coroutine that will be called when a writable property patch
+        is received.
+
+        The function or coroutine definition should take one positional argument (the
+        :class:`azure.iot.device.WritableProperty` object)
+        """
+        if self._client_mode is CLIENT_MODE_PNP:
+            return self._on_writable_property_patch_received_unwrapped
+        else:
+            return None
+
+    @on_writable_property_patch_received.setter
+    def on_writable_property_patch_received(self, value):
+        self._check_client_mode_is_pnp()
+
+        # Generate a wrapper around the user provided handler that will turn a twin patch into
+        # a WritableProperty, then invoke the user's handler
+        translation_wrapper = self._generate_pnp_handler_translation_wrapper(
+            handler_to_wrap=value, translation_fn=pnp_translation.twin_patch_to_writable_property
+        )
+
+        # Set this wrapper as a handler on the HandlerManager
+        self._generic_receive_handler_setter(
+            "on_twin_desired_properties_patch_received",
+            pipeline_constant.TWIN_PATCHES,
+            translation_wrapper,
+        )
+
+        # Cache the unwrapped handler so we can return it to user later
+        self._on_writable_property_patch_received_unwrapped = value
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
@@ -189,6 +189,16 @@ class AbstractIoTHubClient(object):
             else:
                 pass
 
+    def _check_client_mode_is_basic(self):
+        """Call this method first in any feature restricted to a basic client"""
+        if self._client_mode is not CLIENT_MODE_BASIC:
+            raise exceptions.ClientError("This feature is restricted to using a non-PNP client")
+
+    def _check_client_mode_is_pnp(self):
+        """Call this method first when using any feature restricted to a PNP client"""
+        if self._client_mode is not CLIENT_MODE_PNP:
+            raise exceptions.ClientError("This feature is restricted to using PNP")
+
     def _replace_user_supplied_sastoken(self, sastoken_str):
         """
         Replaces the pipeline's NonRenewableSasToken with a new one based on a provided

--- a/azure-iot-device/azure/iot/device/iothub/aio/async_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/aio/async_clients.py
@@ -70,6 +70,7 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         :type mqtt_pipeline: :class:`azure.iot.device.iothub.pipeline.MQTTPipeline`
         :param http_pipeline: The HTTPPipeline used for the client
         :type http_pipeline: :class:`azure.iot.device.iothub.pipeline.HTTPPipeline`
+        :param str client_mode: The client mode (CLIENT_MODE_BASIC or CLIENT_MODE_PNP)
         """
         # Depending on the subclass calling this __init__, there could be different arguments,
         # and the super() call could call a different class, due to the different MROs
@@ -523,7 +524,7 @@ class IoTHubDeviceClient(GenericIoTHubClient, AbstractIoTHubDeviceClient):
     Intended for usage with Python 3.5.3+
     """
 
-    def __init__(self, mqtt_pipeline, http_pipeline):
+    def __init__(self, mqtt_pipeline, http_pipeline, client_mode):
         """Initializer for a IoTHubDeviceClient.
 
         This initializer should not be called directly.
@@ -531,8 +532,13 @@ class IoTHubDeviceClient(GenericIoTHubClient, AbstractIoTHubDeviceClient):
 
         :param mqtt_pipeline: The pipeline used to connect to the IoTHub endpoint.
         :type mqtt_pipeline: :class:`azure.iot.device.iothub.pipeline.MQTTPipeline`
+        :param http_pipeline: The pipeline used to connect to the IoTHub endpoint via HTTP.
+        :type http_pipeline: :class:`azure.iot.device.iothub.pipeline.HTTPPipeline`
+        :param str client_mode: The client mode (CLIENT_MODE_BASIC or CLIENT_MODE_PNP)
         """
-        super().__init__(mqtt_pipeline=mqtt_pipeline, http_pipeline=http_pipeline)
+        super().__init__(
+            mqtt_pipeline=mqtt_pipeline, http_pipeline=http_pipeline, client_mode=client_mode
+        )
         self._mqtt_pipeline.on_c2d_message_received = self._inbox_manager.route_c2d_message
 
     @deprecation.deprecated(
@@ -620,7 +626,7 @@ class IoTHubModuleClient(GenericIoTHubClient, AbstractIoTHubModuleClient):
     Intended for usage with Python 3.5.3+
     """
 
-    def __init__(self, mqtt_pipeline, http_pipeline):
+    def __init__(self, mqtt_pipeline, http_pipeline, client_mode):
         """Intializer for a IoTHubModuleClient.
 
         This initializer should not be called directly.
@@ -628,8 +634,13 @@ class IoTHubModuleClient(GenericIoTHubClient, AbstractIoTHubModuleClient):
 
         :param mqtt_pipeline: The pipeline used to connect to the IoTHub endpoint.
         :type mqtt_pipeline: :class:`azure.iot.device.iothub.pipeline.MQTTPipeline`
+        :param http_pipeline: The pipeline used to connect to the IoTHub endpoint via HTTP.
+        :type http_pipeline: :class:`azure.iot.device.iothub.pipeline.HTTPPipeline`
+        :param str client_mode: The client mode (CLIENT_MODE_BASIC or CLIENT_MODE_PNP)
         """
-        super().__init__(mqtt_pipeline=mqtt_pipeline, http_pipeline=http_pipeline)
+        super().__init__(
+            mqtt_pipeline=mqtt_pipeline, http_pipeline=http_pipeline, client_mode=client_mode
+        )
         self._mqtt_pipeline.on_input_message_received = self._inbox_manager.route_input_message
 
     async def send_message_to_output(self, message, output_name):

--- a/azure-iot-device/azure/iot/device/iothub/aio/async_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/aio/async_clients.py
@@ -282,6 +282,8 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         If the connection to the service has not previously been opened by a call to connect, this
         function will open the connection before sending the event.
 
+        This method is not compatible with PNP.
+
         :param message: The actual message to send. Anything passed that is not an instance of the
             Message class will be converted to Message object.
         :type message: :class:`azure.iot.device.Message` or str
@@ -294,10 +296,13 @@ class GenericIoTHubClient(AbstractIoTHubClient):
             during execution.
         :raises: :class:`azure.iot.device.exceptions.NoConnectionError` if the client is not
             connected (and there is no auto-connect enabled)
+        :raises: :class:`azure.iot.device.exceptions.ClientError` if using PNP mode
         :raises: :class:`azure.iot.device.exceptions.ClientError` if there is an unexpected failure
             during execution.
         :raises: ValueError if the message fails size validation.
         """
+        self._check_client_mode_is_basic()
+
         if not isinstance(message, Message):
             message = Message(message)
 
@@ -323,6 +328,9 @@ class GenericIoTHubClient(AbstractIoTHubClient):
 
         If no method request is yet available, will wait until it is available.
 
+        This method cannot be used when using handlers.
+        This method is not compatible with PNP.
+
         :param str method_name: Optionally provide the name of the method to receive requests for.
             If this parameter is not given, all methods not already being specifically targeted by
             a different call to receive_method will be received.
@@ -331,6 +339,7 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         :rtype: :class:`azure.iot.device.MethodRequest`
         """
         self._check_receive_mode_is_api()
+        self._check_client_mode_is_basic()
 
         if not self._mqtt_pipeline.feature_enabled[constant.METHODS]:
             await self._enable_feature(constant.METHODS)
@@ -348,6 +357,8 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         If the connection to the service has not previously been opened by a call to connect, this
         function will open the connection before sending the event.
 
+        This method is not compatible with PNP.
+
         :param method_response: The MethodResponse to send
         :type method_response: :class:`azure.iot.device.MethodResponse`
 
@@ -362,6 +373,8 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         :raises: :class:`azure.iot.device.exceptions.ClientError` if there is an unexpected failure
             during execution.
         """
+        self._check_client_mode_is_basic()
+
         logger.info("Sending method response to Hub...")
         send_method_response_async = async_adapter.emulate_async(
             self._mqtt_pipeline.send_method_response
@@ -427,6 +440,8 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         :raises: :class:`azure.iot.device.exceptions.ClientError` if there is an unexpected failure
             during execution.
         """
+        self._check_client_mode_is_basic()
+
         logger.info("Patching twin reported properties")
 
         if not self._mqtt_pipeline.feature_enabled[constant.TWIN]:
@@ -453,10 +468,14 @@ class GenericIoTHubClient(AbstractIoTHubClient):
 
         If no method request is yet available, will wait until it is available.
 
+        This method cannot be used when using handlers.
+        This method is not compatible with PNP.
+
         :returns: Twin Desired Properties patch as a JSON dict
         :rtype: dict
         """
         self._check_receive_mode_is_api()
+        self._check_client_mode_is_basic()
 
         if not self._mqtt_pipeline.feature_enabled[constant.TWIN_PATCHES]:
             await self._enable_feature(constant.TWIN_PATCHES)
@@ -550,6 +569,8 @@ class IoTHubDeviceClient(GenericIoTHubClient, AbstractIoTHubDeviceClient):
         """Receive a message that has been sent from the Azure IoT Hub.
 
         If no message is yet available, will wait until an item is available.
+
+        This method cannot be used when using handlers.
 
         :returns: Message that was sent from the Azure IoT Hub.
         :rtype: :class:`azure.iot.device.Message`
@@ -696,6 +717,8 @@ class IoTHubModuleClient(GenericIoTHubClient, AbstractIoTHubModuleClient):
         """Receive an input message that has been sent from another Module to a specific input.
 
         If no message is yet available, will wait until an item is available.
+
+        This method cannot be used when using handlers.
 
         :param str input_name: The input name to receive a message on.
 

--- a/azure-iot-device/azure/iot/device/iothub/aio/async_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/aio/async_clients.py
@@ -520,6 +520,7 @@ class GenericIoTHubClient(AbstractIoTHubClient):
 
     @on_twin_desired_properties_patch_received.setter
     def on_twin_desired_properties_patch_received(self, value):
+        self._check_client_mode_is_basic()
         self._generic_receive_handler_setter(
             "on_twin_desired_properties_patch_received", constant.TWIN_PATCHES, value
         )
@@ -534,6 +535,7 @@ class GenericIoTHubClient(AbstractIoTHubClient):
 
     @on_method_request_received.setter
     def on_method_request_received(self, value):
+        self._check_client_mode_is_basic()
         self._generic_receive_handler_setter("on_method_request_received", constant.METHODS, value)
 
 

--- a/azure-iot-device/azure/iot/device/iothub/models/commands.py
+++ b/azure-iot-device/azure/iot/device/iothub/models/commands.py
@@ -24,6 +24,7 @@ class Command(object):
         """
         self._request_id = request_id
         self._component_name = component_name
+        self._command_name = command_name
         self._payload = payload
 
     @property

--- a/azure-iot-device/azure/iot/device/iothub/models/pnp_translation.py
+++ b/azure-iot-device/azure/iot/device/iothub/models/pnp_translation.py
@@ -1,0 +1,26 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""This module contains utility functions to translate basic IoTHub objects
+into PNP objects
+"""
+
+from .commands import Command
+
+
+def method_request_to_command(method_request):
+    """Given a MethodRequest, returns a Command"""
+    pass
+    # return Command(
+    #     request_id=method_request.request_id,
+    #     component_name="",
+    #     command_name=method_request.name,
+    #     payload=method_request.payload,
+    # )
+
+
+def twin_patch_to_writable_property(twin_patch):
+    """Given a Twin Patch (dict), returns a WritableProperty"""
+    pass

--- a/azure-iot-device/azure/iot/device/iothub/sync_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/sync_clients.py
@@ -292,6 +292,8 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         If the connection to the service has not previously been opened by a call to connect, this
         function will open the connection before sending the event.
 
+        This method is not compatible with PNP.
+
         :param message: The actual message to send. Anything passed that is not an instance of the
             Message class will be converted to Message object.
         :type message: :class:`azure.iot.device.Message` or str
@@ -304,10 +306,13 @@ class GenericIoTHubClient(AbstractIoTHubClient):
             during execution.
         :raises: :class:`azure.iot.device.exceptions.NoConnectionError` if the client is not
             connected (and there is no auto-connect enabled)
+        :raises: :class:`azure.iot.device.exceptions.ClientError` if using PNP mode
         :raises: :class:`azure.iot.device.exceptions.ClientError` if there is an unexpected failure
             during execution.
         :raises: ValueError if the message fails size validation.
         """
+        self._check_client_mode_is_basic()
+
         if not isinstance(message, Message):
             message = Message(message)
 
@@ -330,6 +335,9 @@ class GenericIoTHubClient(AbstractIoTHubClient):
     def receive_method_request(self, method_name=None, block=True, timeout=None):
         """Receive a method request via the Azure IoT Hub or Azure IoT Edge Hub.
 
+        This method cannot be used when using handlers.
+        This method is not compatible with PNP.
+
         :param str method_name: Optionally provide the name of the method to receive requests for.
             If this parameter is not given, all methods not already being specifically targeted by
             a different request to receive_method will be received.
@@ -340,6 +348,7 @@ class GenericIoTHubClient(AbstractIoTHubClient):
             no method request has been received by the end of the blocking period.
         """
         self._check_receive_mode_is_api()
+        self._check_client_mode_is_basic()
 
         if not self._mqtt_pipeline.feature_enabled[pipeline_constant.METHODS]:
             self._enable_feature(pipeline_constant.METHODS)
@@ -364,6 +373,8 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         If the connection to the service has not previously been opened by a call to connect, this
         function will open the connection before sending the event.
 
+        This method is not compatible with PNP.
+
         :param method_response: The MethodResponse to send.
         :type method_response: :class:`azure.iot.device.MethodResponse`
 
@@ -378,6 +389,8 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         :raises: :class:`azure.iot.device.exceptions.ClientError` if there is an unexpected failure
             during execution.
         """
+        self._check_client_mode_is_basic()
+
         logger.info("Sending method response to Hub...")
 
         callback = EventedCallback()
@@ -441,6 +454,8 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         :raises: :class:`azure.iot.device.exceptions.ClientError` if there is an unexpected failure
             during execution.
         """
+        self._check_client_mode_is_basic()
+
         if not self._mqtt_pipeline.feature_enabled[pipeline_constant.TWIN]:
             self._enable_feature(pipeline_constant.TWIN)
 
@@ -471,6 +486,9 @@ class GenericIoTHubClient(AbstractIoTHubClient):
            desired property patches have been received by the pipeline, this function will raise
            an InboxEmpty exception
 
+        This method cannot be used when using handlers.
+        This method is not compatible with PNP.
+
         :param bool block: Indicates if the operation should block until a request is received.
         :param int timeout: Optionally provide a number of seconds until blocking times out.
 
@@ -479,6 +497,7 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         :rtype: dict or None
         """
         self._check_receive_mode_is_api()
+        self._check_client_mode_is_basic()
 
         if not self._mqtt_pipeline.feature_enabled[pipeline_constant.TWIN_PATCHES]:
             self._enable_feature(pipeline_constant.TWIN_PATCHES)
@@ -568,6 +587,8 @@ class IoTHubDeviceClient(GenericIoTHubClient, AbstractIoTHubDeviceClient):
     )
     def receive_message(self, block=True, timeout=None):
         """Receive a message that has been sent from the Azure IoT Hub.
+
+        This method cannot be used when using handlers.
 
         :param bool block: Indicates if the operation should block until a message is received.
         :param int timeout: Optionally provide a number of seconds until blocking times out.
@@ -716,6 +737,8 @@ class IoTHubModuleClient(GenericIoTHubClient, AbstractIoTHubModuleClient):
     )
     def receive_message_on_input(self, input_name, block=True, timeout=None):
         """Receive an input message that has been sent from another Module to a specific input.
+
+        This method cannot be used when using handlers.
 
         :param str input_name: The input name to receive a message on.
         :param bool block: Indicates if the operation should block until a message is received.

--- a/azure-iot-device/azure/iot/device/iothub/sync_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/sync_clients.py
@@ -161,6 +161,22 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         elif new_handler is None and self._mqtt_pipeline.feature_enabled[feature_name]:
             self._disable_feature(feature_name)
 
+    @staticmethod
+    def _generate_pnp_handler_translation_wrapper(handler_to_wrap, translation_fn):
+        """Generate a translation wrapper for a PNP-related handler, using the given
+        translation function.
+
+        :param handler_to_wrap: Handler function that will be wrapped
+        :param translation_fn: Function that translates a non-PNP object passed by the handler
+            into the PNP equivalent
+        """
+
+        def translation_wrapper(handler_obj):
+            translated_obj = translation_fn(handler_obj)
+            handler_to_wrap(translated_obj)
+
+        return translation_wrapper
+
     def shutdown(self):
         """Shut down the client for graceful exit.
 

--- a/azure-iot-device/azure/iot/device/iothub/sync_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/sync_clients.py
@@ -536,6 +536,7 @@ class GenericIoTHubClient(AbstractIoTHubClient):
 
     @on_twin_desired_properties_patch_received.setter
     def on_twin_desired_properties_patch_received(self, value):
+        self._check_client_mode_is_basic()
         self._generic_receive_handler_setter(
             "on_twin_desired_properties_patch_received", pipeline_constant.TWIN_PATCHES, value
         )
@@ -550,6 +551,7 @@ class GenericIoTHubClient(AbstractIoTHubClient):
 
     @on_method_request_received.setter
     def on_method_request_received(self, value):
+        self._check_client_mode_is_basic()
         self._generic_receive_handler_setter(
             "on_method_request_received", pipeline_constant.METHODS, value
         )

--- a/azure-iot-device/azure/iot/device/iothub/sync_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/sync_clients.py
@@ -71,6 +71,7 @@ class GenericIoTHubClient(AbstractIoTHubClient):
         :type mqtt_pipeline: :class:`azure.iot.device.iothub.pipeline.MQTTPipeline`
         :param http_pipeline: The HTTPPipeline used for the client
         :type http_pipeline: :class:`azure.iot.device.iothub.pipeline.HTTPPipeline`
+        :param str client_mode: The client mode (CLIENT_MODE_BASIC or CLIENT_MODE_PNP)
         """
         # Depending on the subclass calling this __init__, there could be different arguments,
         # and the super() call could call a different class, due to the different MROs
@@ -541,7 +542,7 @@ class IoTHubDeviceClient(GenericIoTHubClient, AbstractIoTHubDeviceClient):
     Intended for usage with Python 2.7 or compatibility scenarios for Python 3.5.3+.
     """
 
-    def __init__(self, mqtt_pipeline, http_pipeline):
+    def __init__(self, mqtt_pipeline, http_pipeline, client_mode):
         """Initializer for a IoTHubDeviceClient.
 
         This initializer should not be called directly.
@@ -549,9 +550,12 @@ class IoTHubDeviceClient(GenericIoTHubClient, AbstractIoTHubDeviceClient):
 
         :param mqtt_pipeline: The pipeline used to connect to the IoTHub endpoint.
         :type mqtt_pipeline: :class:`azure.iot.device.iothub.pipeline.MQTTPipeline`
+        :param http_pipeline: The HTTPPipeline used for the client
+        :type http_pipeline: :class:`azure.iot.device.iothub.pipeline.HTTPPipeline`
+        :param str client_mode: The client mode (CLIENT_MODE_BASIC or CLIENT_MODE_PNP)
         """
         super(IoTHubDeviceClient, self).__init__(
-            mqtt_pipeline=mqtt_pipeline, http_pipeline=http_pipeline
+            mqtt_pipeline=mqtt_pipeline, http_pipeline=http_pipeline, client_mode=client_mode
         )
         self._mqtt_pipeline.on_c2d_message_received = CallableWeakMethod(
             self._inbox_manager, "route_c2d_message"
@@ -642,7 +646,7 @@ class IoTHubModuleClient(GenericIoTHubClient, AbstractIoTHubModuleClient):
     Intended for usage with Python 2.7 or compatibility scenarios for Python 3.5.3+.
     """
 
-    def __init__(self, mqtt_pipeline, http_pipeline):
+    def __init__(self, mqtt_pipeline, http_pipeline, client_mode):
         """Intializer for a IoTHubModuleClient.
 
         This initializer should not be called directly.
@@ -652,9 +656,10 @@ class IoTHubModuleClient(GenericIoTHubClient, AbstractIoTHubModuleClient):
         :type mqtt_pipeline: :class:`azure.iot.device.iothub.pipeline.MQTTPipeline`
         :param http_pipeline: The pipeline used to connect to the IoTHub endpoint via HTTP.
         :type http_pipeline: :class:`azure.iot.device.iothub.pipeline.HTTPPipeline`
+        :param str client_mode: The client mode (CLIENT_MODE_BASIC or CLIENT_MODE_PNP)
         """
         super(IoTHubModuleClient, self).__init__(
-            mqtt_pipeline=mqtt_pipeline, http_pipeline=http_pipeline
+            mqtt_pipeline=mqtt_pipeline, http_pipeline=http_pipeline, client_mode=client_mode
         )
         self._mqtt_pipeline.on_input_message_received = CallableWeakMethod(
             self._inbox_manager, "route_input_message"

--- a/azure-iot-device/tests/iothub/aio/test_async_clients.py
+++ b/azure-iot-device/tests/iothub/aio/test_async_clients.py
@@ -348,19 +348,24 @@ class SharedClientUpdateSasTokenTests(object):
         return hostname
 
     @pytest.fixture
-    def sas_client(self, client_class, mqtt_pipeline, http_pipeline, sas_config):
+    def sas_client(self, client_class, mqtt_pipeline, http_pipeline, sas_config, client_mode):
         """Client configured as if using user-provided, non-renewable SAS auth"""
         mqtt_pipeline.pipeline_configuration = sas_config
         http_pipeline.pipeline_configuration = sas_config
-        return client_class(mqtt_pipeline, http_pipeline)
+        return client_class(mqtt_pipeline, http_pipeline, client_mode)
 
     @pytest.fixture
     def sas_client_manual_cb(
-        self, client_class, mqtt_pipeline_manual_cb, http_pipeline_manual_cb, sas_config
+        self,
+        client_class,
+        mqtt_pipeline_manual_cb,
+        http_pipeline_manual_cb,
+        sas_config,
+        client_mode,
     ):
         mqtt_pipeline_manual_cb.pipeline_configuration = sas_config
         http_pipeline_manual_cb.pipeline_configuration = sas_config
-        return client_class(mqtt_pipeline_manual_cb, http_pipeline_manual_cb)
+        return client_class(mqtt_pipeline_manual_cb, http_pipeline_manual_cb, client_mode)
 
     @pytest.fixture
     def new_sas_token_string(self, uri):
@@ -1160,11 +1165,11 @@ class IoTHubDeviceClientTestsConfig(object):
         return IoTHubDeviceClient
 
     @pytest.fixture
-    def client(self, mqtt_pipeline, http_pipeline):
+    def client(self, mqtt_pipeline, http_pipeline, client_mode):
         """This client automatically resolves callbacks sent to the pipeline.
         It should be used for the majority of tests.
         """
-        client = IoTHubDeviceClient(mqtt_pipeline, http_pipeline)
+        client = IoTHubDeviceClient(mqtt_pipeline, http_pipeline, client_mode)
         yield client
         # We can't await a disconnect here because this is a function, not a coroutine, so some
         # kind of messy loop stuff has to happen.
@@ -1191,9 +1196,9 @@ class TestIoTHubDeviceClientInstantiation(
 ):
     @pytest.mark.it("Sets on_c2d_message_received handler in the MQTTPipeline")
     async def test_sets_on_c2d_message_received_handler_in_pipeline(
-        self, client_class, mqtt_pipeline, http_pipeline
+        self, client_class, mqtt_pipeline, http_pipeline, client_mode
     ):
-        client = client_class(mqtt_pipeline, http_pipeline)
+        client = client_class(mqtt_pipeline, http_pipeline, client_mode)
 
         assert client._mqtt_pipeline.on_c2d_message_received is not None
         assert (
@@ -1644,11 +1649,11 @@ class IoTHubModuleClientTestsConfig(object):
         return IoTHubModuleClient
 
     @pytest.fixture
-    def client(self, mqtt_pipeline, http_pipeline):
+    def client(self, mqtt_pipeline, http_pipeline, client_mode):
         """This client automatically resolves callbacks sent to the pipeline.
         It should be used for the majority of tests.
         """
-        client = IoTHubModuleClient(mqtt_pipeline, http_pipeline)
+        client = IoTHubModuleClient(mqtt_pipeline, http_pipeline, client_mode)
         yield client
         # We can't await a disconnect here because this is a function, not a coroutine, so some
         # kind of messy loop stuff has to happen.
@@ -1675,9 +1680,9 @@ class TestIoTHubModuleClientInstantiation(
 ):
     @pytest.mark.it("Sets on_input_message_received handler in the MQTTPipeline")
     async def test_sets_on_input_message_received_handler_in_pipeline(
-        self, client_class, mqtt_pipeline, http_pipeline
+        self, client_class, mqtt_pipeline, http_pipeline, client_mode
     ):
-        client = client_class(mqtt_pipeline, http_pipeline)
+        client = client_class(mqtt_pipeline, http_pipeline, client_mode)
 
         assert client._mqtt_pipeline.on_input_message_received is not None
         assert (

--- a/azure-iot-device/tests/iothub/aio/test_async_clients.py
+++ b/azure-iot-device/tests/iothub/aio/test_async_clients.py
@@ -1679,12 +1679,26 @@ class TestIoTHubDeviceClientPROPERTYOnMethodRequestReceivedHandler(
     IoTHubDeviceClientTestsConfig, SharedIoTHubClientPROPERTYReceiverHandlerTests
 ):
     @pytest.fixture
+    def client(self, mqtt_pipeline, http_pipeline):
+        """.on_method_request_received property is only compatible with BASIC mode, so need to
+        override fixture
+        """
+        return IoTHubDeviceClient(mqtt_pipeline, http_pipeline, CLIENT_MODE_BASIC)
+
+    @pytest.fixture
     def handler_name(self):
         return "on_method_request_received"
 
     @pytest.fixture
     def feature_name(self):
         return pipeline_constant.METHODS
+
+    @pytest.mark.it("Raises a ClientError if trying to set value on a client in PNP Mode")
+    def test_client_mode_pnp(self, client, handler):
+        client._client_mode = CLIENT_MODE_PNP
+        with pytest.raises(client_exceptions.ClientError):
+            client.on_method_request_received = handler
+        assert client.on_method_request_received is None
 
 
 @pytest.mark.describe(
@@ -1694,12 +1708,26 @@ class TestIoTHubDeviceClientPROPERTYOnTwinDesiredPropertiesPatchReceivedHandler(
     IoTHubDeviceClientTestsConfig, SharedIoTHubClientPROPERTYReceiverHandlerTests
 ):
     @pytest.fixture
+    def client(self, mqtt_pipeline, http_pipeline):
+        """.on_twin_desired_properties_patch_received property is only compatible with BASIC mode,
+        so need to override fixture
+        """
+        return IoTHubDeviceClient(mqtt_pipeline, http_pipeline, CLIENT_MODE_BASIC)
+
+    @pytest.fixture
     def handler_name(self):
         return "on_twin_desired_properties_patch_received"
 
     @pytest.fixture
     def feature_name(self):
         return pipeline_constant.TWIN_PATCHES
+
+    @pytest.mark.it("Raises a ClientError if trying to set value on a client in PNP Mode")
+    def test_client_mode_pnp(self, client, handler):
+        client._client_mode = CLIENT_MODE_PNP
+        with pytest.raises(client_exceptions.ClientError):
+            client.on_twin_desired_properties_patch_received = handler
+        assert client.on_twin_desired_properties_patch_received is None
 
 
 @pytest.mark.describe("IoTHubDeviceClient (Asynchronous) - PROPERTY .on_connection_state_change")
@@ -2297,12 +2325,26 @@ class TestIoTHubModuleClientPROPERTYOnMethodRequestReceivedHandler(
     IoTHubModuleClientTestsConfig, SharedIoTHubClientPROPERTYReceiverHandlerTests
 ):
     @pytest.fixture
+    def client(self, mqtt_pipeline, http_pipeline):
+        """.on_method_request_received property is only compatible with BASIC mode, so need to
+        override fixture
+        """
+        return IoTHubModuleClient(mqtt_pipeline, http_pipeline, CLIENT_MODE_BASIC)
+
+    @pytest.fixture
     def handler_name(self):
         return "on_method_request_received"
 
     @pytest.fixture
     def feature_name(self):
         return pipeline_constant.METHODS
+
+    @pytest.mark.it("Raises a ClientError if trying to set value on a client in PNP Mode")
+    def test_client_mode_pnp(self, client, handler):
+        client._client_mode = CLIENT_MODE_PNP
+        with pytest.raises(client_exceptions.ClientError):
+            client.on_method_request_received = handler
+        assert client.on_method_request_received is None
 
 
 @pytest.mark.describe(
@@ -2312,12 +2354,26 @@ class TestIoTHubModuleClientPROPERTYOnTwinDesiredPropertiesPatchReceivedHandler(
     IoTHubModuleClientTestsConfig, SharedIoTHubClientPROPERTYReceiverHandlerTests
 ):
     @pytest.fixture
+    def client(self, mqtt_pipeline, http_pipeline):
+        """.on_twin_desired_properties_patch_received property is only compatible with BASIC mode,
+        so need to override fixture
+        """
+        return IoTHubModuleClient(mqtt_pipeline, http_pipeline, CLIENT_MODE_BASIC)
+
+    @pytest.fixture
     def handler_name(self):
         return "on_twin_desired_properties_patch_received"
 
     @pytest.fixture
     def feature_name(self):
         return pipeline_constant.TWIN_PATCHES
+
+    @pytest.mark.it("Raises a ClientError if trying to set value on a client in PNP Mode")
+    def test_client_mode_pnp(self, client, handler):
+        client._client_mode = CLIENT_MODE_PNP
+        with pytest.raises(client_exceptions.ClientError):
+            client.on_twin_desired_properties_patch_received = handler
+        assert client.on_twin_desired_properties_patch_received is None
 
 
 @pytest.mark.describe("IoTHubModuleClient (Synchronous) - PROPERTY .on_connection_state_change")

--- a/azure-iot-device/tests/iothub/aio/test_async_clients.py
+++ b/azure-iot-device/tests/iothub/aio/test_async_clients.py
@@ -2394,8 +2394,18 @@ class TestIoTHubModuleClientPROPERTYOnMethodRequestReceivedHandler(
     def feature_name(self):
         return pipeline_constant.METHODS
 
+    @pytest.mark.it("Returns None if trying to get the value from a client in PNP Mode")
+    def test_client_mode_pnp_get(self, client, handler):
+        client._client_mode = CLIENT_MODE_PNP
+        # Handler is None
+        assert client.on_method_request_received is None
+        # Set analogous PNP handler
+        client.on_command_received = handler
+        # Still None
+        assert client.on_method_request_received is None
+
     @pytest.mark.it("Raises a ClientError if trying to set value on a client in PNP Mode")
-    def test_client_mode_pnp(self, client, handler):
+    def test_client_mode_pnp_set(self, client, handler):
         client._client_mode = CLIENT_MODE_PNP
         with pytest.raises(client_exceptions.ClientError):
             client.on_method_request_received = handler
@@ -2423,8 +2433,18 @@ class TestIoTHubModuleClientPROPERTYOnTwinDesiredPropertiesPatchReceivedHandler(
     def feature_name(self):
         return pipeline_constant.TWIN_PATCHES
 
+    @pytest.mark.it("Returns None if trying to get the value from a client in PNP Mode")
+    def test_client_mode_pnp_get(self, client, handler):
+        client._client_mode = CLIENT_MODE_PNP
+        # Handler is None
+        assert client.on_twin_desired_properties_patch_received is None
+        # Set analogous PNP handler
+        client.on_writable_property_patch_received = handler
+        # Still None
+        assert client.on_twin_desired_properties_patch_received is None
+
     @pytest.mark.it("Raises a ClientError if trying to set value on a client in PNP Mode")
-    def test_client_mode_pnp(self, client, handler):
+    def test_client_mode_pnp_set(self, client, handler):
         client._client_mode = CLIENT_MODE_PNP
         with pytest.raises(client_exceptions.ClientError):
             client.on_twin_desired_properties_patch_received = handler

--- a/azure-iot-device/tests/iothub/client_fixtures.py
+++ b/azure-iot-device/tests/iothub/client_fixtures.py
@@ -10,6 +10,7 @@ from six.moves import urllib
 from azure.iot.device.iothub.pipeline import constant
 from azure.iot.device.iothub.models import Message, MethodResponse, MethodRequest
 from azure.iot.device.common.models.x509 import X509
+from azure.iot.device.iothub.abstract_clients import CLIENT_MODE_BASIC, CLIENT_MODE_PNP
 
 
 """---Constants---"""
@@ -287,3 +288,8 @@ def mock_mqtt_pipeline_init(mocker):
 @pytest.fixture
 def mock_http_pipeline_init(mocker):
     return mocker.patch("azure.iot.device.iothub.pipeline.HTTPPipeline")
+
+
+@pytest.fixture(params=[CLIENT_MODE_BASIC, CLIENT_MODE_PNP])
+def client_mode(request):
+    return request.param

--- a/azure-iot-device/tests/iothub/conftest.py
+++ b/azure-iot-device/tests/iothub/conftest.py
@@ -29,6 +29,7 @@ from .client_fixtures import (
     edge_local_debug_environment,
     x509,
     mock_edge_hsm,
+    client_mode,
 )
 
 collect_ignore = []

--- a/azure-iot-device/tests/iothub/shared_client_tests.py
+++ b/azure-iot-device/tests/iothub/shared_client_tests.py
@@ -58,42 +58,44 @@ class SharedIoTHubClientInstantiationTests(object):
     @pytest.mark.it(
         "Stores the MQTTPipeline from the 'mqtt_pipeline' parameter in the '_mqtt_pipeline' attribute"
     )
-    def test_mqtt_pipeline_attribute(self, client_class, mqtt_pipeline, http_pipeline):
-        client = client_class(mqtt_pipeline, http_pipeline)
+    def test_mqtt_pipeline_attribute(self, client_class, mqtt_pipeline, http_pipeline, client_mode):
+        client = client_class(mqtt_pipeline, http_pipeline, client_mode)
 
         assert client._mqtt_pipeline is mqtt_pipeline
 
     @pytest.mark.it(
         "Stores the HTTPPipeline from the 'http_pipeline' parameter in the '_http_pipeline' attribute"
     )
-    def test_sets_http_pipeline_attribute(self, client_class, mqtt_pipeline, http_pipeline):
-        client = client_class(mqtt_pipeline, http_pipeline)
+    def test_sets_http_pipeline_attribute(
+        self, client_class, mqtt_pipeline, http_pipeline, client_mode
+    ):
+        client = client_class(mqtt_pipeline, http_pipeline, client_mode)
 
         assert client._http_pipeline is http_pipeline
 
     @pytest.mark.it("Sets on_connected handler in the MQTTPipeline")
     def test_sets_on_connected_handler_in_pipeline(
-        self, client_class, mqtt_pipeline, http_pipeline
+        self, client_class, mqtt_pipeline, http_pipeline, client_mode
     ):
-        client = client_class(mqtt_pipeline, http_pipeline)
+        client = client_class(mqtt_pipeline, http_pipeline, client_mode)
 
         assert client._mqtt_pipeline.on_connected is not None
         assert client._mqtt_pipeline.on_connected == client._on_connected
 
     @pytest.mark.it("Sets on_disconnected handler in the MQTTPipeline")
     def test_sets_on_disconnected_handler_in_pipeline(
-        self, client_class, mqtt_pipeline, http_pipeline
+        self, client_class, mqtt_pipeline, http_pipeline, client_mode
     ):
-        client = client_class(mqtt_pipeline, http_pipeline)
+        client = client_class(mqtt_pipeline, http_pipeline, client_mode)
 
         assert client._mqtt_pipeline.on_disconnected is not None
         assert client._mqtt_pipeline.on_disconnected == client._on_disconnected
 
     @pytest.mark.it("Sets on_method_request_received handler in the MQTTPipeline")
     def test_sets_on_method_request_received_handler_in_pipleline(
-        self, client_class, mqtt_pipeline, http_pipeline
+        self, client_class, mqtt_pipeline, http_pipeline, client_mode
     ):
-        client = client_class(mqtt_pipeline, http_pipeline)
+        client = client_class(mqtt_pipeline, http_pipeline, client_mode)
 
         assert client._mqtt_pipeline.on_method_request_received is not None
         assert (
@@ -102,10 +104,16 @@ class SharedIoTHubClientInstantiationTests(object):
         )
 
     @pytest.mark.it("Sets the Receive Mode/Type for the client as yet-unchosen")
-    def test_initial_receive_mode(self, client_class, mqtt_pipeline, http_pipeline):
-        client = client_class(mqtt_pipeline, http_pipeline)
+    def test_initial_receive_mode(self, client_class, mqtt_pipeline, http_pipeline, client_mode):
+        client = client_class(mqtt_pipeline, http_pipeline, client_mode)
 
         assert client._receive_type == RECEIVE_TYPE_NONE_SET
+
+    @pytest.mark.it("Sets the Client Type to the value provided via the 'client_mode' parameter")
+    def test_client_mode(self, client_class, mqtt_pipeline, http_pipeline, client_mode):
+        client = client_class(mqtt_pipeline, http_pipeline, client_mode)
+
+        assert client._client_mode == client_mode
 
 
 @pytest.mark.usefixtures("mock_mqtt_pipeline_init", "mock_http_pipeline_init")

--- a/azure-iot-device/tests/iothub/test_sync_clients.py
+++ b/azure-iot-device/tests/iothub/test_sync_clients.py
@@ -1925,12 +1925,26 @@ class TestIoTHubDeviceClientPROPERTYOnMethodRequestReceivedHandler(
     IoTHubDeviceClientTestsConfig, SharedIoTHubClientPROPERTYReceiverHandlerTests
 ):
     @pytest.fixture
+    def client(self, mqtt_pipeline, http_pipeline):
+        """.on_method_request_received property is only compatible with BASIC mode, so need to
+        override fixture
+        """
+        return IoTHubDeviceClient(mqtt_pipeline, http_pipeline, CLIENT_MODE_BASIC)
+
+    @pytest.fixture
     def handler_name(self):
         return "on_method_request_received"
 
     @pytest.fixture
     def feature_name(self):
         return pipeline_constant.METHODS
+
+    @pytest.mark.it("Raises a ClientError if trying to set value on a client in PNP Mode")
+    def test_client_mode_pnp(self, client, handler):
+        client._client_mode = CLIENT_MODE_PNP
+        with pytest.raises(client_exceptions.ClientError):
+            client.on_method_request_received = handler
+        assert client.on_method_request_received is None
 
 
 @pytest.mark.describe(
@@ -1940,12 +1954,26 @@ class TestIoTHubDeviceClientPROPERTYOnTwinDesiredPropertiesPatchReceivedHandler(
     IoTHubDeviceClientTestsConfig, SharedIoTHubClientPROPERTYReceiverHandlerTests
 ):
     @pytest.fixture
+    def client(self, mqtt_pipeline, http_pipeline):
+        """.on_twin_desired_properties_patch_received property is only compatible with BASIC mode,
+        so need to override fixture
+        """
+        return IoTHubDeviceClient(mqtt_pipeline, http_pipeline, CLIENT_MODE_BASIC)
+
+    @pytest.fixture
     def handler_name(self):
         return "on_twin_desired_properties_patch_received"
 
     @pytest.fixture
     def feature_name(self):
         return pipeline_constant.TWIN_PATCHES
+
+    @pytest.mark.it("Raises a ClientError if trying to set value on a client in PNP Mode")
+    def test_client_mode_pnp(self, client, handler):
+        client._client_mode = CLIENT_MODE_PNP
+        with pytest.raises(client_exceptions.ClientError):
+            client.on_twin_desired_properties_patch_received = handler
+        assert client.on_twin_desired_properties_patch_received is None
 
 
 @pytest.mark.describe("IoTHubDeviceClient (Synchronous) - PROPERTY .on_connection_state_change")
@@ -2616,12 +2644,26 @@ class TestIoTHubModuleClientPROPERTYOnMethodRequestReceivedHandler(
     IoTHubModuleClientTestsConfig, SharedIoTHubClientPROPERTYReceiverHandlerTests
 ):
     @pytest.fixture
+    def client(self, mqtt_pipeline, http_pipeline):
+        """.on_method_request_received property is only compatible with BASIC mode, so need to
+        override fixture
+        """
+        return IoTHubModuleClient(mqtt_pipeline, http_pipeline, CLIENT_MODE_BASIC)
+
+    @pytest.fixture
     def handler_name(self):
         return "on_method_request_received"
 
     @pytest.fixture
     def feature_name(self):
         return pipeline_constant.METHODS
+
+    @pytest.mark.it("Raises a ClientError if trying to set value on a client in PNP Mode")
+    def test_client_mode_pnp(self, client, handler):
+        client._client_mode = CLIENT_MODE_PNP
+        with pytest.raises(client_exceptions.ClientError):
+            client.on_method_request_received = handler
+        assert client.on_method_request_received is None
 
 
 @pytest.mark.describe(
@@ -2631,12 +2673,26 @@ class TestIoTHubModuleClientPROPERTYOnTwinDesiredPropertiesPatchReceivedHandler(
     IoTHubModuleClientTestsConfig, SharedIoTHubClientPROPERTYReceiverHandlerTests
 ):
     @pytest.fixture
+    def client(self, mqtt_pipeline, http_pipeline):
+        """.on_twin_desired_properties_patch_received property is only compatible with BASIC mode,
+        so need to override fixture
+        """
+        return IoTHubModuleClient(mqtt_pipeline, http_pipeline, CLIENT_MODE_BASIC)
+
+    @pytest.fixture
     def handler_name(self):
         return "on_twin_desired_properties_patch_received"
 
     @pytest.fixture
     def feature_name(self):
         return pipeline_constant.TWIN_PATCHES
+
+    @pytest.mark.it("Raises a ClientError if trying to set value on a client in PNP Mode")
+    def test_client_mode_pnp(self, client, handler):
+        client._client_mode = CLIENT_MODE_PNP
+        with pytest.raises(client_exceptions.ClientError):
+            client.on_twin_desired_properties_patch_received = handler
+        assert client.on_twin_desired_properties_patch_received is None
 
 
 @pytest.mark.describe("IoTHubModuleClient (Synchronous) - PROPERTY .on_connection_state_change")

--- a/azure-iot-device/tests/iothub/test_sync_clients.py
+++ b/azure-iot-device/tests/iothub/test_sync_clients.py
@@ -1990,8 +1990,18 @@ class TestIoTHubDeviceClientPROPERTYOnMethodRequestReceivedHandler(
     def feature_name(self):
         return pipeline_constant.METHODS
 
+    @pytest.mark.it("Returns None if trying to get the value from a client in PNP Mode")
+    def test_client_mode_pnp_get(self, client, handler):
+        client._client_mode = CLIENT_MODE_PNP
+        # Handler is None
+        assert client.on_method_request_received is None
+        # Set analogous PNP handler
+        client.on_command_received = handler
+        # Still None
+        assert client.on_method_request_received is None
+
     @pytest.mark.it("Raises a ClientError if trying to set value on a client in PNP Mode")
-    def test_client_mode_pnp(self, client, handler):
+    def test_client_mode_pnp_set(self, client, handler):
         client._client_mode = CLIENT_MODE_PNP
         with pytest.raises(client_exceptions.ClientError):
             client.on_method_request_received = handler
@@ -2019,8 +2029,18 @@ class TestIoTHubDeviceClientPROPERTYOnTwinDesiredPropertiesPatchReceivedHandler(
     def feature_name(self):
         return pipeline_constant.TWIN_PATCHES
 
+    @pytest.mark.it("Returns None if trying to get the value from a client in PNP Mode")
+    def test_client_mode_pnp_get(self, client, handler):
+        client._client_mode = CLIENT_MODE_PNP
+        # Handler is None
+        assert client.on_twin_desired_properties_patch_received is None
+        # Set analogous PNP handler
+        client.on_writable_property_patch_received = handler
+        # Still None
+        assert client.on_twin_desired_properties_patch_received is None
+
     @pytest.mark.it("Raises a ClientError if trying to set value on a client in PNP Mode")
-    def test_client_mode_pnp(self, client, handler):
+    def test_client_mode_pnp_set(self, client, handler):
         client._client_mode = CLIENT_MODE_PNP
         with pytest.raises(client_exceptions.ClientError):
             client.on_twin_desired_properties_patch_received = handler

--- a/azure-iot-device/tests/iothub/test_sync_clients.py
+++ b/azure-iot-device/tests/iothub/test_sync_clients.py
@@ -336,19 +336,24 @@ class SharedClientUpdateSasTokenTests(WaitsForEventCompletion):
         return hostname
 
     @pytest.fixture
-    def sas_client(self, client_class, mqtt_pipeline, http_pipeline, sas_config):
+    def sas_client(self, client_class, mqtt_pipeline, http_pipeline, sas_config, client_mode):
         """Client configured as if using user-provided, non-renewable SAS auth"""
         mqtt_pipeline.pipeline_configuration = sas_config
         http_pipeline.pipeline_configuration = sas_config
-        return client_class(mqtt_pipeline, http_pipeline)
+        return client_class(mqtt_pipeline, http_pipeline, client_mode)
 
     @pytest.fixture
     def sas_client_manual_cb(
-        self, client_class, mqtt_pipeline_manual_cb, http_pipeline_manual_cb, sas_config
+        self,
+        client_class,
+        mqtt_pipeline_manual_cb,
+        http_pipeline_manual_cb,
+        sas_config,
+        client_mode,
     ):
         mqtt_pipeline_manual_cb.pipeline_configuration = sas_config
         http_pipeline_manual_cb.pipeline_configuration = sas_config
-        return client_class(mqtt_pipeline_manual_cb, http_pipeline_manual_cb)
+        return client_class(mqtt_pipeline_manual_cb, http_pipeline_manual_cb, client_mode)
 
     @pytest.fixture
     def new_sas_token_string(self, uri):
@@ -1323,18 +1328,18 @@ class IoTHubDeviceClientTestsConfig(object):
         return IoTHubDeviceClient
 
     @pytest.fixture
-    def client(self, mqtt_pipeline, http_pipeline):
+    def client(self, mqtt_pipeline, http_pipeline, client_mode):
         """This client automatically resolves callbacks sent to the pipeline.
         It should be used for the majority of tests.
         """
-        return IoTHubDeviceClient(mqtt_pipeline, http_pipeline)
+        return IoTHubDeviceClient(mqtt_pipeline, http_pipeline, client_mode)
 
     @pytest.fixture
-    def client_manual_cb(self, mqtt_pipeline_manual_cb, http_pipeline_manual_cb):
+    def client_manual_cb(self, mqtt_pipeline_manual_cb, http_pipeline_manual_cb, client_mode):
         """This client requires manual triggering of the callbacks sent to the pipeline.
         It should only be used for tests where manual control fo a callback is required.
         """
-        return IoTHubDeviceClient(mqtt_pipeline_manual_cb, http_pipeline_manual_cb)
+        return IoTHubDeviceClient(mqtt_pipeline_manual_cb, http_pipeline_manual_cb, client_mode)
 
     @pytest.fixture
     def connection_string(self, device_connection_string):
@@ -1354,9 +1359,9 @@ class TestIoTHubDeviceClientInstantiation(
 ):
     @pytest.mark.it("Sets on_c2d_message_received handler in the MQTTPipeline")
     def test_sets_on_c2d_message_received_handler_in_pipeline(
-        self, client_class, mqtt_pipeline, http_pipeline
+        self, client_class, mqtt_pipeline, http_pipeline, client_mode
     ):
-        client = client_class(mqtt_pipeline, http_pipeline)
+        client = client_class(mqtt_pipeline, http_pipeline, client_mode=client_mode)
 
         assert client._mqtt_pipeline.on_c2d_message_received is not None
         assert (
@@ -1410,13 +1415,6 @@ class TestIoTHubDeviceClientUpdateSasToken(
         device_id = token_uri_pieces[2]
         sas_config = IoTHubPipelineConfig(hostname=hostname, device_id=device_id, sastoken=sastoken)
         return sas_config
-
-    @pytest.fixture
-    def sas_client(self, mqtt_pipeline, http_pipeline, sas_config):
-        """Client configured as if using user-provided, non-renewable SAS auth"""
-        mqtt_pipeline.pipeline_configuration = sas_config
-        http_pipeline.pipeline_configuration = sas_config
-        return IoTHubDeviceClient(mqtt_pipeline, http_pipeline)
 
     @pytest.fixture
     def uri(self, hostname, device_id):
@@ -1881,18 +1879,18 @@ class IoTHubModuleClientTestsConfig(object):
         return IoTHubModuleClient
 
     @pytest.fixture
-    def client(self, mqtt_pipeline, http_pipeline):
+    def client(self, mqtt_pipeline, http_pipeline, client_mode):
         """This client automatically resolves callbacks sent to the pipeline.
         It should be used for the majority of tests.
         """
-        return IoTHubModuleClient(mqtt_pipeline, http_pipeline)
+        return IoTHubModuleClient(mqtt_pipeline, http_pipeline, client_mode)
 
     @pytest.fixture
-    def client_manual_cb(self, mqtt_pipeline_manual_cb, http_pipeline_manual_cb):
+    def client_manual_cb(self, mqtt_pipeline_manual_cb, http_pipeline_manual_cb, client_mode):
         """This client requires manual triggering of the callbacks sent to the pipeline.
         It should only be used for tests where manual control fo a callback is required.
         """
-        return IoTHubModuleClient(mqtt_pipeline_manual_cb, http_pipeline_manual_cb)
+        return IoTHubModuleClient(mqtt_pipeline_manual_cb, http_pipeline_manual_cb, client_mode)
 
     @pytest.fixture
     def connection_string(self, module_connection_string):
@@ -1912,9 +1910,9 @@ class TestIoTHubModuleClientInstantiation(
 ):
     @pytest.mark.it("Sets on_input_message_received handler in the MQTTPipeline")
     def test_sets_on_input_message_received_handler_in_pipeline(
-        self, client_class, mqtt_pipeline, http_pipeline
+        self, client_class, mqtt_pipeline, http_pipeline, client_mode
     ):
-        client = client_class(mqtt_pipeline, http_pipeline)
+        client = client_class(mqtt_pipeline, http_pipeline, client_mode)
 
         assert client._mqtt_pipeline.on_input_message_received is not None
         assert (


### PR DESCRIPTION
* Added a new internal "client_mode" attribute to track whether PNP is in use or not
* Added logic that will lock out certain APIs and properties depending on the mode
* Added (partial) implementation of PNP handlers + test stubs