### PR TITLE
feature(azure-iot-device): Added support for user-provided gateway_hostname

### DIFF
--- a/azure-iot-device/azure/iot/device/common/auth/connection_string.py
+++ b/azure-iot-device/azure/iot/device/common/auth/connection_string.py
@@ -17,6 +17,7 @@ SHARED_ACCESS_SIGNATURE = "SharedAccessSignature"
 DEVICE_ID = "DeviceId"
 MODULE_ID = "ModuleId"
 GATEWAY_HOST_NAME = "GatewayHostName"
+X509 = "x509"
 
 _valid_keys = [
     HOST_NAME,
@@ -26,6 +27,7 @@ _valid_keys = [
     DEVICE_ID,
     MODULE_ID,
     GATEWAY_HOST_NAME,
+    X509,
 ]
 
 
@@ -56,9 +58,13 @@ def _validate_keys(d):
     shared_access_key_name = d.get(SHARED_ACCESS_KEY_NAME)
     shared_access_key = d.get(SHARED_ACCESS_KEY)
     device_id = d.get(DEVICE_ID)
+    x509 = d.get(X509)
+
+    if shared_access_key and x509:
+        raise ValueError("Invalid Connection String - Mixed authentication scheme")
 
     # This logic could be expanded to return the category of ConnectionString
-    if host_name and device_id and shared_access_key:
+    if host_name and device_id and (shared_access_key or x509):
         pass
     elif host_name and shared_access_key and shared_access_key_name:
         pass

--- a/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
@@ -29,6 +29,7 @@ def _validate_kwargs(exclude=[], **kwargs):
     Raises TypeError if an invalid option has been provided"""
     valid_kwargs = [
         "server_verification_cert",
+        "gateway_hostname",
         "websockets",
         "cipher",
         "product_info",
@@ -49,6 +50,7 @@ def _get_config_kwargs(**kwargs):
     """Get the subset of kwargs which pertain the config object"""
     valid_config_kwargs = [
         "server_verification_cert",
+        "gateway_hostname",
         "websockets",
         "cipher",
         "product_info",
@@ -271,7 +273,8 @@ class AbstractIoTHubClient(abc.ABC):
         # TODO: Make this device/module specific and reject non-matching connection strings.
 
         # Ensure no invalid kwargs were passed by the user
-        _validate_kwargs(**kwargs)
+        excluded_kwargs = ["gateway_hostname"]
+        _validate_kwargs(exclude=excluded_kwargs, **kwargs)
 
         # Create SasToken
         connection_string = cs.ConnectionString(connection_string)
@@ -318,6 +321,8 @@ class AbstractIoTHubClient(abc.ABC):
         :param str server_verification_cert: Configuration Option. The trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
+        :param str gateway_hostname: Configuration Option. The gateway hostname for the gateway
+            device.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT
             over websockets.
         :param cipher: Configuration Option. Cipher suite(s) for TLS/SSL, as a string in
@@ -525,6 +530,8 @@ class AbstractIoTHubDeviceClient(AbstractIoTHubClient):
         :param str server_verification_cert: Configuration Option. The trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
+        :param str gateway_hostname: Configuration Option. The gateway hostname for the gateway
+            device.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT
             over websockets.
         :param cipher: Configuration Option. Cipher suite(s) for TLS/SSL, as a string in
@@ -578,6 +585,8 @@ class AbstractIoTHubDeviceClient(AbstractIoTHubClient):
         :param str server_verification_cert: Configuration Option. The trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
+        :param str gateway_hostname: Configuration Option. The gateway hostname for the gateway
+            device.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT
             over websockets.
         :param cipher: Configuration Option. Cipher suite(s) for TLS/SSL, as a string in
@@ -698,7 +707,7 @@ class AbstractIoTHubModuleClient(AbstractIoTHubClient):
             authentication.
         """
         # Ensure no invalid kwargs were passed by the user
-        excluded_kwargs = ["server_verification_cert"]
+        excluded_kwargs = ["server_verification_cert", "gateway_hostname"]
         _validate_kwargs(exclude=excluded_kwargs, **kwargs)
 
         # First try the regular Edge container variables
@@ -814,6 +823,8 @@ class AbstractIoTHubModuleClient(AbstractIoTHubClient):
         :param str server_verification_cert: Configuration Option. The trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
+        :param str gateway_hostname: Configuration Option. The gateway hostname for the gateway
+            device.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT
             over websockets.
         :param cipher: Configuration Option. Cipher suite(s) for TLS/SSL, as a string in

--- a/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
@@ -278,6 +278,10 @@ class AbstractIoTHubClient(abc.ABC):
 
         # Create SasToken
         connection_string = cs.ConnectionString(connection_string)
+        if connection_string.get(cs.X509) is not None:
+            raise ValueError(
+                "Use the .create_from_x509_certificate() method instead when using X509 certificates"
+            )
         uri = _form_sas_uri(
             hostname=connection_string[cs.HOST_NAME],
             device_id=connection_string[cs.DEVICE_ID],

--- a/azure-iot-device/azure/iot/device/provisioning/abstract_provisioning_device_client.py
+++ b/azure-iot-device/azure/iot/device/provisioning/abstract_provisioning_device_client.py
@@ -24,6 +24,7 @@ def _validate_kwargs(exclude=[], **kwargs):
     # TODO: add support for server_verification_cert
     valid_kwargs = [
         "server_verification_cert",
+        "gateway_hostname",
         "websockets",
         "cipher",
         "proxy_options",
@@ -45,6 +46,7 @@ def _get_config_kwargs(**kwargs):
     """Get the subset of kwargs which pertain the config object"""
     valid_config_kwargs = [
         "server_verification_cert",
+        "gateway_hostname",
         "websockets",
         "cipher",
         "proxy_options",
@@ -112,6 +114,8 @@ class AbstractProvisioningDeviceClient(abc.ABC):
         :param str server_verification_cert: Configuration Option. The trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
+        :param str gateway_hostname: Configuration Option. The gateway hostname for the gateway
+            device.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT
             over websockets.
         :param cipher: Configuration Option. Cipher suite(s) for TLS/SSL, as a string in
@@ -182,6 +186,8 @@ class AbstractProvisioningDeviceClient(abc.ABC):
         :param str server_verification_cert: Configuration Option. The trusted certificate chain.
             Necessary when using connecting to an endpoint which has a non-standard root of trust,
             such as a protocol gateway.
+        :param str gateway_hostname: Configuration Option. The gateway hostname for the gateway
+            device.
         :param bool websockets: Configuration Option. Default is False. Set to true if using MQTT
             over websockets.
         :param cipher: Configuration Option. Cipher suite(s) for TLS/SSL, as a string in

--- a/azure-iot-device/tests/common/auth/test_connection_string.py
+++ b/azure-iot-device/tests/common/auth/test_connection_string.py
@@ -30,12 +30,20 @@ class TestConnectionString(object):
                 id="Device connection string w/ gatewayhostname",
             ),
             pytest.param(
+                "HostName=my.host.name;DeviceId=my-device;x509=True",
+                id="Device connection string w/ X509",
+            ),
+            pytest.param(
                 "HostName=my.host.name;DeviceId=my-device;ModuleId=my-module;SharedAccessKey=Zm9vYmFy",
                 id="Module connection string",
             ),
             pytest.param(
                 "HostName=my.host.name;DeviceId=my-device;ModuleId=my-module;SharedAccessKey=Zm9vYmFy;GatewayHostName=mygateway",
                 id="Module connection string w/ gatewayhostname",
+            ),
+            pytest.param(
+                "HostName=my.host.name;DeviceId=my-device;ModuleId=my-module;x509=True",
+                id="Module connection string w/ X509",
             ),
         ],
     )
@@ -57,6 +65,10 @@ class TestConnectionString(object):
             pytest.param(
                 "HostName=my.host.name;HostName=my.host.name;SharedAccessKey=mykeyname;SharedAccessKey=Zm9vYmFy",
                 id="Duplicate key",
+            ),
+            pytest.param(
+                "HostName=my.host.name;DeviceId=my-device;ModuleId=my-module;SharedAccessKey=mykeyname;x509=True",
+                id="Mixed authentication scheme",
             ),
         ],
     )

--- a/azure-iot-device/tests/iothub/shared_client_tests.py
+++ b/azure-iot-device/tests/iothub/shared_client_tests.py
@@ -231,6 +231,28 @@ class SharedIoTHubClientCreateMethodUserOptionTests(object):
         assert config.server_verification_cert == server_verification_cert
 
     @pytest.mark.it(
+        "Sets the 'gateway_hostname' user option parameter on the PipelineConfig, if provided"
+    )
+    def test_gateway_hostname_option(
+        self,
+        option_test_required_patching,
+        client_create_method,
+        create_method_args,
+        mock_mqtt_pipeline_init,
+        mock_http_pipeline_init,
+    ):
+        gateway_hostname = "my.gateway"
+        client_create_method(*create_method_args, gateway_hostname=gateway_hostname)
+
+        # Get configuration object, and ensure it was used for both protocol pipelines
+        assert mock_mqtt_pipeline_init.call_count == 1
+        config = mock_mqtt_pipeline_init.call_args[0][0]
+        assert isinstance(config, IoTHubPipelineConfig)
+        assert config == mock_http_pipeline_init.call_args[0][0]
+
+        assert config.gateway_hostname == gateway_hostname
+
+    @pytest.mark.it(
         "Sets the 'proxy_options' user option parameter on the PipelineConfig, if provided"
     )
     def test_proxy_options(
@@ -349,6 +371,7 @@ class SharedIoTHubClientCreateMethodUserOptionTests(object):
         with pytest.raises(TypeError):
             client_create_method(*create_method_args, invalid_option="some_value")
 
+    # NOTE: If any further tests need to override this test, it's time to restructure.
     @pytest.mark.it("Sets default user options if none are provided")
     def test_default_options(
         self,
@@ -374,6 +397,7 @@ class SharedIoTHubClientCreateMethodUserOptionTests(object):
         assert config.cipher == ""
         assert config.proxy_options is None
         assert config.server_verification_cert is None
+        assert config.gateway_hostname is None
         assert config.keep_alive == DEFAULT_KEEPALIVE
         assert config.auto_connect is True
         assert config.connection_retry is True
@@ -395,6 +419,56 @@ class SharedIoTHubClientCreateFromConnectionStringTests(
     def create_method_args(self, connection_string):
         """Provides the specific create method args for use in universal tests"""
         return [connection_string]
+
+    @pytest.mark.it(
+        "Raises a TypeError if the 'gateway_hostname' user option parameter is provided"
+    )
+    def test_gateway_hostname_option(
+        self,
+        option_test_required_patching,
+        client_create_method,
+        create_method_args,
+        mock_mqtt_pipeline_init,
+        mock_http_pipeline_init,
+    ):
+        """THIS TEST OVERRIDES AN INHERITED TEST"""
+        # Override to test that gateway_hostname CANNOT be provided in Edge scenarios
+
+        with pytest.raises(TypeError):
+            client_create_method(*create_method_args, gateway_hostname="my.gateway.device")
+
+    @pytest.mark.it("Sets default user options if none are provided")
+    def test_default_options(
+        self,
+        mocker,
+        option_test_required_patching,
+        client_create_method,
+        create_method_args,
+        mock_mqtt_pipeline_init,
+        mock_http_pipeline_init,
+    ):
+        """THIS TEST OVERRIDES AN INHERITED TEST"""
+        # Override to remove an assertion about gateway_hostname
+
+        client_create_method(*create_method_args)
+
+        # Both pipelines use the same IoTHubPipelineConfig
+        assert mock_mqtt_pipeline_init.call_count == 1
+        assert mock_http_pipeline_init.call_count == 1
+        assert mock_mqtt_pipeline_init.call_args[0][0] is mock_http_pipeline_init.call_args[0][0]
+        config = mock_mqtt_pipeline_init.call_args[0][0]
+        assert isinstance(config, IoTHubPipelineConfig)
+
+        # Pipeline Config has default options set that were not user-specified
+        assert config.product_info == ""
+        assert config.websockets is False
+        assert config.cipher == ""
+        assert config.proxy_options is None
+        assert config.server_verification_cert is None
+        assert config.keep_alive == DEFAULT_KEEPALIVE
+        assert config.auto_connect is True
+        assert config.connection_retry is True
+        assert config.connection_retry_interval == 10
 
     @pytest.mark.it(
         "Creates a SasToken that uses a SymmetricKeySigningMechanism, from the values in the provided connection string"
@@ -1440,6 +1514,23 @@ class SharedIoTHubModuleClientClientCreateFromEdgeEnvironmentUserOptionTests(
             client_create_method(
                 *create_method_args, server_verification_cert="fake_server_verification_cert"
             )
+
+    @pytest.mark.it(
+        "Raises a TypeError if the 'gateway_hostname' user option parameter is provided"
+    )
+    def test_gateway_hostname_option(
+        self,
+        option_test_required_patching,
+        client_create_method,
+        create_method_args,
+        mock_mqtt_pipeline_init,
+        mock_http_pipeline_init,
+    ):
+        """THIS TEST OVERRIDES AN INHERITED TEST"""
+        # Override to test that gateway_hostname CANNOT be provided in Edge scenarios
+
+        with pytest.raises(TypeError):
+            client_create_method(*create_method_args, gateway_hostname="my.gateway.device")
 
     @pytest.mark.it("Sets default user options if none are provided")
     def test_default_options(

--- a/azure-iot-device/tests/iothub/shared_client_tests.py
+++ b/azure-iot-device/tests/iothub/shared_client_tests.py
@@ -605,6 +605,10 @@ class SharedIoTHubClientCreateFromConnectionStringTests(
                 id="Contains extraneous data",
             ),
             pytest.param("HostName=value.domain.net;DeviceId=my_device", id="Incomplete"),
+            pytest.param(
+                "HostName=value.domain.net;DeviceId=my_device;x509=True",
+                id="X509 Connection String",
+            ),
         ],
     )
     def test_raises_value_error_on_bad_connection_string(self, client_class, bad_cs):

--- a/azure-iot-device/tests/provisioning/shared_client_tests.py
+++ b/azure-iot-device/tests/provisioning/shared_client_tests.py
@@ -70,6 +70,22 @@ class SharedProvisioningClientCreateMethodUserOptionTests(object):
         assert config.server_verification_cert == server_verification_cert
 
     @pytest.mark.it(
+        "Sets the 'gateway_hostname' user option parameter on the PipelineConfig, if provided"
+    )
+    def test_gateway_hostname_option(
+        self, client_create_method, create_method_args, mock_pipeline_init
+    ):
+        gateway_hostname = "my.gateway.hostname"
+        client_create_method(*create_method_args, gateway_hostname=gateway_hostname)
+
+        # Get configuration object
+        assert mock_pipeline_init.call_count == 1
+        config = mock_pipeline_init.call_args[0][0]
+        assert isinstance(config, ProvisioningPipelineConfig)
+
+        assert config.gateway_hostname == gateway_hostname
+
+    @pytest.mark.it(
         "Sets the 'websockets' user option parameter on the PipelineConfig, if provided"
     )
     def test_websockets_option(
@@ -146,6 +162,7 @@ class SharedProvisioningClientCreateMethodUserOptionTests(object):
 
         # ProvisioningPipelineConfig has default options set that were not user-specified
         assert config.server_verification_cert is None
+        assert config.gateway_hostname is None
         assert config.websockets is False
         assert config.cipher == ""
         assert config.proxy_options is None


### PR DESCRIPTION
* Added `gateway_hostname` user option to `.create_from_sastoken()`, `.create_from_x509_certificate()` and `.create_from_symmetric_key()` on the Device/Module IoTHub Clients
* Added `gateway_hostname` user option to all factory methods on the Provisioning Clients