### PR TITLE
fix: release script

### DIFF
--- a/scripts/build-release.ps1
+++ b/scripts/build-release.ps1
@@ -20,7 +20,7 @@ function Invoke-Python {
 
 function Build {
 
-    Write-Output "Python version is '$(python.exe --version)'"
+    Write-Output "Python version is '$(py.exe --version)'"
 
     $sourceFiles = $env:sources  # sdk repo top folder
     $dist = $env:dist  # release artifacts top folder

--- a/scripts/build-release.ps1
+++ b/scripts/build-release.ps1
@@ -20,7 +20,7 @@ function Invoke-Python {
 
 function Build {
 
-    Write-Output "Python version is '$(py.exe --version)'"
+    Write-Output "Python version is '$(python.exe --version)'"
 
     $sourceFiles = $env:sources  # sdk repo top folder
     $dist = $env:dist  # release artifacts top folder

--- a/scripts/build-release.ps1
+++ b/scripts/build-release.ps1
@@ -27,7 +27,7 @@ function Build {
 
     # hashtable key is package folder name in repository root
 
-    $packages = @{ } # TODO add new packages to this hashtable
+    $packages = @{ } # NOTE: add any new packages to this hashtable
 
     $packages["azure-iot-device"] = [PSCustomObject]@{
         File = "azure\iot\device\constant.py"

--- a/scripts/build-release.ps1
+++ b/scripts/build-release.ps1
@@ -20,7 +20,7 @@ function Invoke-Python {
 
 function Build {
 
-    Write-Output "Python version is '$(python3.exe --version)'"
+    Write-Output "Python version is '$(python --version)'"
 
     $sourceFiles = $env:sources  # sdk repo top folder
     $dist = $env:dist  # release artifacts top folder

--- a/scripts/build-release.ps1
+++ b/scripts/build-release.ps1
@@ -20,7 +20,7 @@ function Invoke-Python {
 
 function Build {
 
-    Write-Output "Python version is '$(python.exe --version)'"
+    Write-Output "Python version is '$(python3.exe --version)'"
 
     $sourceFiles = $env:sources  # sdk repo top folder
     $dist = $env:dist  # release artifacts top folder


### PR DESCRIPTION
For some reason `python.exe` stopped working but `python` still does
       ¯\_(ツ)_/¯