### PR TITLE
fall back to Paho 1.5.1 for Python 2.7

### DIFF
--- a/azure-iot-device/setup.py
+++ b/azure-iot-device/setup.py
@@ -82,7 +82,8 @@ setup(
         # Actual project dependencies
         "deprecation>=2.1.0,<3.0.0",
         "six>=1.12.0,<2.0.0",
-        "paho-mqtt>=1.4.0,<2.0.0",
+        "paho-mqtt>=1.4.0,<1.6.0;python_version == '2.7'",
+        "paho-mqtt>=1.4.0,<2.0.0;python_version > '2.7'",
         "requests>=2.20.0,<3.0.0",
         "requests-unixsocket>=0.1.5,<1.0.0",
         "janus==0.4.0;python_version>='3.5'",


### PR DESCRIPTION
PR for fixing this in Paho has been submitted here: https://github.com/eclipse/paho.mqtt.python/pull/611
In the meantime, fall back to 1.5.1