### PR TITLE
fix(azure-iot-device): Added timeout to HTTP requests

### DIFF
--- a/azure-iot-device/azure/iot/device/common/http_transport.py
+++ b/azure-iot-device/azure/iot/device/common/http_transport.py
@@ -156,6 +156,13 @@ class HTTPTransport(object):
         except ValueError as e:
             # Allow ValueError to propagate
             callback(error=e)
+        except requests.exceptions.Timeout as e:
+            # Allow Timeout to propagate
+            # NOTE: This breaks the convention in transports where we don't expose anything
+            # but builtin exceptions and the exceptions defined in transport_exceptions.py.
+            # However, we don't exactly have infrastructure to support timeout at Transport level.
+            # For now, just expose it, and if/when we more broadly support timeout, this can change
+            callback(error=e)
         except Exception as e:
             # Raise error via the callback
             new_err = exceptions.ProtocolClientError("Unexpected HTTPS failure during connect")

--- a/azure-iot-device/azure/iot/device/common/http_transport.py
+++ b/azure-iot-device/azure/iot/device/common/http_transport.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+from email.policy import HTTP
 import logging
 import ssl
 import requests
@@ -11,6 +12,10 @@ from . import transport_exceptions as exceptions
 from .pipeline import pipeline_thread
 
 logger = logging.getLogger(__name__)
+
+
+# NOTE: There should probably be a more global timeout configuration, but for now this will do.
+HTTP_TIMEOUT = 10
 
 
 class HTTPTransport(object):
@@ -127,15 +132,25 @@ class HTTPTransport(object):
             # Note that various configuration options are not set here due to them being set
             # via the HTTPAdapter that was mounted at session level.
             if method == "GET":
-                response = session.get(url, data=body, headers=headers, proxies=self._proxies)
+                response = session.get(
+                    url, data=body, headers=headers, proxies=self._proxies, timeout=HTTP_TIMEOUT
+                )
             elif method == "POST":
-                response = session.post(url, data=body, headers=headers, proxies=self._proxies)
+                response = session.post(
+                    url, data=body, headers=headers, proxies=self._proxies, timeout=HTTP_TIMEOUT
+                )
             elif method == "PUT":
-                response = session.put(url, data=body, headers=headers, proxies=self._proxies)
+                response = session.put(
+                    url, data=body, headers=headers, proxies=self._proxies, timeout=HTTP_TIMEOUT
+                )
             elif method == "PATCH":
-                response = session.patch(url, data=body, headers=headers, proxies=self._proxies)
+                response = session.patch(
+                    url, data=body, headers=headers, proxies=self._proxies, timeout=HTTP_TIMEOUT
+                )
             elif method == "DELETE":
-                response = session.delete(url, data=body, headers=headers, proxies=self._proxies)
+                response = session.delete(
+                    url, data=body, headers=headers, proxies=self._proxies, timeout=HTTP_TIMEOUT
+                )
             else:
                 raise ValueError("Invalid method type: {}".format(method))
         except ValueError as e:

--- a/azure-iot-device/tests/common/test_http_transport.py
+++ b/azure-iot-device/tests/common/test_http_transport.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from azure.iot.device.common.http_transport import HTTPTransport
+from azure.iot.device.common.http_transport import HTTPTransport, HTTP_TIMEOUT
 from azure.iot.device.common.models import X509, ProxyOptions
 from azure.iot.device.common import transport_exceptions as errors
 import pytest
@@ -318,7 +318,11 @@ class TestRequest(object):
         session_method = getattr(session, request_method.lower())
         assert session_method.call_count == 1
         assert session_method.call_args == mocker.call(
-            expected_url, data=body, headers=headers, proxies=transport._proxies
+            expected_url,
+            data=body,
+            headers=headers,
+            proxies=transport._proxies,
+            timeout=HTTP_TIMEOUT,
         )
 
     @pytest.mark.it(


### PR DESCRIPTION
* Added the recommended 'timeout' argument to the `HTTPTransport`'s invocation of the `requests` library
* Intentionally did not provide customization in lieu of overarching timeout strategy.