### PR TITLE
iot.device: add proxy options support for HTTP transport

### DIFF
--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_http.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_http.py
@@ -63,6 +63,7 @@ class HTTPTransportStage(PipelineStage):
                 server_verification_cert=self.pipeline_root.pipeline_configuration.server_verification_cert,
                 x509_cert=self.pipeline_root.pipeline_configuration.x509,
                 cipher=self.pipeline_root.pipeline_configuration.cipher,
+                proxy_options=self.pipeline_root.pipeline_configuration.proxy_options,
             )
 
             self.pipeline_root.transport = self.transport


### PR DESCRIPTION
This adds proxy options support for HTTP transport in the same manner as it was implemented for MQTT.
