### PR TITLE
fix (azure-iot-device): Prevent duplicate twin GET upon Connect

### DIFF
--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
@@ -871,8 +871,6 @@ class CoordinateRequestAndResponseStage(PipelineStage):
             undefined.
             """
 
-            self.send_event_up(event)
-
             for request_id in self.pending_responses:
                 logger.info(
                     "{stage}: ConnectedEvent: re-publishing request {id} for {method} {type} ".format(
@@ -883,6 +881,8 @@ class CoordinateRequestAndResponseStage(PipelineStage):
                     )
                 )
                 self._send_request_down(request_id, self.pending_responses[request_id])
+
+            self.send_event_up(event)
 
         else:
             self.send_event_up(event)

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub.py
@@ -114,7 +114,7 @@ class EnsureDesiredPropertiesStage(PipelineStage):
             # before (or we've enabled them at least).  If this is the case, get the twin to
             # see if the desired props have been updated.
             if self.last_version_seen:
-                logger.info("{}: Reconnected.  Getting twin")
+                logger.info("{}: Reconnected.  Getting twin".format(self.name))
                 self._ensure_get_op()
         self.send_event_up(event)
 


### PR DESCRIPTION
* Stages (except the MQTTTransportStage) now always invoke `.send_event_up`() at the _end_ of the `.handle_pipeline_event()` call
* Now that connection state has been improved by previous PRs, we no longer have to work around timing issues by invoking `.send_event_up()` early
* By doing things in the correct order, we now will no longer be accidentally republishing the twin GET that triggers upon connection
* Fixes #994