### PR TITLE
fix(azure-iot-device): OverflowError for sufficiently long SAS expiry or retry interval

### DIFF
--- a/azure-iot-device/azure/iot/device/common/pipeline/config.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/config.py
@@ -127,6 +127,7 @@ class BasePipelineConfig(object):
             raise TypeError("Invalid type for 'connection_retry_interval'. Must be a numeric value")
 
         if connection_retry_interval > threading.TIMEOUT_MAX:
+            # Python timers have a (platform dependent) max timeout.
             raise ValueError(
                 "'connection_retry_interval' cannot exceed {} seconds".format(threading.TIMEOUT_MAX)
             )

--- a/azure-iot-device/azure/iot/device/common/pipeline/config.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/config.py
@@ -12,7 +12,7 @@ import abc
 from azure.iot.device import constant
 
 # Python 2 doesn't define this constant, so manually do it
-if sys.version_info <= (2, 7):
+if sys.version_info < (3,):
     threading.TIMEOUT_MAX = 4294967.0
 
 logger = logging.getLogger(__name__)

--- a/azure-iot-device/azure/iot/device/common/pipeline/config.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/config.py
@@ -5,9 +5,15 @@
 # --------------------------------------------------------------------------
 
 import logging
+import threading
 import six
+import sys
 import abc
 from azure.iot.device import constant
+
+# Python 2 doesn't define this constant, so manually do it
+if sys.version_info <= (2, 7):
+    threading.TIMEOUT_MAX = 4294967.0
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +70,7 @@ class BasePipelineConfig(object):
         # Network
         self.hostname = hostname
         self.gateway_hostname = gateway_hostname
-        self.keep_alive = self._validate_keep_alive(keep_alive)
+        self.keep_alive = self._sanitize_keep_alive(keep_alive)
 
         # Auth
         self.sastoken = sastoken
@@ -79,7 +85,9 @@ class BasePipelineConfig(object):
         # Pipeline
         self.auto_connect = auto_connect
         self.connection_retry = connection_retry
-        self.connection_retry_interval = connection_retry_interval
+        self.connection_retry_interval = self._sanitize_connection_retry_interval(
+            connection_retry_interval
+        )
 
     @staticmethod
     def _sanitize_cipher(cipher):
@@ -96,17 +104,34 @@ class BasePipelineConfig(object):
         return cipher
 
     @staticmethod
-    def _validate_keep_alive(keep_alive):
+    def _sanitize_keep_alive(keep_alive):
         try:
             keep_alive = int(keep_alive)
         except (ValueError, TypeError):
-            raise ValueError("Invalid type for 'keep alive'. Permissible types are integer.")
+            raise TypeError("Invalid type for 'keep alive'. Must be a numeric value.")
 
-        if keep_alive <= 0 or keep_alive > constant.MAX_KEEP_ALIVE_SECS:
+        if keep_alive <= 0:
             # Not allowing a keep alive of 0 as this would mean frequent ping exchanges.
-            raise ValueError(
-                "'keep alive' can not be zero OR negative AND can not be more than 29 minutes. "
-                "It is recommended to choose 'keep alive' around 60 secs."
-            )
+            raise ValueError("'keep alive' must be greater than 0")
+
+        if keep_alive > constant.MAX_KEEP_ALIVE_SECS:
+            raise ValueError("'keep_alive' cannot exceed 1740 seconds (29 minutes)")
 
         return keep_alive
+
+    @staticmethod
+    def _sanitize_connection_retry_interval(connection_retry_interval):
+        try:
+            connection_retry_interval = int(connection_retry_interval)
+        except (ValueError, TypeError):
+            raise TypeError("Invalid type for 'connection_retry_interval'. Must be a numeric value")
+
+        if connection_retry_interval > threading.TIMEOUT_MAX:
+            raise ValueError(
+                "'connection_retry_interval' cannot exceed {} seconds".format(threading.TIMEOUT_MAX)
+            )
+
+        if connection_retry_interval <= 0:
+            raise ValueError("'connection_retry_interval' must be greater than 0")
+
+        return connection_retry_interval

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
@@ -24,8 +24,9 @@ from azure.iot.device.common.auth import sastoken as st
 logger = logging.getLogger(__name__)
 
 # Python 2 doesn't define this constant, so manually do it
-if sys.version_info <= (2, 7):
-    threading.TIMEOUT_MAX = 4294967.0
+if sys.version_info < (3,):
+    if not hasattr(threading, "TIMEOUT_MAX"):
+        threading.TIMEOUT_MAX = 4294967.0
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -440,11 +441,14 @@ class SasTokenStage(PipelineStage):
             self.pipeline_root.pipeline_configuration.sastoken.expiry_time
             - self.DEFAULT_TOKEN_UPDATE_MARGIN
         )
-        # Python threading events (which power Timers and Alarms) cannot wait for more than
-        # approximately 49.7 days. This means we need to update the token at least this often.
-        # If we really need to adjust this in the future so that we use the entire SAS lifespan
-        # we could implement Alarms that trigger other Alarms, but for now just capping renewal
-        # at once every 49.7 days is good enough.
+
+        # On Windows platforms, the threading event TIMEOUT_MAX (approximately 49.7 days) could
+        # conceivably be less than the SAS lifespan, which means we may need to update the token
+        # before the lifespan ends.
+        # If we really wanted to adjust this in the future to use the entire SAS lifespan, we could
+        # implement Alarms that trigger other Alarms, but for now, just forcing a token update
+        # is good enough.
+        # Note that this doesn't apply to (most) Unix platforms, where TIMEOUT_MAX is 292.5 years.
         if (update_time - time.time()) > threading.TIMEOUT_MAX:
             update_time = time.time() + threading.TIMEOUT_MAX
             logger.warning(

--- a/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
@@ -433,8 +433,9 @@ class AbstractIoTHubClient(object):
     @property
     def on_new_sastoken_required(self):
         """The handler function or coroutine that will be called when the client requires a new
-        SAS token. This will happen approximately 2 minutes before the SAS Token expires, or after
-        49 days, whichever comes first.
+        SAS token. This will happen approximately 2 minutes before the SAS Token expires.
+        On Windows platforms, if the lifespan exceeds approximately 49 days, a new token will
+        be required after those 49 days regardless of how long the SAS lifespan is.
 
         Note that this handler is ONLY necessary when using a client created via the
         .create_from_sastoken() method.

--- a/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
@@ -246,7 +246,7 @@ class AbstractIoTHubClient(object):
         :param proxy_options: Options for sending traffic through proxy servers.
         :type proxy_options: :class:`azure.iot.device.ProxyOptions`
         :param int sastoken_ttl: The time to live (in seconds) for the created SasToken used for
-            authentication. Default is 3600 seconds (1 hour)
+            authentication. Default is 3600 seconds (1 hour).
         :param int keep_alive: Maximum period in seconds between communications with the
             broker. If no other messages are being exchanged, this controls the
             rate at which the client will send ping messages to the broker.
@@ -432,8 +432,12 @@ class AbstractIoTHubClient(object):
 
     @property
     def on_new_sastoken_required(self):
-        """The handler function or coroutine that will be called when a user-provided SAS token is
-        about to expire, and a new one is required.
+        """The handler function or coroutine that will be called when the client requires a new
+        SAS token. This will happen approximately 2 minutes before the SAS Token expires, or after
+        49 days, whichever comes first.
+
+        Note that this handler is ONLY necessary when using a client created via the
+        .create_from_sastoken() method.
 
         The new token can be provided in your function or coroutine via use of the client's
         .update_sastoken() method.

--- a/azure-iot-device/tests/common/pipeline/config_test.py
+++ b/azure-iot-device/tests/common/pipeline/config_test.py
@@ -6,9 +6,16 @@
 import pytest
 import abc
 import six
+import threading
+import sys
 from azure.iot.device import ProxyOptions
 from azure.iot.device import constant
 from azure.iot.device.common.pipeline.config import DEFAULT_KEEPALIVE
+
+# Python 2 doesn't define this constant, so manually do it
+if sys.version_info < (3,):
+    if not hasattr(threading, "TIMEOUT_MAX"):
+        threading.TIMEOUT_MAX = 4294967.0
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -372,7 +379,7 @@ class PipelineConfigInstantiationTestBase(object):
     @pytest.mark.parametrize(
         "connection_retry_interval",
         [
-            pytest.param(4294967 + 1, id="> than max"),
+            pytest.param(threading.TIMEOUT_MAX + 1, id="> than max"),
             pytest.param(-1, id="negative"),
             pytest.param(0, id="zero"),
         ],

--- a/azure-iot-device/tests/common/pipeline/config_test.py
+++ b/azure-iot-device/tests/common/pipeline/config_test.py
@@ -69,6 +69,61 @@ class PipelineConfigInstantiationTestBase(object):
         assert config.gateway_hostname is None
 
     @pytest.mark.it(
+        "Instantiates with the 'keep_alive' attribute set to the provided 'keep_alive' parameter (converting the value to int)"
+    )
+    @pytest.mark.parametrize(
+        "keep_alive",
+        [
+            pytest.param(1, id="int"),
+            pytest.param(35.90, id="float"),
+            pytest.param(0b1010, id="binary"),
+            pytest.param(0x9, id="hexadecimal"),
+            pytest.param("7", id="Numeric string"),
+        ],
+    )
+    def test_keep_alive_valid_with_conversion(
+        self, mocker, required_kwargs, config_cls, sastoken, keep_alive
+    ):
+        config = config_cls(sastoken=sastoken, keep_alive=keep_alive, **required_kwargs)
+        assert config.keep_alive == int(keep_alive)
+
+    @pytest.mark.it(
+        "Instantiates with the 'keep_alive' attribute to 'None' if no 'keep_alive' parameter is provided"
+    )
+    def test_keep_alive_default(self, config_cls, required_kwargs, sastoken):
+        config = config_cls(sastoken=sastoken, **required_kwargs)
+        assert config.keep_alive == DEFAULT_KEEPALIVE
+
+    @pytest.mark.it("Raises TypeError if the provided 'keep_alive' parameter is not numeric")
+    @pytest.mark.parametrize(
+        "keep_alive",
+        [
+            pytest.param("sectumsempra", id="non-numeric string"),
+            pytest.param((1, 2), id="tuple"),
+            pytest.param([1, 2], id="list"),
+            pytest.param(object(), id="object"),
+        ],
+    )
+    def test_keep_alive_invalid_type(self, config_cls, required_kwargs, sastoken, keep_alive):
+        with pytest.raises(TypeError):
+            config_cls(sastoken=sastoken, keep_alive=keep_alive, **required_kwargs)
+
+    @pytest.mark.it("Raises ValueError if the provided 'keep_alive' parameter has an invalid value")
+    @pytest.mark.parametrize(
+        "keep_alive",
+        [
+            pytest.param(9876543210987654321098765432109876543210, id="> than max"),
+            pytest.param(-2001, id="negative"),
+            pytest.param(0, id="zero"),
+        ],
+    )
+    def test_keep_alive_invalid_value(
+        self, mocker, required_kwargs, config_cls, sastoken, keep_alive
+    ):
+        with pytest.raises(ValueError):
+            config_cls(sastoken=sastoken, keep_alive=keep_alive, **required_kwargs)
+
+    @pytest.mark.it(
         "Instantiates with the 'sastoken' attribute set to the provided 'sastoken' parameter"
     )
     def test_sastoken_set(self, config_cls, required_kwargs, sastoken):
@@ -232,59 +287,6 @@ class PipelineConfigInstantiationTestBase(object):
         assert config.proxy_options is None
 
     @pytest.mark.it(
-        "Raises TypeError if the provided 'keep_alive' attribute is not a type of integer or float or long"
-    )
-    @pytest.mark.parametrize(
-        "keep_alive",
-        [
-            pytest.param("sectumsempra", id="string"),
-            pytest.param((1, 2), id="tuple"),
-            pytest.param(object(), id="object"),
-        ],
-    )
-    def test_invalid_keep_alive_param(self, config_cls, required_kwargs, sastoken, keep_alive):
-        with pytest.raises(ValueError):
-            config_cls(sastoken=sastoken, keep_alive=keep_alive, **required_kwargs)
-
-    @pytest.mark.it(
-        "Instantiates with the 'keep_alive' attribute to 'None' if no 'keep_alive' parameter is provided"
-    )
-    def test_keep_alive_default(self, config_cls, required_kwargs, sastoken):
-        config = config_cls(sastoken=sastoken, **required_kwargs)
-        assert config.keep_alive == DEFAULT_KEEPALIVE
-
-    @pytest.mark.it(
-        "Instantiates with the 'keep_alive' attribute set to the provided 'keep_alive' parameter converting the value to an integer"
-    )
-    @pytest.mark.parametrize(
-        "keep_alive",
-        [
-            pytest.param(1, id="int"),
-            pytest.param(35.90, id="float"),
-            pytest.param(0b1010, id="binary"),
-            pytest.param(0x9, id="hexadecimal"),
-        ],
-    )
-    def test_keep_alive_valid_with_conversion(
-        self, mocker, required_kwargs, config_cls, sastoken, keep_alive
-    ):
-        config = config_cls(sastoken=sastoken, keep_alive=keep_alive, **required_kwargs)
-        assert config.keep_alive == int(keep_alive)
-
-    @pytest.mark.it("Raises ValueError if the provided 'keep_alive' attribute has an invalid value")
-    @pytest.mark.parametrize(
-        "keep_alive",
-        [
-            pytest.param(9876543210987654321098765432109876543210, id="> than max"),
-            pytest.param(-2001, id="negative"),
-            pytest.param(0, id="zero"),
-        ],
-    )
-    def test_keep_alive_invalid(self, mocker, required_kwargs, config_cls, sastoken, keep_alive):
-        with pytest.raises(ValueError):
-            config_cls(sastoken=sastoken, keep_alive=keep_alive, **required_kwargs)
-
-    @pytest.mark.it(
         "Instantiates with the 'auto_connect' attribute set to the provided 'auto_connect' parameter"
     )
     def test_auto_connect_set(self, config_cls, required_kwargs, sastoken):
@@ -311,3 +313,76 @@ class PipelineConfigInstantiationTestBase(object):
     def test_connection_retry_default(self, config_cls, required_kwargs, sastoken):
         config = config_cls(sastoken=sastoken, **required_kwargs)
         assert config.connection_retry is True
+
+    @pytest.mark.it(
+        "Instantiates with the 'connection_retry_interval' attribute set to the provided 'connection_retry_interval' parameter (converting the value to int)"
+    )
+    @pytest.mark.parametrize(
+        "connection_retry_interval",
+        [
+            pytest.param(1, id="int"),
+            pytest.param(35.90, id="float"),
+            pytest.param(0b1010, id="binary"),
+            pytest.param(0x9, id="hexadecimal"),
+            pytest.param("7", id="Numeric string"),
+        ],
+    )
+    def test_connection_retry_interval_set(
+        self, connection_retry_interval, config_cls, required_kwargs, sastoken
+    ):
+        config = config_cls(
+            sastoken=sastoken,
+            connection_retry_interval=connection_retry_interval,
+            **required_kwargs
+        )
+        assert config.connection_retry_interval == int(connection_retry_interval)
+
+    @pytest.mark.it(
+        "Instantiates with the 'connection_retry_interval' attribute set to 10 if no 'connection_retry_interval' parameter is provided"
+    )
+    def test_connection_retry_interval_default(self, config_cls, required_kwargs, sastoken):
+        config = config_cls(sastoken=sastoken, **required_kwargs)
+        assert config.connection_retry_interval == 10
+
+    @pytest.mark.it(
+        "Raises a TypeError if the provided 'connection_retry_interval' paramater is not numeric"
+    )
+    @pytest.mark.parametrize(
+        "connection_retry_interval",
+        [
+            pytest.param("non-numeric-string", id="non-numeric string"),
+            pytest.param((1, 2), id="tuple"),
+            pytest.param([1, 2], id="list"),
+            pytest.param(object(), id="object"),
+        ],
+    )
+    def test_connection_retry_interval_invalid_type(
+        self, config_cls, sastoken, required_kwargs, connection_retry_interval
+    ):
+        with pytest.raises(TypeError):
+            config_cls(
+                sastoken=sastoken,
+                connection_retry_interval=connection_retry_interval,
+                **required_kwargs
+            )
+
+    @pytest.mark.it(
+        "Raises a ValueError if the provided 'connection_retry_interval' parameter has an invalid value"
+    )
+    @pytest.mark.parametrize(
+        "connection_retry_interval",
+        [
+            pytest.param(4294967 + 1, id="> than max"),
+            pytest.param(-1, id="negative"),
+            pytest.param(0, id="zero"),
+        ],
+    )
+    def test_connection_retry_interval_invalid_value(
+        self, config_cls, sastoken, required_kwargs, connection_retry_interval
+    ):
+        with pytest.raises(ValueError):
+            config_cls(
+                sastoken=sastoken,
+                connection_retry_interval=connection_retry_interval,
+                **required_kwargs
+            )

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
@@ -30,7 +30,8 @@ from tests.common.pipeline import pipeline_stage_test
 
 # Python 2 doesn't define this constant, so manually do it
 if sys.version_info <= (2, 7):
-    threading.TIMEOUT_MAX = 4294967.0
+    if not hasattr(threading, "TIMEOUT_MAX"):
+        threading.TIMEOUT_MAX = 4294967.0
 
 this_module = sys.modules[__name__]
 logging.basicConfig(level=logging.DEBUG)

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
@@ -29,7 +29,7 @@ from .fixtures import ArbitraryOperation, ArbitraryEvent
 from tests.common.pipeline import pipeline_stage_test
 
 # Python 2 doesn't define this constant, so manually do it
-if sys.version_info < (3):
+if sys.version_info < (3,):
     if not hasattr(threading, "TIMEOUT_MAX"):
         threading.TIMEOUT_MAX = 4294967.0
 

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
@@ -28,6 +28,10 @@ from .helpers import StageRunOpTestBase, StageHandlePipelineEventTestBase
 from .fixtures import ArbitraryOperation, ArbitraryEvent
 from tests.common.pipeline import pipeline_stage_test
 
+# Python 2 doesn't define this constant, so manually do it
+if sys.version_info <= (2, 7):
+    threading.TIMEOUT_MAX = 4294967.0
+
 this_module = sys.modules[__name__]
 logging.basicConfig(level=logging.DEBUG)
 pytestmark = pytest.mark.usefixtures("fake_pipeline_thread")
@@ -35,7 +39,8 @@ pytestmark = pytest.mark.usefixtures("fake_pipeline_thread")
 
 fake_signed_data = "ajsc8nLKacIjGsYyB4iYDFCZaRMmmDrUuY5lncYDYPI="
 fake_uri = "some/resource/location"
-fake_expiry = 12321312
+fake_current_time = 10000000000
+fake_expiry = 10000003600
 
 
 ###################
@@ -49,6 +54,13 @@ def mock_timer(mocker):
 @pytest.fixture
 def mock_alarm(mocker):
     return mocker.patch.object(alarm, "Alarm")
+
+
+@pytest.fixture(autouse=True)
+def mock_time(mocker):
+    # Need to ALWAYS mock current time
+    time_mock = mocker.patch.object(time, "time")
+    time_mock.return_value = fake_current_time
 
 
 # Not a fixture, but useful for sharing
@@ -411,6 +423,28 @@ class TestSasTokenStageRunOpWithInitializePipelineOpSasTokenConfig(
         assert mock_alarm.return_value.start.call_count == 1
         assert mock_alarm.return_value.start.call_args == mocker.call()
 
+    @pytest.mark.it(
+        "Starts a background update alarm that will instead trigger after MAX_TIMEOUT seconds if the SasToken expiration time (less the Update Margin) is more than MAX_TIMEOUT seconds in the future"
+    )
+    def test_sets_alarm_long_expiration(self, mocker, stage, op, mock_alarm):
+        token = stage.pipeline_root.pipeline_configuration.sastoken
+        new_expiry = token.expiry_time + threading.TIMEOUT_MAX
+        if isinstance(token, st.RenewableSasToken):
+            token._expiry_time = new_expiry
+        else:
+            token._token_info["se"] = new_expiry
+        # NOTE: time.time is implicitly mocked to return a constant test value here
+        expected_alarm_time = time.time() + threading.TIMEOUT_MAX
+        assert expected_alarm_time < token.expiry_time
+
+        stage.run_op(op)
+
+        assert mock_alarm.call_count == 1
+        assert mock_alarm.call_args[0][0] == expected_alarm_time
+        assert mock_alarm.return_value.daemon is True
+        assert mock_alarm.return_value.start.call_count == 1
+        assert mock_alarm.return_value.start.call_args == mocker.call()
+
 
 @pytest.mark.describe(
     "SasTokenStage - .run_op() -- Called with InitializePipelineOperation (Pipeline not configured for SAS authentication)"
@@ -500,6 +534,28 @@ class TestSasTokenStageRunOpWithReauthorizeConnectionOperationPipelineOpSasToken
             stage.pipeline_root.pipeline_configuration.sastoken.expiry_time
             - pipeline_stages_base.SasTokenStage.DEFAULT_TOKEN_UPDATE_MARGIN
         )
+
+        stage.run_op(op)
+
+        assert mock_alarm.call_count == 1
+        assert mock_alarm.call_args[0][0] == expected_alarm_time
+        assert mock_alarm.return_value.daemon is True
+        assert mock_alarm.return_value.start.call_count == 1
+        assert mock_alarm.return_value.start.call_args == mocker.call()
+
+    @pytest.mark.it(
+        "Starts a background update alarm that will instead trigger after MAX_TIMEOUT seconds if the SasToken expiration time (less the Update Margin) is more than MAX_TIMEOUT seconds in the future"
+    )
+    def test_sets_alarm_long_expiration(self, mocker, stage, op, mock_alarm):
+        token = stage.pipeline_root.pipeline_configuration.sastoken
+        new_expiry = token.expiry_time + threading.TIMEOUT_MAX
+        if isinstance(token, st.RenewableSasToken):
+            token._expiry_time = new_expiry
+        else:
+            token._token_info["se"] = new_expiry
+        # NOTE: time.time is implicitly mocked to return a constant test value here
+        expected_alarm_time = time.time() + threading.TIMEOUT_MAX
+        assert expected_alarm_time < token.expiry_time
 
         stage.run_op(op)
 
@@ -715,7 +771,9 @@ class TestSasTokenStageOCCURRENCEUpdateAlarmExpiresRenewToken(SasTokenStageTestC
         # No further ops have been sent down
         assert stage.send_op_down.call_count == 1
 
-    @pytest.mark.it("Begins a new SasToken update alarm")
+    @pytest.mark.it(
+        "Begins a new SasToken update alarm that will trigger 'Update Margin' number of seconds prior to the refreshed SasToken expiration"
+    )
     @pytest.mark.parametrize(
         "connected",
         [
@@ -768,6 +826,86 @@ class TestSasTokenStageOCCURRENCEUpdateAlarmExpiresRenewToken(SasTokenStageTestC
             stage.pipeline_root.pipeline_configuration.sastoken.expiry_time
             - pipeline_stages_base.SasTokenStage.DEFAULT_TOKEN_UPDATE_MARGIN
         )
+        assert mock_alarm.call_args[0][0] == expected_alarm_time
+        assert stage._token_update_alarm is mock_alarm.return_value
+        assert stage._token_update_alarm.daemon is True
+        assert stage._token_update_alarm.start.call_count == 2
+        assert stage._token_update_alarm.start.call_args == mocker.call()
+
+        # When THAT alarm expires, the token is refreshed, and the reauth is sent, etc. etc. etc.
+        # ... recursion :)
+        new_on_alarm_complete = mock_alarm.call_args[0][1]
+        new_on_alarm_complete()
+
+        assert token.refresh.call_count == 2
+        if connected:
+            assert stage.send_op_down.call_count == 3
+            assert isinstance(
+                stage.send_op_down.call_args[0][0], pipeline_ops_base.ReauthorizeConnectionOperation
+            )
+        else:
+            assert stage.send_op_down.call_count == 1
+
+        assert mock_alarm.call_count == 3
+        # .... and on and on for infinity
+
+    @pytest.mark.it(
+        "Begins a new SasToken update alarm that will instead trigger after MAX_TIMEOUT seconds if the refreshed SasToken expiration time (less the Update Margin) is more than MAX_TIMEOUT seconds in the future"
+    )
+    @pytest.mark.parametrize(
+        "connected",
+        [
+            pytest.param(True, id="Pipeline connected"),
+            pytest.param(False, id="Pipeline not connected"),
+        ],
+    )
+    # I am sorry for this test length, but IDK how else to test this...
+    # ... other than throwing everything at it at once
+    def test_new_alarm_long_expiry(self, mocker, stage, init_op, mock_alarm, connected):
+        token = stage.pipeline_root.pipeline_configuration.sastoken
+        # Manually change the token TTL and expiry time to exceed max timeout
+        # Note that time.time() is implicitly mocked to return a constant value
+        token.ttl = threading.TIMEOUT_MAX + 3600
+        token._expiry_time = int(time.time() + token.ttl)
+
+        # Set connected state
+        stage.pipeline_root.connected = connected
+
+        # Apply the alarm
+        stage.run_op(init_op)
+
+        # init_op was passed down
+        assert stage.send_op_down.call_count == 1
+        assert stage.send_op_down.call_args == mocker.call(init_op)
+
+        # Only one alarm has been created and started. No cancellation.
+        assert mock_alarm.call_count == 1
+        assert mock_alarm.return_value.start.call_count == 1
+        assert mock_alarm.return_value.cancel.call_count == 0
+
+        # Call alarm complete callback (as if alarm expired)
+        on_alarm_complete = mock_alarm.call_args[0][1]
+        on_alarm_complete()
+
+        # Existing alarm was cancelled
+        assert mock_alarm.return_value.cancel.call_count == 1
+
+        # Token was refreshed
+        assert token.refresh.call_count == 1
+
+        # Reauthorize was sent down (if the connection state was right)
+        if connected:
+            assert stage.send_op_down.call_count == 2
+            assert isinstance(
+                stage.send_op_down.call_args[0][0], pipeline_ops_base.ReauthorizeConnectionOperation
+            )
+        else:
+            assert stage.send_op_down.call_count == 1
+
+        # Another alarm was created and started for the expected time
+        assert mock_alarm.call_count == 2
+        # NOTE: time.time() is implicitly mocked to return a constant test value here
+        expected_alarm_time = time.time() + threading.TIMEOUT_MAX
         assert mock_alarm.call_args[0][0] == expected_alarm_time
         assert stage._token_update_alarm is mock_alarm.return_value
         assert stage._token_update_alarm.daemon is True

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
@@ -29,7 +29,7 @@ from .fixtures import ArbitraryOperation, ArbitraryEvent
 from tests.common.pipeline import pipeline_stage_test
 
 # Python 2 doesn't define this constant, so manually do it
-if sys.version_info <= (2, 7):
+if sys.version_info < (3):
     if not hasattr(threading, "TIMEOUT_MAX"):
         threading.TIMEOUT_MAX = 4294967.0
 


### PR DESCRIPTION
Fixed an issue where sufficiently long SAS token expiry or retry interval could cause a OverflowError due to exceeding the max value supported by a waiting thread