### PR TITLE
refactor(azure-iot-device): ReconnectStage -> ConnectionStateStage

### DIFF
--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
@@ -1099,231 +1099,220 @@ class ReconnectStage(PipelineStage):
 
     @pipeline_thread.runs_on_pipeline_thread
     def _run_op(self, op):
-        # NOTE: Connection Retry == Reconnect. These terms are used interchangeably. 'reconnect' is a
-        # more accurate term for the process happening internally here, but the feature is called
-        # 'connection retry' when facing the end user.
-        if self.nucleus.pipeline_configuration.connection_retry:
 
-            # If receiving a connection op while one is already in progress, wait for the current
-            # one to finish. This is kind of like a ConnectionLockStage, but inside this one.
-            # It has to happen here because just relying on a ConnectionLockStage before or after
-            # in the pipeline is insufficient, given that operations can spawn in this stage.
-            # We need a way to wait ops without letting them pass through and affect the connection
-            # state in order to address edge cases e.g. a user-initiated connect and a automatic
-            # reconnect connect happen at approximately the same time.
-            if self.state in self.intermediate_states and type(op) in self.connection_ops:
-                logger.debug(
-                    "{}({}): State is {} - waiting for in-progress operation to finish".format(
-                        self.name, op.name, self.state
-                    )
+        # If receiving a connection op while one is already in progress, wait for the current
+        # one to finish. This is kind of like a ConnectionLockStage, but inside this one.
+        # It has to happen here because just relying on a ConnectionLockStage before or after
+        # in the pipeline is insufficient, given that operations can spawn in this stage.
+        # We need a way to wait ops without letting them pass through and affect the connection
+        # state in order to address edge cases e.g. a user-initiated connect and a automatic
+        # reconnect connect happen at approximately the same time.
+        if self.state in self.intermediate_states and type(op) in self.connection_ops:
+            logger.debug(
+                "{}({}): State is {} - waiting for in-progress operation to finish".format(
+                    self.name, op.name, self.state
                 )
-                self.waiting_ops.put_nowait(op)
+            )
+            self.waiting_ops.put_nowait(op)
 
-            else:
-                if isinstance(op, pipeline_ops_base.ConnectOperation):
-                    if self.state is ReconnectState.CONNECTED:
-                        logger.debug(
-                            "{}({}): State is already CONNECTED. Sending op down".format(
-                                self.name, op.name
-                            )
-                        )
-                        self._add_connection_op_callback(op)
-                        # NOTE: This is the safest thing to do while the ConnectionLockStage is
-                        # doing auto-completes based on connection status. When it is revisited,
-                        # this logic may need to be updated.
-                    elif self.state is ReconnectState.DISCONNECTED:
-                        logger.debug(
-                            "{}({}): State changes DISCONNECTED -> CONNECTING. Sending op down".format(
-                                self.name, op.name
-                            )
-                        )
-                        self.state = ReconnectState.CONNECTING
-                        self._add_connection_op_callback(op)
-                    else:
-                        # This should be impossible to reach. If the state were intermediate, it
-                        # would have been added to the waiting ops queue above.
-                        logger.warning(
-                            "{}({}): Invalid State - {}".format(self.name, op.name, self.state)
-                        )
-
-                elif isinstance(op, pipeline_ops_base.DisconnectOperation):
-                    # First, always clear any reconnect timer. Because a manual disconnection is
-                    # occurring, we won't want to be reconnecting any more.
-                    self._clear_reconnect_timer()
-
-                    if self.state is ReconnectState.CONNECTED:
-                        logger.debug(
-                            "{}({}): State changes CONNECTED -> DISCONNECTING. Sending op down.".format(
-                                self.name, op.name
-                            )
-                        )
-                        self.state = ReconnectState.DISCONNECTING
-                        self._add_connection_op_callback(op)
-                    elif self.state is ReconnectState.DISCONNECTED:
-                        logger.debug(
-                            "{}({}): State is already DISCONNECTED. Sending op down".format(
-                                self.name, op.name
-                            )
-                        )
-                        self._add_connection_op_callback(op)
-                        # NOTE: This is the safest thing to do while the ConnectionLockStage is
-                        # doing auto-completes based on connection status. When it is revisited,
-                        # this logic may need to be updated.
-                    else:
-                        # This should be impossible to reach. If the state were intermediate, it
-                        # would have been added to the waiting ops queue above.
-                        logger.warning(
-                            "{}({}): Invalid State - {}".format(self.name, op.name, self.state)
-                        )
-
-                elif isinstance(op, pipeline_ops_base.ReauthorizeConnectionOperation):
-                    if self.state is ReconnectState.CONNECTED:
-                        logger.debug(
-                            "{}({}): State changes CONNECTED -> REAUTHORIZING. Sending op down.".format(
-                                self.name, op.name
-                            )
-                        )
-                        self.state = ReconnectState.REAUTHORIZING
-                        self._add_connection_op_callback(op)
-                    elif self.state is ReconnectState.DISCONNECTED:
-                        logger.debug(
-                            "{}({}): State changes DISCONNECTED -> REAUTHORIZING. Sending op down".format(
-                                self.name, op.name
-                            )
-                        )
-                        self.state = ReconnectState.REAUTHORIZING
-                        self._add_connection_op_callback(op)
-                    else:
-                        # This should be impossible to reach. If the state were intermediate, it
-                        # would have been added to the waiting ops queue above.
-                        logger.warning(
-                            "{}({}): Invalid State - {}".format(self.name, op.name, self.state)
-                        )
-
-                elif isinstance(op, pipeline_ops_base.ShutdownPipelineOperation):
-                    self._clear_reconnect_timer()
-                    # Cancel all pending ops so they don't hang
-                    while not self.waiting_ops.empty():
-                        waiting_op = self.waiting_ops.get_nowait()
-                        cancel_error = pipeline_exceptions.OperationCancelled(
-                            "Operation waiting in ReconnectStage cancelled by shutdown"
-                        )
-                        waiting_op.complete(error=cancel_error)
-
-                # In all cases the op gets sent down
-                self.send_op_down(op)
-
-        # Connection retry disabled
         else:
+            if isinstance(op, pipeline_ops_base.ConnectOperation):
+                if self.state is ReconnectState.CONNECTED:
+                    logger.debug(
+                        "{}({}): State is already CONNECTED. Sending op down".format(
+                            self.name, op.name
+                        )
+                    )
+                    self._add_connection_op_callback(op)
+                    # NOTE: This is the safest thing to do while the ConnectionLockStage is
+                    # doing auto-completes based on connection status. When it is revisited,
+                    # this logic may need to be updated.
+                elif self.state is ReconnectState.DISCONNECTED:
+                    logger.debug(
+                        "{}({}): State changes DISCONNECTED -> CONNECTING. Sending op down".format(
+                            self.name, op.name
+                        )
+                    )
+                    self.state = ReconnectState.CONNECTING
+                    self._add_connection_op_callback(op)
+                else:
+                    # This should be impossible to reach. If the state were intermediate, it
+                    # would have been added to the waiting ops queue above.
+                    logger.warning(
+                        "{}({}): Invalid State - {}".format(self.name, op.name, self.state)
+                    )
+
+            elif isinstance(op, pipeline_ops_base.DisconnectOperation):
+                # First, always clear any reconnect timer. Because a manual disconnection is
+                # occurring, we won't want to be reconnecting any more.
+                self._clear_reconnect_timer()
+
+                if self.state is ReconnectState.CONNECTED:
+                    logger.debug(
+                        "{}({}): State changes CONNECTED -> DISCONNECTING. Sending op down.".format(
+                            self.name, op.name
+                        )
+                    )
+                    self.state = ReconnectState.DISCONNECTING
+                    self._add_connection_op_callback(op)
+                elif self.state is ReconnectState.DISCONNECTED:
+                    logger.debug(
+                        "{}({}): State is already DISCONNECTED. Sending op down".format(
+                            self.name, op.name
+                        )
+                    )
+                    self._add_connection_op_callback(op)
+                    # NOTE: This is the safest thing to do while the ConnectionLockStage is
+                    # doing auto-completes based on connection status. When it is revisited,
+                    # this logic may need to be updated.
+                else:
+                    # This should be impossible to reach. If the state were intermediate, it
+                    # would have been added to the waiting ops queue above.
+                    logger.warning(
+                        "{}({}): Invalid State - {}".format(self.name, op.name, self.state)
+                    )
+
+            elif isinstance(op, pipeline_ops_base.ReauthorizeConnectionOperation):
+                if self.state is ReconnectState.CONNECTED:
+                    logger.debug(
+                        "{}({}): State changes CONNECTED -> REAUTHORIZING. Sending op down.".format(
+                            self.name, op.name
+                        )
+                    )
+                    self.state = ReconnectState.REAUTHORIZING
+                    self._add_connection_op_callback(op)
+                elif self.state is ReconnectState.DISCONNECTED:
+                    logger.debug(
+                        "{}({}): State changes DISCONNECTED -> REAUTHORIZING. Sending op down".format(
+                            self.name, op.name
+                        )
+                    )
+                    self.state = ReconnectState.REAUTHORIZING
+                    self._add_connection_op_callback(op)
+                else:
+                    # This should be impossible to reach. If the state were intermediate, it
+                    # would have been added to the waiting ops queue above.
+                    logger.warning(
+                        "{}({}): Invalid State - {}".format(self.name, op.name, self.state)
+                    )
+
+            elif isinstance(op, pipeline_ops_base.ShutdownPipelineOperation):
+                self._clear_reconnect_timer()
+                # Cancel all pending ops so they don't hang
+                while not self.waiting_ops.empty():
+                    waiting_op = self.waiting_ops.get_nowait()
+                    cancel_error = pipeline_exceptions.OperationCancelled(
+                        "Operation waiting in ReconnectStage cancelled by shutdown"
+                    )
+                    waiting_op.complete(error=cancel_error)
+
+            # In all cases the op gets sent down
             self.send_op_down(op)
 
     @pipeline_thread.runs_on_pipeline_thread
     def _handle_pipeline_event(self, event):
-        # Connection Retry Enabled
-        if self.nucleus.pipeline_configuration.connection_retry:
-            if isinstance(event, pipeline_events_base.ConnectedEvent):
-                # First, clear the reconnect timer no matter what.
-                # We are now connected, so any ongoing reconnect is unnecessary
-                self._clear_reconnect_timer()
 
-                # EXPECTED CONNECTION (ConnectOperation was previously issued)
-                if self.state is ReconnectState.CONNECTING:
-                    logger.debug(
-                        "{}({}): State changes CONNECTING -> CONNECTED. Connection established".format(
-                            self.name, event.name
-                        )
-                    )
-                    self.state = ReconnectState.CONNECTED
+        if isinstance(event, pipeline_events_base.ConnectedEvent):
+            # First, clear the reconnect timer no matter what.
+            # We are now connected, so any ongoing reconnect is unnecessary
+            self._clear_reconnect_timer()
 
-                # EXPECTED CONNECTION (ReauthorizeConnectionOperation was previously issued)
-                elif self.state is ReconnectState.REAUTHORIZING:
-                    logger.debug(
-                        "{}({}): State changes REAUTHORIZING -> CONNECTED. Connection re-established after re-authentication".format(
-                            self.name, event.name
-                        )
+            # EXPECTED CONNECTION (ConnectOperation was previously issued)
+            if self.state is ReconnectState.CONNECTING:
+                logger.debug(
+                    "{}({}): State changes CONNECTING -> CONNECTED. Connection established".format(
+                        self.name, event.name
                     )
-                    self.state = ReconnectState.CONNECTED
+                )
+                self.state = ReconnectState.CONNECTED
 
-                # BAD STATE (this block should not be reached)
-                else:
-                    logger.warning(
-                        "{}: ConnectedEvent received while in unexpected state - {}, Connected: {}".format(
-                            self.name, self.state, self.nucleus.connected
-                        )
+            # EXPECTED CONNECTION (ReauthorizeConnectionOperation was previously issued)
+            elif self.state is ReconnectState.REAUTHORIZING:
+                logger.debug(
+                    "{}({}): State changes REAUTHORIZING -> CONNECTED. Connection re-established after re-authentication".format(
+                        self.name, event.name
                     )
-                    logger.debug(
-                        "{}({}): State changes {} -> CONNECTED. Unexpected connection".format(
-                            self.name, event.name, self.state
-                        )
-                    )
-                    self.state = ReconnectState.CONNECTED
+                )
+                self.state = ReconnectState.CONNECTED
 
-            elif isinstance(event, pipeline_events_base.DisconnectedEvent):
-                # UNEXPECTED DISCONNECTION (i.e. Connection has been lost)
-                if self.state is ReconnectState.CONNECTED:
-                    # When we get disconnected, we try to reconnect as soon as we can. We set a
-                    # timer here that will start the process in another thread because we don't
-                    # want to hold up the event flow
-                    logger.debug(
-                        "{}({}): State changes CONNECTED -> DISCONNECTED. Attempting to reconnect".format(
-                            self.name, event.name
-                        )
+            # BAD STATE (this block should not be reached)
+            else:
+                logger.warning(
+                    "{}: ConnectedEvent received while in unexpected state - {}, Connected: {}".format(
+                        self.name, self.state, self.nucleus.connected
                     )
-                    # Set the state change before starting the timer in order to make sure
-                    # there's no issues when the timer expires. The pipeline threading model should
-                    # already be preventing any weirdness with timing, but can't hurt to do this
-                    # as well.
-                    self.state = ReconnectState.DISCONNECTED
+                )
+                logger.debug(
+                    "{}({}): State changes {} -> CONNECTED. Unexpected connection".format(
+                        self.name, event.name, self.state
+                    )
+                )
+                self.state = ReconnectState.CONNECTED
+
+        elif isinstance(event, pipeline_events_base.DisconnectedEvent):
+            # UNEXPECTED DISCONNECTION (i.e. Connection has been lost)
+            if self.state is ReconnectState.CONNECTED:
+                # When we get disconnected, we try to reconnect as soon as we can. We set a
+                # timer here that will start the process in another thread because we don't
+                # want to hold up the event flow
+                logger.debug(
+                    "{}({}): State changes CONNECTED -> DISCONNECTED. Attempting to reconnect".format(
+                        self.name, event.name
+                    )
+                )
+                # Set the state change before starting the timer in order to make sure
+                # there's no issues when the timer expires. The pipeline threading model should
+                # already be preventing any weirdness with timing, but can't hurt to do this
+                # as well.
+                self.state = ReconnectState.DISCONNECTED
+
+                if self.nucleus.pipeline_configuration.connection_retry:
                     self._start_reconnect_timer(0.01)
 
-                # EXPECTED DISCONNECTION (DisconnectOperation was previously issued)
-                elif self.state is ReconnectState.DISCONNECTING:
-                    # No reconnect timer will be created.
-                    logger.debug(
-                        "{}({}): State changes DISCONNECTING -> DISCONNECTED. Not attempting to reconnect (User-initiated disconnect)".format(
-                            self.name, event.name
-                        )
+            # EXPECTED DISCONNECTION (DisconnectOperation was previously issued)
+            elif self.state is ReconnectState.DISCONNECTING:
+                # No reconnect timer will be created.
+                logger.debug(
+                    "{}({}): State changes DISCONNECTING -> DISCONNECTED. Not attempting to reconnect (User-initiated disconnect)".format(
+                        self.name, event.name
                     )
-                    self.state = ReconnectState.DISCONNECTED
+                )
+                self.state = ReconnectState.DISCONNECTED
 
-                # EXPECTED DISCONNECTION (Reauthorization process)
-                elif self.state is ReconnectState.REAUTHORIZING:
-                    # ReconnectState will remain REAUTHORIZING until completion of the process
-                    # upon re-establishing the connection
+            # EXPECTED DISCONNECTION (Reauthorization process)
+            elif self.state is ReconnectState.REAUTHORIZING:
+                # ReconnectState will remain REAUTHORIZING until completion of the process
+                # upon re-establishing the connection
 
-                    # NOTE: There is a ~small~ chance of a false positive here if an unexpected
-                    # disconnection occurs while a ReauthorizationOperation is in flight.
-                    # However, it will sort itself out - the ensuing connect that occurs as part
-                    # of the reauthorization will restore connection (no harm done) or it will
-                    # fail, at which point the failure was a result of a manual operation and
-                    # reconnection is not supposed to occur. So either way, we end up where we want
-                    # to be despite the false positive - just be aware that this can happen.
-                    logger.debug(
-                        "{}({}): Not attempting to reconnect (Reauthorization in progress)".format(
-                            self.name, event.name
-                        )
+                # NOTE: There is a ~small~ chance of a false positive here if an unexpected
+                # disconnection occurs while a ReauthorizationOperation is in flight.
+                # However, it will sort itself out - the ensuing connect that occurs as part
+                # of the reauthorization will restore connection (no harm done) or it will
+                # fail, at which point the failure was a result of a manual operation and
+                # reconnection is not supposed to occur. So either way, we end up where we want
+                # to be despite the false positive - just be aware that this can happen.
+                logger.debug(
+                    "{}({}): Not attempting to reconnect (Reauthorization in progress)".format(
+                        self.name, event.name
                     )
+                )
 
-                # BAD STATE (this block should not be reached)
-                else:
-                    logger.warning(
-                        "{}: DisconnectEvent received while in unexpected state - {}, Connected: {}".format(
-                            self.name, self.state, self.nucleus.connected
-                        )
+            # BAD STATE (this block should not be reached)
+            else:
+                logger.warning(
+                    "{}: DisconnectEvent received while in unexpected state - {}, Connected: {}".format(
+                        self.name, self.state, self.nucleus.connected
                     )
-                    logger.debug(
-                        "{}({}): State changes {} -> DISCONNECTED. Unexpected disconnect in unexpected state".format(
-                            self.name, event.name, self.state
-                        )
+                )
+                logger.debug(
+                    "{}({}): State changes {} -> DISCONNECTED. Unexpected disconnect in unexpected state".format(
+                        self.name, event.name, self.state
                     )
-                    self.state = ReconnectState.DISCONNECTED
+                )
+                self.state = ReconnectState.DISCONNECTED
 
-            # In all cases the event is sent up
-            self.send_event_up(event)
-
-        # Connection Retry disabled
-        else:
-            self.send_event_up(event)
+        # In all cases the event is sent up
+        self.send_event_up(event)
 
     @pipeline_thread.runs_on_pipeline_thread
     def _add_connection_op_callback(self, op):

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
@@ -523,8 +523,8 @@ class SasTokenStage(PipelineStage):
                 # NOTE: we only do this if connection retry is enabled on the pipeline. If it is,
                 # we have a contract to maintain a connection. If it has been disabled, we have
                 # a contract to not do so.
-                # NOTE: We can't rely on the ReconnectStage to do this because 1) the pipeline
-                # stages should stand on their own, and 2) if the reauth failed, the ReconnectStage
+                # NOTE: We can't rely on the ConnectionStateStage to do this because 1) the pipeline
+                # stages should stand on their own, and 2) if the reauth failed, the ConnectionStateStage
                 # wouldn't know to reconnect, because the expected state of a failed reauth is
                 # to be disconnected.
                 if (
@@ -1065,7 +1065,7 @@ class ReconnectState(object):
     # NOTE: Reauthorizing is the process of doing a disconnect, then a connect at transport level
 
 
-class ReconnectStage(PipelineStage):
+class ConnectionStateStage(PipelineStage):
 
     intermediate_states = [
         ReconnectState.CONNECTING,
@@ -1202,7 +1202,7 @@ class ReconnectStage(PipelineStage):
                 while not self.waiting_ops.empty():
                     waiting_op = self.waiting_ops.get_nowait()
                     cancel_error = pipeline_exceptions.OperationCancelled(
-                        "Operation waiting in ReconnectStage cancelled by shutdown"
+                        "Operation waiting in ConnectionStateStage cancelled by shutdown"
                     )
                     waiting_op.complete(error=cancel_error)
 

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/mqtt_pipeline.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/mqtt_pipeline.py
@@ -94,18 +94,14 @@ class MQTTPipeline(object):
             #
             .append_stage(pipeline_stages_base.AutoConnectStage())
             #
-            # ReconnectStage needs to be after AutoConnectStage because ReconnectStage sets/clears
-            # the virtually_connected flag and we want an automatic connection op to set this flag so
-            # we can reconnect auto-connect operations.  This is important, for example, if a
-            # send_message causes the transport to automatically connect, but that connection fails.
-            # When that happens, the ReconnectState will hold onto the ConnectOperation until it
-            # succeeds, and only then will return success to the AutoConnectStage which will
-            # allow the publish to continue.
+            # ConnectionStateStage needs to be after AutoConnectStage because the AutoConnectStage
+            # can create ConnectOperations and we (may) want to queue connection related operations
+            # in the ConnectionStateStage
             #
-            .append_stage(pipeline_stages_base.ReconnectStage())
+            .append_stage(pipeline_stages_base.ConnectionStateStage())
             #
-            # ConnectionLockStage needs to be after ReconnectStage because we want any ops that
-            # ReconnectStage creates to go through the ConnectionLockStage gate
+            # ConnectionLockStage needs to be after ConnectionStateStage because we want any ops that
+            # ConnectionStateStage creates to go through the ConnectionLockStage gate
             #
             .append_stage(pipeline_stages_base.ConnectionLockStage())
             #

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/mqtt_pipeline.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/mqtt_pipeline.py
@@ -81,14 +81,14 @@ class MQTTPipeline(object):
             #
             .append_stage(pipeline_stages_base.AutoConnectStage())
             #
-            # ReconnectStage needs to be after AutoConnectStage because ReconnectStage sets/clears
-            # the virtually_conencted flag and we want an automatic connection op to set this flag so
-            # we can reconnect autoconnect operations.
+            # ConnectionStateStage needs to be after AutoConnectStage because the AutoConnectStage
+            # can create ConnectOperations and we (may) want to queue connection related operations
+            # in the ConnectionStateStage
             #
-            .append_stage(pipeline_stages_base.ReconnectStage())
+            .append_stage(pipeline_stages_base.ConnectionStateStage())
             #
-            # ConnectionLockStage needs to be after ReconnectStage because we want any ops that
-            # ReconnectStage creates to go through the ConnectionLockStage gate
+            # ConnectionLockStage needs to be after ConnectionStateStage because we want any ops that
+            # ConnectionStateStage creates to go through the ConnectionLockStage gate
             #
             .append_stage(pipeline_stages_base.ConnectionLockStage())
             #

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
@@ -26,7 +26,7 @@ from azure.iot.device.common.pipeline import (
 # I normally try to keep my imports in tests at module level, but it's just too unwieldy w/ ReconnectState
 from azure.iot.device.common.pipeline.pipeline_stages_base import ReconnectState
 from .helpers import StageRunOpTestBase, StageHandlePipelineEventTestBase
-from .fixtures import ArbitraryOperation, ArbitraryEvent
+from .fixtures import ArbitraryOperation
 from tests.common.pipeline import pipeline_stage_test
 
 
@@ -3120,8 +3120,6 @@ class ReconnectStageTestConfig(object):
     def stage(self, mocker, cls_type, init_kwargs):
         stage = cls_type(**init_kwargs)
         stage.nucleus = pipeline_nucleus.PipelineNucleus(pipeline_configuration=mocker.MagicMock())
-        # Majority of tests will want connection retry enabled
-        stage.nucleus.pipeline_configuration.connection_retry = True
         stage.nucleus.pipeline_configuration.connection_retry_interval = 1234
         mocker.spy(stage, "run_op")
         stage.send_op_down = mocker.MagicMock()
@@ -3156,9 +3154,7 @@ pipeline_stage_test.add_base_pipeline_stage_tests(
 )
 
 
-@pytest.mark.describe(
-    "ReconnectStage - .run_op() -- Called with ConnectOperation (Connection Retry/Reconnect enabled)"
-)
+@pytest.mark.describe("ReconnectStage - .run_op() -- Called with ConnectOperation")
 class TestReconnectStageRunOpWithConnectOperation(ReconnectStageTestConfig, StageRunOpTestBase):
     @pytest.fixture
     def op(self, mocker):
@@ -3325,9 +3321,7 @@ class TestReconnectStageRunOpWithConnectOperation(ReconnectStageTestConfig, Stag
             assert stage.run_op.call_args_list[i] == mocker.call(queued_ops[i])
 
 
-@pytest.mark.describe(
-    "ReconnectStage - .run_op() -- Called with DisconnectOperation (Connection Retry/Reconnect enabled)"
-)
+@pytest.mark.describe("ReconnectStage - .run_op() -- Called with DisconnectOperation")
 class TestReconnectStageRunOpWithDisconnectOperation(ReconnectStageTestConfig, StageRunOpTestBase):
     @pytest.fixture
     def op(self, mocker):
@@ -3518,9 +3512,7 @@ class TestReconnectStageRunOpWithDisconnectOperation(ReconnectStageTestConfig, S
             assert stage.run_op.call_args_list[i] == mocker.call(queued_ops[i])
 
 
-@pytest.mark.describe(
-    "ReconnectStage - .run_op() -- Called with ReauthorizeConnectionOperation (Connection Retry/Reconnect enabled)"
-)
+@pytest.mark.describe("ReconnectStage - .run_op() -- Called with ReauthorizeConnectionOperation")
 class TestReconnectStageRunOpWithReauthorizeConnectionOperation(
     ReconnectStageTestConfig, StageRunOpTestBase
 ):
@@ -3693,9 +3685,7 @@ class TestReconnectStageRunOpWithReauthorizeConnectionOperation(
             assert stage.run_op.call_args_list[i] == mocker.call(queued_ops[i])
 
 
-@pytest.mark.describe(
-    "ReconnectStage - .run_op() -- Called with ShutdownPipelineOperation (Connection Retry/Reconnect enabled)"
-)
+@pytest.mark.describe("ReconnectStage - .run_op() -- Called with ShutdownPipelineOperation")
 class TestReconnectStageRunOpWithShutdownPipelineOperation(
     ReconnectStageTestConfig, StageRunOpTestBase
 ):
@@ -3775,9 +3765,7 @@ class TestReconnectStageRunOpWithShutdownPipelineOperation(
         assert stage.state is state
 
 
-@pytest.mark.describe(
-    "ReconnectStage - .run_op() -- Called with arbitrary other operation (Connection Retry/Reconnect enabled)"
-)
+@pytest.mark.describe("ReconnectStage - .run_op() -- Called with arbitrary other operation")
 class TestReconnectStageRunOpWithArbitraryOperation(ReconnectStageTestConfig, StageRunOpTestBase):
     @pytest.fixture
     def op(self, arbitrary_op):
@@ -3804,57 +3792,7 @@ class TestReconnectStageRunOpWithArbitraryOperation(ReconnectStageTestConfig, St
         assert stage.state is state
 
 
-@pytest.mark.describe("ReconnectStage - .run_op() -- Connection Retry/Reconnect disabled")
-class TestReconnectStageRunOpWhileConnectionRetryDisabled(
-    ReconnectStageTestConfig, StageRunOpTestBase
-):
-    @pytest.fixture
-    def stage(self, mocker, cls_type, init_kwargs):
-        # Override fixture to set connect retry to False
-        stage = cls_type(**init_kwargs)
-        stage.nucleus = pipeline_nucleus.PipelineNucleus(pipeline_configuration=mocker.MagicMock())
-        stage.nucleus.pipeline_configuration.connection_retry = False
-        mocker.spy(stage, "run_op")
-        stage.send_op_down = mocker.MagicMock()
-        stage.send_event_up = mocker.MagicMock()
-        mocker.spy(stage, "report_background_exception")
-        return stage
-
-    @pytest.fixture(
-        params=[
-            pipeline_ops_base.ConnectOperation,
-            pipeline_ops_base.DisconnectOperation,
-            pipeline_ops_base.ReauthorizeConnectionOperation,
-            pipeline_ops_base.ShutdownPipelineOperation,
-            ArbitraryOperation,
-        ]
-    )
-    def op(self, request, mocker):
-        return request.param(mocker.MagicMock())
-
-    @pytest.mark.it("Sends the operation down the pipeline without changing the state")
-    @pytest.mark.parametrize(
-        "state",
-        [
-            ReconnectState.CONNECTING,
-            ReconnectState.CONNECTED,
-            ReconnectState.DISCONNECTING,
-            ReconnectState.DISCONNECTED,
-            ReconnectState.REAUTHORIZING,
-        ],
-    )
-    def test_sends_op_down(self, mocker, stage, op, state):
-        stage.state = state
-        stage.run_op(op)
-
-        assert stage.send_op_down.call_count == 1
-        assert stage.send_op_down.call_args == mocker.call(op)
-        assert stage.state is state
-
-
-@pytest.mark.describe(
-    "ReconnectStage - .handle_pipeline_event() -- Called with ConnectedEvent (Connection Retry/Reconnect enabled)"
-)
+@pytest.mark.describe("ReconnectStage - .handle_pipeline_event() -- Called with ConnectedEvent")
 class TestReconnectStageHandlePipelineEventCalledWithConnectedEvent(
     ReconnectStageTestConfig, StageHandlePipelineEventTestBase
 ):
@@ -3931,9 +3869,7 @@ class TestReconnectStageHandlePipelineEventCalledWithConnectedEvent(
         assert stage.send_event_up.call_args == mocker.call(event)
 
 
-@pytest.mark.describe(
-    "ReconnectStage - .handle_pipeline_event() -- Called with DisconnectedEvent (Connection Retry/Reconnect enabled)"
-)
+@pytest.mark.describe("ReconnectStage - .handle_pipeline_event() -- Called with DisconnectedEvent")
 class TestReconnectStageHandlePipelineEventCalledWithDisconnectedEvent(
     ReconnectStageTestConfig, StageHandlePipelineEventTestBase
 ):
@@ -3942,69 +3878,135 @@ class TestReconnectStageHandlePipelineEventCalledWithDisconnectedEvent(
         return pipeline_events_base.DisconnectedEvent()
 
     @pytest.mark.it(
-        "Changes the state to DISCONNECTED, starts a immediate reconnect timer, and sends the event up the pipeline if in a CONNECTED state (i.e. Unexpected Disconnect)"
+        "Changes the state to DISCONNECTED and sends the event up the pipeline if in a CONNECTED state (i.e. Unexpected Disconnect)"
     )
     def test_connected_state(self, mocker, stage, event, mock_timer):
+        # mock_timer is required here, even though it's unused so that we don't set a real timer
         stage.state = ReconnectState.CONNECTED
-        assert stage.reconnect_timer is None
 
         stage.handle_pipeline_event(event)
 
         assert stage.state is ReconnectState.DISCONNECTED
-        assert stage.reconnect_timer is mock_timer.return_value
-        assert mock_timer.call_count == 1
-        assert mock_timer.call_args == mocker.call(0.01, mocker.ANY)
-        assert mock_timer.return_value.start.call_count == 1
         assert stage.send_event_up.call_count == 1
         assert stage.send_event_up.call_args == mocker.call(event)
 
     @pytest.mark.it(
-        "Changes the state to DISCONNECTED, does NOT start a reconnect timer, but sends the event up the pipeline if in a DISCONNECTING state (i.e. Expected Disconnect - Disconnection process)"
+        "Changes the state to DISCONNECTED and sends the event up the pipeline if in a DISCONNECTING state (i.e. Expected Disconnect - Disconnection process)"
     )
     def test_disconnecting_state(self, mocker, stage, event):
         stage.state = ReconnectState.DISCONNECTING
-        assert stage.reconnect_timer is None
 
         stage.handle_pipeline_event(event)
 
         assert stage.state is ReconnectState.DISCONNECTED
-        assert stage.reconnect_timer is None
         assert stage.send_event_up.call_count == 1
         assert stage.send_event_up.call_args == mocker.call(event)
 
     @pytest.mark.it(
-        "Does NOT change the state or start a reconnect timer, but sends the event up the pipeline if in a REAUTHORIZING state (i.e. Expected Disconnect - Reauthorization process)"
+        "Does NOT change the state, but sends the event up the pipeline if in a REAUTHORIZING state (i.e. Expected Disconnect - Reauthorization process)"
     )
     def test_reauthorizing_state(self, mocker, stage, event):
         stage.state = ReconnectState.REAUTHORIZING
-        assert stage.reconnect_timer is None
 
         stage.handle_pipeline_event(event)
 
         assert stage.state is ReconnectState.REAUTHORIZING
-        assert stage.reconnect_timer is None
         assert stage.send_event_up.call_count == 1
         assert stage.send_event_up.call_args == mocker.call(event)
 
     @pytest.mark.it(
-        "Changes the state to DISCONNECTED, does NOT start a reconnect timer, but sends the event up the pipeline if in an invalid state"
+        "Changes the state to DISCONNECTED and sends the event up the pipeline if in an invalid state"
     )
     @pytest.mark.parametrize("state", [ReconnectState.DISCONNECTED, ReconnectState.CONNECTING])
     def test_invalid_states(self, mocker, stage, event, state):
         # NOTE: This should never happen in practice
         stage.state = state
-        assert stage.reconnect_timer is None
 
         stage.handle_pipeline_event(event)
 
         assert stage.state is ReconnectState.DISCONNECTED
-        assert stage.reconnect_timer is None
         assert stage.send_event_up.call_count == 1
         assert stage.send_event_up.call_args == mocker.call(event)
 
+    @pytest.mark.it(
+        "Starts an immediate reconnect timer following an Unexpected Disconnect if Connection Retry is enabled"
+    )
+    def test_reconnect_timer_created(self, mocker, stage, event, mock_timer):
+        stage.nucleus.pipeline_configuration.connection_retry = True
+        stage.state = ReconnectState.CONNECTED
+        assert stage.reconnect_timer is None
+
+        stage.handle_pipeline_event(event)
+
+        assert stage.reconnect_timer is mock_timer.return_value
+        assert mock_timer.call_count == 1
+        assert mock_timer.call_args == mocker.call(0.01, mocker.ANY)
+        assert mock_timer.return_value.start.call_count == 1
+
+    @pytest.mark.it("Does NOT start a reconnect timer under any other conditions")
+    @pytest.mark.parametrize(
+        "state, retry_enabled",
+        [
+            pytest.param(
+                ReconnectState.CONNECTED,
+                False,
+                id="Unexpected Disconnect - Connection Retry Disabled",
+            ),
+            pytest.param(
+                ReconnectState.DISCONNECTING,
+                True,
+                id="Expected Disconnect (Disconnection Process) - Connection Retry Enabled",
+            ),
+            pytest.param(
+                ReconnectState.DISCONNECTING,
+                False,
+                id="Expected Disconnect (Disconnection Process) - Connection Retry Disabled",
+            ),
+            pytest.param(
+                ReconnectState.REAUTHORIZING,
+                True,
+                id="Expected Disconnect (Reauthorization Process) - Connection Retry Enabled",
+            ),
+            pytest.param(
+                ReconnectState.REAUTHORIZING,
+                False,
+                id="Expected Disconnect (Reauthorization Process) - Connection Retry Disabled",
+            ),
+            pytest.param(
+                ReconnectState.DISCONNECTED,
+                True,
+                id="Unexpected Disconnect (Invalid State: DISCONNECTED) - Connection Retry Enabled",
+            ),
+            pytest.param(
+                ReconnectState.DISCONNECTED,
+                False,
+                id="Unexpected Disconnect (Invalid State: DISCONNECTED) - Connection Retry Disabled",
+            ),
+            pytest.param(
+                ReconnectState.CONNECTING,
+                True,
+                id="Unexpected Disconnect (Invalid State: CONNECTING) - Connection Retry Enabled",
+            ),
+            pytest.param(
+                ReconnectState.CONNECTING,
+                False,
+                id="Unexpected Disconnect (Invalid State: CONNECTING) - Connection Retry Disabled",
+            ),
+        ],
+    )
+    def test_no_reconnect_timer_creation(self, stage, event, state, retry_enabled, mock_timer):
+        stage.nucleus.pipeline_configuration.connection_retry = retry_enabled
+        stage.state = state
+        assert stage.reconnect_timer is None
+
+        stage.handle_pipeline_event(event)
+
+        assert stage.reconnect_timer is None
+        assert mock_timer.call_count == 0
+
 
 @pytest.mark.describe(
-    "ReconnectStage - .handle_pipeline_event() -- Called with arbitrary other event (Connection Retry/Reconnect enabled)"
+    "ReconnectStage - .handle_pipeline_event() -- Called with arbitrary other event"
 )
 class TestReconnectStageHandlePipelineEventCalledWithArbitraryEvent(
     ReconnectStageTestConfig, StageHandlePipelineEventTestBase
@@ -4012,59 +4014,6 @@ class TestReconnectStageHandlePipelineEventCalledWithArbitraryEvent(
     @pytest.fixture
     def event(self, arbitrary_event):
         return arbitrary_event
-
-    @pytest.mark.it(
-        "Sends the event up the pipeline without changing the state or starting a reconnect timer"
-    )
-    @pytest.mark.parametrize(
-        "state",
-        [
-            ReconnectState.CONNECTING,
-            ReconnectState.CONNECTED,
-            ReconnectState.DISCONNECTING,
-            ReconnectState.DISCONNECTED,
-            ReconnectState.REAUTHORIZING,
-        ],
-    )
-    def test_sends_event_up(self, mocker, stage, event, state):
-        stage.state = state
-        assert stage.reconnect_timer is None
-
-        stage.handle_pipeline_event(event)
-
-        assert stage.state is state
-        assert stage.reconnect_timer is None
-        assert stage.send_event_up.call_count == 1
-        assert stage.send_event_up.call_args == mocker.call(event)
-
-
-@pytest.mark.describe(
-    "ReconnectStage -.handle_pipeline_event() -- Connection Retry/Reconnect disabled"
-)
-class TestReconnectStageHandlePipelineEventConnectionRetryDisabled(
-    ReconnectStageTestConfig, StageHandlePipelineEventTestBase
-):
-    @pytest.fixture
-    def stage(self, mocker, cls_type, init_kwargs):
-        # Override fixture to set connect retry to False
-        stage = cls_type(**init_kwargs)
-        stage.nucleus = pipeline_nucleus.PipelineNucleus(pipeline_configuration=mocker.MagicMock())
-        stage.nucleus.pipeline_configuration.connection_retry = False
-        mocker.spy(stage, "run_op")
-        stage.send_op_down = mocker.MagicMock()
-        stage.send_event_up = mocker.MagicMock()
-        mocker.spy(stage, "report_background_exception")
-        return stage
-
-    @pytest.fixture(
-        params=[
-            pipeline_events_base.ConnectedEvent,
-            pipeline_events_base.DisconnectedEvent,
-            ArbitraryEvent,
-        ]
-    )
-    def event(self, request):
-        return request.param()
 
     @pytest.mark.it(
         "Sends the event up the pipeline without changing the state or starting a reconnect timer"

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
@@ -3107,10 +3107,10 @@ class TestRetryStageNonretryableOperationCompleted(RetryStageTestConfig):
 ###################
 
 
-class ReconnectStageTestConfig(object):
+class ConnectionStateStageTestConfig(object):
     @pytest.fixture
     def cls_type(self):
-        return pipeline_stages_base.ReconnectStage
+        return pipeline_stages_base.ConnectionStateStage
 
     @pytest.fixture
     def init_kwargs(self, mocker):
@@ -3128,7 +3128,7 @@ class ReconnectStageTestConfig(object):
         return stage
 
 
-class ReconnectStageInstantiationTests(ReconnectStageTestConfig):
+class ConnectionStateStageInstantiationTests(ConnectionStateStageTestConfig):
     @pytest.mark.it("Initializes the 'reconnect_timer' attribute as None")
     def test_reconnect_timer(self, cls_type, init_kwargs):
         stage = cls_type(**init_kwargs)
@@ -3148,14 +3148,16 @@ class ReconnectStageInstantiationTests(ReconnectStageTestConfig):
 
 pipeline_stage_test.add_base_pipeline_stage_tests(
     test_module=this_module,
-    stage_class_under_test=pipeline_stages_base.ReconnectStage,
-    stage_test_config_class=ReconnectStageTestConfig,
-    extended_stage_instantiation_test_class=ReconnectStageInstantiationTests,
+    stage_class_under_test=pipeline_stages_base.ConnectionStateStage,
+    stage_test_config_class=ConnectionStateStageTestConfig,
+    extended_stage_instantiation_test_class=ConnectionStateStageInstantiationTests,
 )
 
 
-@pytest.mark.describe("ReconnectStage - .run_op() -- Called with ConnectOperation")
-class TestReconnectStageRunOpWithConnectOperation(ReconnectStageTestConfig, StageRunOpTestBase):
+@pytest.mark.describe("ConnectionStateStage - .run_op() -- Called with ConnectOperation")
+class TestConnectionStateStageRunOpWithConnectOperation(
+    ConnectionStateStageTestConfig, StageRunOpTestBase
+):
     @pytest.fixture
     def op(self, mocker):
         return pipeline_ops_base.ConnectOperation(callback=mocker.MagicMock())
@@ -3321,8 +3323,10 @@ class TestReconnectStageRunOpWithConnectOperation(ReconnectStageTestConfig, Stag
             assert stage.run_op.call_args_list[i] == mocker.call(queued_ops[i])
 
 
-@pytest.mark.describe("ReconnectStage - .run_op() -- Called with DisconnectOperation")
-class TestReconnectStageRunOpWithDisconnectOperation(ReconnectStageTestConfig, StageRunOpTestBase):
+@pytest.mark.describe("ConnectionStateStage - .run_op() -- Called with DisconnectOperation")
+class TestConnectionStateStageRunOpWithDisconnectOperation(
+    ConnectionStateStageTestConfig, StageRunOpTestBase
+):
     @pytest.fixture
     def op(self, mocker):
         return pipeline_ops_base.DisconnectOperation(callback=mocker.MagicMock())
@@ -3512,9 +3516,11 @@ class TestReconnectStageRunOpWithDisconnectOperation(ReconnectStageTestConfig, S
             assert stage.run_op.call_args_list[i] == mocker.call(queued_ops[i])
 
 
-@pytest.mark.describe("ReconnectStage - .run_op() -- Called with ReauthorizeConnectionOperation")
-class TestReconnectStageRunOpWithReauthorizeConnectionOperation(
-    ReconnectStageTestConfig, StageRunOpTestBase
+@pytest.mark.describe(
+    "ConnectionStateStage - .run_op() -- Called with ReauthorizeConnectionOperation"
+)
+class TestConnectionStateStageRunOpWithReauthorizeConnectionOperation(
+    ConnectionStateStageTestConfig, StageRunOpTestBase
 ):
     @pytest.fixture
     def op(self, mocker):
@@ -3685,9 +3691,9 @@ class TestReconnectStageRunOpWithReauthorizeConnectionOperation(
             assert stage.run_op.call_args_list[i] == mocker.call(queued_ops[i])
 
 
-@pytest.mark.describe("ReconnectStage - .run_op() -- Called with ShutdownPipelineOperation")
-class TestReconnectStageRunOpWithShutdownPipelineOperation(
-    ReconnectStageTestConfig, StageRunOpTestBase
+@pytest.mark.describe("ConnectionStateStage - .run_op() -- Called with ShutdownPipelineOperation")
+class TestConnectionStateStageRunOpWithShutdownPipelineOperation(
+    ConnectionStateStageTestConfig, StageRunOpTestBase
 ):
     @pytest.fixture
     def op(self, mocker):
@@ -3765,8 +3771,10 @@ class TestReconnectStageRunOpWithShutdownPipelineOperation(
         assert stage.state is state
 
 
-@pytest.mark.describe("ReconnectStage - .run_op() -- Called with arbitrary other operation")
-class TestReconnectStageRunOpWithArbitraryOperation(ReconnectStageTestConfig, StageRunOpTestBase):
+@pytest.mark.describe("ConnectionStateStage - .run_op() -- Called with arbitrary other operation")
+class TestConnectionStateStageRunOpWithArbitraryOperation(
+    ConnectionStateStageTestConfig, StageRunOpTestBase
+):
     @pytest.fixture
     def op(self, arbitrary_op):
         return arbitrary_op
@@ -3792,9 +3800,11 @@ class TestReconnectStageRunOpWithArbitraryOperation(ReconnectStageTestConfig, St
         assert stage.state is state
 
 
-@pytest.mark.describe("ReconnectStage - .handle_pipeline_event() -- Called with ConnectedEvent")
-class TestReconnectStageHandlePipelineEventCalledWithConnectedEvent(
-    ReconnectStageTestConfig, StageHandlePipelineEventTestBase
+@pytest.mark.describe(
+    "ConnectionStateStage - .handle_pipeline_event() -- Called with ConnectedEvent"
+)
+class TestConnectionStateStageHandlePipelineEventCalledWithConnectedEvent(
+    ConnectionStateStageTestConfig, StageHandlePipelineEventTestBase
 ):
     @pytest.fixture
     def event(self):
@@ -3869,9 +3879,11 @@ class TestReconnectStageHandlePipelineEventCalledWithConnectedEvent(
         assert stage.send_event_up.call_args == mocker.call(event)
 
 
-@pytest.mark.describe("ReconnectStage - .handle_pipeline_event() -- Called with DisconnectedEvent")
-class TestReconnectStageHandlePipelineEventCalledWithDisconnectedEvent(
-    ReconnectStageTestConfig, StageHandlePipelineEventTestBase
+@pytest.mark.describe(
+    "ConnectionStateStage - .handle_pipeline_event() -- Called with DisconnectedEvent"
+)
+class TestConnectionStateStageHandlePipelineEventCalledWithDisconnectedEvent(
+    ConnectionStateStageTestConfig, StageHandlePipelineEventTestBase
 ):
     @pytest.fixture
     def event(self):
@@ -4006,10 +4018,10 @@ class TestReconnectStageHandlePipelineEventCalledWithDisconnectedEvent(
 
 
 @pytest.mark.describe(
-    "ReconnectStage - .handle_pipeline_event() -- Called with arbitrary other event"
+    "ConnectionStateStage - .handle_pipeline_event() -- Called with arbitrary other event"
 )
-class TestReconnectStageHandlePipelineEventCalledWithArbitraryEvent(
-    ReconnectStageTestConfig, StageHandlePipelineEventTestBase
+class TestConnectionStateStageHandlePipelineEventCalledWithArbitraryEvent(
+    ConnectionStateStageTestConfig, StageHandlePipelineEventTestBase
 ):
     @pytest.fixture
     def event(self, arbitrary_event):
@@ -4040,8 +4052,8 @@ class TestReconnectStageHandlePipelineEventCalledWithArbitraryEvent(
         assert stage.send_event_up.call_args == mocker.call(event)
 
 
-@pytest.mark.describe("ReconnectStage - OCCURRENCE: Reconnect Timer Expires")
-class TestReconnectStageOCCURRENCEReconnectTimerExpires(ReconnectStageTestConfig):
+@pytest.mark.describe("ConnectionStateStage - OCCURRENCE: Reconnect Timer Expires")
+class TestConnectionStateStageOCCURRENCEReconnectTimerExpires(ConnectionStateStageTestConfig):
     @pytest.fixture(
         params=[
             "Timer created by unexpected disconnect",
@@ -4170,8 +4182,8 @@ class TestReconnectStageOCCURRENCEReconnectTimerExpires(ReconnectStageTestConfig
         assert stage.reconnect_timer is None
 
 
-@pytest.mark.describe("ReconnectStage - OCCURRENCE: Reconnection Completes")
-class TestReconnectStageOCCURRENCEReconnectionCompletes(ReconnectStageTestConfig):
+@pytest.mark.describe("ConnectionStateStage - OCCURRENCE: Reconnection Completes")
+class TestConnectionStateStageOCCURRENCEReconnectionCompletes(ConnectionStateStageTestConfig):
     @pytest.fixture(
         params=[
             "Reconnect after unexpected disconnect",

--- a/azure-iot-device/tests/iothub/pipeline/test_mqtt_pipeline.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_mqtt_pipeline.py
@@ -115,7 +115,7 @@ class TestMQTTPipelineInstantiation(object):
             pipeline_stages_base.CoordinateRequestAndResponseStage,
             pipeline_stages_iothub_mqtt.IoTHubMQTTTranslationStage,
             pipeline_stages_base.AutoConnectStage,
-            pipeline_stages_base.ReconnectStage,
+            pipeline_stages_base.ConnectionStateStage,
             pipeline_stages_base.ConnectionLockStage,
             pipeline_stages_base.RetryStage,
             pipeline_stages_base.OpTimeoutStage,

--- a/azure-iot-device/tests/provisioning/pipeline/test_mqtt_pipeline.py
+++ b/azure-iot-device/tests/provisioning/pipeline/test_mqtt_pipeline.py
@@ -107,7 +107,7 @@ class TestMQTTPipelineInstantiation(object):
             pipeline_stages_base.CoordinateRequestAndResponseStage,
             pipeline_stages_provisioning_mqtt.ProvisioningMQTTTranslationStage,
             pipeline_stages_base.AutoConnectStage,
-            pipeline_stages_base.ReconnectStage,
+            pipeline_stages_base.ConnectionStateStage,
             pipeline_stages_base.ConnectionLockStage,
             pipeline_stages_base.RetryStage,
             pipeline_stages_base.OpTimeoutStage,


### PR DESCRIPTION
ReconnectStage renamed to ConnectionStateStage. This is because I have changed the stage such that the connection state machine logic is now in use, even when not using connection_retry. Naturally, connection retry / reconnect functionality is only used if the user option has been enabled.

Note that this change has no meaningful change in functionality - the state machine running when not using connection_retry doesn't mean much if it's not being used to reconnect. Only real difference is that now when not using connection_retry operations will queue here in addition to the ConnectionLockStage if a connection is in progress so that we can ensure the state is what we think it is, but that really doesn't change anything.

This is necessary as an intermediate step to unifying the connection state in the pipeline - we want this state machine to eventually serve as the single source of truth regarding the connection status of the client, but we can't do that while it's optional.

There is an argument to be made ConnectionState and Reconnect ought to be split up, but I'll leave that for another time and another PR for now.