### PR TITLE
feature(azure-iot-device): Support for proxies in HTTPTransport (TEST ONLY)

### DIFF
--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_http.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_http.py
@@ -63,6 +63,7 @@ class HTTPTransportStage(PipelineStage):
                 server_verification_cert=self.pipeline_root.pipeline_configuration.server_verification_cert,
                 x509_cert=self.pipeline_root.pipeline_configuration.x509,
                 cipher=self.pipeline_root.pipeline_configuration.cipher,
+                proxy_options=self.pipeline_root.pipeline_configuration.proxy_options,
             )
 
             self.pipeline_root.transport = self.transport


### PR DESCRIPTION
* Replaced the use of the HTTPSConnection client with the use of the requests library for HTTP operations in the Transport
* Enabled HTTP, SOCKS4 and SOCKS5 proxy support