### PR TITLE
refactor (azure-iot-device): Remove ConnectionLockStage

### DIFF
--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
@@ -1198,10 +1198,6 @@ class ConnectionStateStage(PipelineStage):
         """Adds callback to a connection op passing through to do necessary stage upkeep"""
         self_weakref = weakref.ref(self)
 
-        # NOTE: we are currently protected from connect failing due to being already connected
-        # by the AutoCompleteStage. If the AutoCompleteStage changes functionality,
-        # we may need some logic changes to address an op that can fail while leaving us CONNECTED
-
         @pipeline_thread.runs_on_pipeline_thread
         def on_complete(op, error):
             this = self_weakref()

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
@@ -1032,11 +1032,11 @@ class ConnectionStateStage(PipelineStage):
             if isinstance(op, pipeline_ops_base.ConnectOperation):
                 if self.nucleus.connection_state is ConnectionState.CONNECTED:
                     logger.debug(
-                        "{}({}): State is already CONNECTED. Sending op down".format(
+                        "{}({}): State is already CONNECTED. Completing operation".format(
                             self.name, op.name
                         )
                     )
-                    self._add_connection_op_callback(op)
+                    op.complete()
                 elif self.nucleus.connection_state is ConnectionState.DISCONNECTED:
                     logger.debug(
                         "{}({}): State changes DISCONNECTED -> CONNECTING. Sending op down".format(
@@ -1045,6 +1045,7 @@ class ConnectionStateStage(PipelineStage):
                     )
                     self.nucleus.connection_state = ConnectionState.CONNECTING
                     self._add_connection_op_callback(op)
+                    self.send_op_down()
                 else:
                     # This should be impossible to reach. If the state were intermediate, it
                     # would have been added to the waiting ops queue above.
@@ -1053,6 +1054,7 @@ class ConnectionStateStage(PipelineStage):
                             self.name, op.name, self.nucleus.connection_state
                         )
                     )
+                    self.send_op_down()
 
             elif isinstance(op, pipeline_ops_base.DisconnectOperation):
                 # First, always clear any reconnect timer. Because a manual disconnection is
@@ -1067,13 +1069,14 @@ class ConnectionStateStage(PipelineStage):
                     )
                     self.nucleus.connection_state = ConnectionState.DISCONNECTING
                     self._add_connection_op_callback(op)
+                    self.send_op_down()
                 elif self.nucleus.connection_state is ConnectionState.DISCONNECTED:
                     logger.debug(
-                        "{}({}): State is already DISCONNECTED. Sending op down".format(
+                        "{}({}): State is already DISCONNECTED. Completing operation".format(
                             self.name, op.name
                         )
                     )
-                    self._add_connection_op_callback(op)
+                    op.complete()
                 else:
                     # This should be impossible to reach. If the state were intermediate, it
                     # would have been added to the waiting ops queue above.
@@ -1082,6 +1085,7 @@ class ConnectionStateStage(PipelineStage):
                             self.name, op.name, self.nucleus.connection_state
                         )
                     )
+                    self.send_op_down()
 
             elif isinstance(op, pipeline_ops_base.ReauthorizeConnectionOperation):
                 if self.nucleus.connection_state is ConnectionState.CONNECTED:
@@ -1092,6 +1096,7 @@ class ConnectionStateStage(PipelineStage):
                     )
                     self.nucleus.connection_state = ConnectionState.REAUTHORIZING
                     self._add_connection_op_callback(op)
+                    self.send_op_down()
                 elif self.nucleus.connection_state is ConnectionState.DISCONNECTED:
                     logger.debug(
                         "{}({}): State changes DISCONNECTED -> REAUTHORIZING. Sending op down".format(
@@ -1100,6 +1105,7 @@ class ConnectionStateStage(PipelineStage):
                     )
                     self.nucleus.connection_state = ConnectionState.REAUTHORIZING
                     self._add_connection_op_callback(op)
+                    self.send_op_down()
                 else:
                     # This should be impossible to reach. If the state were intermediate, it
                     # would have been added to the waiting ops queue above.
@@ -1118,9 +1124,10 @@ class ConnectionStateStage(PipelineStage):
                         "Operation waiting in ConnectionStateStage cancelled by shutdown"
                     )
                     waiting_op.complete(error=cancel_error)
+                self.send_op_down()
 
-            # In all cases the op gets sent down
-            self.send_op_down(op)
+            else:
+                self.send_op_down(op)
 
     @pipeline_thread.runs_on_pipeline_thread
     def _handle_pipeline_event(self, event):

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
@@ -1045,7 +1045,7 @@ class ConnectionStateStage(PipelineStage):
                     )
                     self.nucleus.connection_state = ConnectionState.CONNECTING
                     self._add_connection_op_callback(op)
-                    self.send_op_down()
+                    self.send_op_down(op)
                 else:
                     # This should be impossible to reach. If the state were intermediate, it
                     # would have been added to the waiting ops queue above.
@@ -1054,7 +1054,7 @@ class ConnectionStateStage(PipelineStage):
                             self.name, op.name, self.nucleus.connection_state
                         )
                     )
-                    self.send_op_down()
+                    self.send_op_down(op)
 
             elif isinstance(op, pipeline_ops_base.DisconnectOperation):
                 # First, always clear any reconnect timer. Because a manual disconnection is
@@ -1069,7 +1069,7 @@ class ConnectionStateStage(PipelineStage):
                     )
                     self.nucleus.connection_state = ConnectionState.DISCONNECTING
                     self._add_connection_op_callback(op)
-                    self.send_op_down()
+                    self.send_op_down(op)
                 elif self.nucleus.connection_state is ConnectionState.DISCONNECTED:
                     logger.debug(
                         "{}({}): State is already DISCONNECTED. Completing operation".format(
@@ -1085,7 +1085,7 @@ class ConnectionStateStage(PipelineStage):
                             self.name, op.name, self.nucleus.connection_state
                         )
                     )
-                    self.send_op_down()
+                    self.send_op_down(op)
 
             elif isinstance(op, pipeline_ops_base.ReauthorizeConnectionOperation):
                 if self.nucleus.connection_state is ConnectionState.CONNECTED:
@@ -1096,7 +1096,7 @@ class ConnectionStateStage(PipelineStage):
                     )
                     self.nucleus.connection_state = ConnectionState.REAUTHORIZING
                     self._add_connection_op_callback(op)
-                    self.send_op_down()
+                    self.send_op_down(op)
                 elif self.nucleus.connection_state is ConnectionState.DISCONNECTED:
                     logger.debug(
                         "{}({}): State changes DISCONNECTED -> REAUTHORIZING. Sending op down".format(
@@ -1105,7 +1105,7 @@ class ConnectionStateStage(PipelineStage):
                     )
                     self.nucleus.connection_state = ConnectionState.REAUTHORIZING
                     self._add_connection_op_callback(op)
-                    self.send_op_down()
+                    self.send_op_down(op)
                 else:
                     # This should be impossible to reach. If the state were intermediate, it
                     # would have been added to the waiting ops queue above.
@@ -1114,6 +1114,7 @@ class ConnectionStateStage(PipelineStage):
                             self.name, op.name, self.nucleus.connection_state
                         )
                     )
+                    self.send_op_down(op)
 
             elif isinstance(op, pipeline_ops_base.ShutdownPipelineOperation):
                 self._clear_reconnect_timer()
@@ -1124,7 +1125,7 @@ class ConnectionStateStage(PipelineStage):
                         "Operation waiting in ConnectionStateStage cancelled by shutdown"
                     )
                     waiting_op.complete(error=cancel_error)
-                self.send_op_down()
+                self.send_op_down(op)
 
             else:
                 self.send_op_down(op)

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
@@ -660,30 +660,30 @@ class ConnectionLockStage(PipelineStage):
             )
             op.complete()
 
-        elif (
-            isinstance(op, pipeline_ops_base.DisconnectOperation)
-            or isinstance(op, pipeline_ops_base.ConnectOperation)
-            or isinstance(op, pipeline_ops_base.ReauthorizeConnectionOperation)
-        ):
-            self._block(op)
+        # elif (
+        #     isinstance(op, pipeline_ops_base.DisconnectOperation)
+        #     or isinstance(op, pipeline_ops_base.ConnectOperation)
+        #     or isinstance(op, pipeline_ops_base.ReauthorizeConnectionOperation)
+        # ):
+        #     self._block(op)
 
-            @pipeline_thread.runs_on_pipeline_thread
-            def on_operation_complete(op, error):
-                if error:
-                    logger.debug(
-                        "{}({}): op failed.  Unblocking queue with error: {}".format(
-                            self.name, op.name, error
-                        )
-                    )
-                else:
-                    logger.debug(
-                        "{}({}): op succeeded.  Unblocking queue".format(self.name, op.name)
-                    )
+        #     @pipeline_thread.runs_on_pipeline_thread
+        #     def on_operation_complete(op, error):
+        #         if error:
+        #             logger.debug(
+        #                 "{}({}): op failed.  Unblocking queue with error: {}".format(
+        #                     self.name, op.name, error
+        #                 )
+        #             )
+        #         else:
+        #             logger.debug(
+        #                 "{}({}): op succeeded.  Unblocking queue".format(self.name, op.name)
+        #             )
 
-                self._unblock(op, error)
+        #         self._unblock(op, error)
 
-            op.add_callback(on_operation_complete)
-            self.send_op_down(op)
+        #     op.add_callback(on_operation_complete)
+        #     self.send_op_down(op)
 
         else:
             self.send_op_down(op)
@@ -1065,11 +1065,6 @@ class ConnectionStateStage(PipelineStage):
         ConnectionState.DISCONNECTING,
         ConnectionState.REAUTHORIZING,
     ]
-    connection_ops = [
-        pipeline_ops_base.ConnectOperation,
-        pipeline_ops_base.DisconnectOperation,
-        pipeline_ops_base.ReauthorizeConnectionOperation,
-    ]
     transient_connect_errors = [
         pipeline_exceptions.OperationCancelled,
         pipeline_exceptions.OperationTimeout,
@@ -1099,10 +1094,7 @@ class ConnectionStateStage(PipelineStage):
         # We need a way to wait ops without letting them pass through and affect the connection
         # state in order to address edge cases e.g. a user-initiated connect and a automatic
         # reconnect connect happen at approximately the same time.
-        if (
-            self.nucleus.connection_state in self.intermediate_states
-            and type(op) in self.connection_ops
-        ):
+        if self.nucleus.connection_state in self.intermediate_states:
             logger.debug(
                 "{}({}): State is {} - waiting for in-progress operation to finish".format(
                     self.name, op.name, self.nucleus.connection_state

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
@@ -615,122 +615,53 @@ class AutoConnectStage(PipelineStage):
         self.send_op_down(pipeline_ops_base.ConnectOperation(callback=on_connect_op_complete))
 
 
-class ConnectionLockStage(PipelineStage):
+class AutoCompleteStage(PipelineStage):
     """
-    This stage is responsible for serializing connect, disconnect, and reauthorize ops on
-    the pipeline, such that only a single one of these ops can go past this stage at a
-    time.  This way, we don't have to worry about cases like "what happens if we try to
-    disconnect if we're in the middle of reauthorizing."  This stage will wait for the
-    reauthorize to complete before letting the disconnect past.
+    Automatically complete connection operations that are attempting to get us to a state
+    we are already in. This is necessary because letting these operations get to the transport
+    runs the risk of them hanging, so we stop them here before they can get down there.
     """
-
-    def __init__(self):
-        super().__init__()
-        self.queue = queue.Queue()
-        self.blocked = False
 
     @pipeline_thread.runs_on_pipeline_thread
     def _run_op(self, op):
 
-        # If this stage is currently blocked (because we're waiting for a connection, etc,
-        # to complete), we queue up all operations until after the connect completes.
-        if self.blocked:
+        if (
+            isinstance(op, pipeline_ops_base.ConnectOperation)
+            and self.nucleus.connection_state is ConnectionState.CONNECTED
+        ):
             logger.debug(
-                "{}({}): pipeline is blocked waiting for a prior connect/disconnect/reauthorize to complete.  queueing.".format(
-                    self.name, op.name
-                )
-            )
-            self.queue.put_nowait(op)
-
-        elif isinstance(op, pipeline_ops_base.ConnectOperation) and self.nucleus.connected:
-            logger.info(
-                "{}({}): Transport is already connected.  Completing.".format(self.name, op.name)
+                "{}({}): Pipeline is already connected. Completing.".format(self.name, op.name)
             )
             op.complete()
 
-        # NOTE: We ought not to be checking specific ConnectionStates if it can be helped.
-        # Unfortunately, here, it can't be - it's okay, this stage will be deleted very soon
-        # TODO: Move auto-completion logic to ConnectionStateStage and delete this stage.
         elif (
             isinstance(op, pipeline_ops_base.DisconnectOperation)
             and self.nucleus.connection_state is ConnectionState.DISCONNECTED
         ):
-            logger.info(
-                "{}({}): Transport is already disconnected.  Completing.".format(self.name, op.name)
+            logger.debug(
+                "{}({}): Pipeline is already disconnected. Completing.".format(self.name, op.name)
             )
             op.complete()
 
-        # elif (
-        #     isinstance(op, pipeline_ops_base.DisconnectOperation)
-        #     or isinstance(op, pipeline_ops_base.ConnectOperation)
-        #     or isinstance(op, pipeline_ops_base.ReauthorizeConnectionOperation)
-        # ):
-        #     self._block(op)
-
-        #     @pipeline_thread.runs_on_pipeline_thread
-        #     def on_operation_complete(op, error):
-        #         if error:
-        #             logger.debug(
-        #                 "{}({}): op failed.  Unblocking queue with error: {}".format(
-        #                     self.name, op.name, error
-        #                 )
-        #             )
-        #         else:
-        #             logger.debug(
-        #                 "{}({}): op succeeded.  Unblocking queue".format(self.name, op.name)
-        #             )
-
-        #         self._unblock(op, error)
-
-        #     op.add_callback(on_operation_complete)
-        #     self.send_op_down(op)
+        elif self.nucleus.connection_state in [
+            ConnectionState.CONNECTING,
+            ConnectionState.DISCONNECTING,
+            ConnectionState.REAUTHORIZING,
+        ]:
+            # NOTE: This should NEVER happen. This is because of the ConnectionStateStage blocking
+            # ops from being sent down until a stable state is reached. The fact that this stage
+            # makes that assumption probably is evidence this functionality should be completely
+            # collapsed into the ConnectionStateStage at some point.
+            # This conditional block essentially just exists here for safety and logging.
+            logger.warning(
+                "{}({}): Pipeline in unexpected state: {}".format(
+                    self.name, op.name, self.nucleus.connection_state
+                )
+            )
+            self.send_op_down(op)
 
         else:
             self.send_op_down(op)
-
-    @pipeline_thread.runs_on_pipeline_thread
-    def _block(self, op):
-        """
-        block this stage while we're waiting for the connect/disconnect/reauthorize operation to complete.
-        """
-        logger.debug("{}({}): blocking".format(self.name, op.name))
-        self.blocked = True
-
-    @pipeline_thread.runs_on_pipeline_thread
-    def _unblock(self, op, error):
-        """
-        Unblock this stage after the connect/disconnect/reauthorize operation is complete.  This also means
-        releasing all the operations that were queued up.
-        """
-        logger.debug("{}({}): unblocking and releasing queued ops.".format(self.name, op.name))
-        self.blocked = False
-        logger.debug(
-            "{}({}): processing {} items in queue for error={}".format(
-                self.name, op.name, self.queue.qsize(), error
-            )
-        )
-        # Loop through our queue and release all the blocked operations
-        # Put a new Queue in self.queue because releasing ops might put them back in the
-        # queue, especially if there's a ConnectOperation in the list of ops to release
-        old_queue = self.queue
-        self.queue = queue.Queue()
-        while not old_queue.empty():
-            op_to_release = old_queue.get_nowait()
-            if error:
-                # if we're unblocking the queue because something (like a connect operation) failed,
-                # then we fail all of the blocked operations with the same error.
-                logger.debug(
-                    "{}({}): failing {} op because of error".format(
-                        self.name, op.name, op_to_release.name
-                    )
-                )
-                op_to_release.complete(error=error)
-            else:
-                logger.debug(
-                    "{}({}): releasing {} op.".format(self.name, op.name, op_to_release.name)
-                )
-                # call run_op directly here so operations go through this stage again (especially connect/disconnect ops)
-                self.run_op(op_to_release)
 
 
 class CoordinateRequestAndResponseStage(PipelineStage):
@@ -1087,13 +1018,8 @@ class ConnectionStateStage(PipelineStage):
     @pipeline_thread.runs_on_pipeline_thread
     def _run_op(self, op):
 
-        # If receiving a connection op while one is already in progress, wait for the current
-        # one to finish. This is kind of like a ConnectionLockStage, but inside this one.
-        # It has to happen here because just relying on a ConnectionLockStage before or after
-        # in the pipeline is insufficient, given that operations can spawn in this stage.
-        # We need a way to wait ops without letting them pass through and affect the connection
-        # state in order to address edge cases e.g. a user-initiated connect and a automatic
-        # reconnect connect happen at approximately the same time.
+        # If receiving an operation while the connection state is changing, wait for the
+        # connection state to reach a stable state before continuing.
         if self.nucleus.connection_state in self.intermediate_states:
             logger.debug(
                 "{}({}): State is {} - waiting for in-progress operation to finish".format(
@@ -1111,9 +1037,6 @@ class ConnectionStateStage(PipelineStage):
                         )
                     )
                     self._add_connection_op_callback(op)
-                    # NOTE: This is the safest thing to do while the ConnectionLockStage is
-                    # doing auto-completes based on connection status. When it is revisited,
-                    # this logic may need to be updated.
                 elif self.nucleus.connection_state is ConnectionState.DISCONNECTED:
                     logger.debug(
                         "{}({}): State changes DISCONNECTED -> CONNECTING. Sending op down".format(
@@ -1151,9 +1074,6 @@ class ConnectionStateStage(PipelineStage):
                         )
                     )
                     self._add_connection_op_callback(op)
-                    # NOTE: This is the safest thing to do while the ConnectionLockStage is
-                    # doing auto-completes based on connection status. When it is revisited,
-                    # this logic may need to be updated.
                 else:
                     # This should be impossible to reach. If the state were intermediate, it
                     # would have been added to the waiting ops queue above.
@@ -1320,7 +1240,7 @@ class ConnectionStateStage(PipelineStage):
         self_weakref = weakref.ref(self)
 
         # NOTE: we are currently protected from connect failing due to being already connected
-        # by the ConnectionLockStage. If the ConnectionLockStage changes functionality,
+        # by the AutoCompleteStage. If the AutoCompleteStage changes functionality,
         # we may need some logic changes to address an op that can fail while leaving us CONNECTED
 
         @pipeline_thread.runs_on_pipeline_thread

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/mqtt_pipeline.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/mqtt_pipeline.py
@@ -100,10 +100,10 @@ class MQTTPipeline(object):
             #
             .append_stage(pipeline_stages_base.ConnectionStateStage())
             #
-            # ConnectionLockStage needs to be after ConnectionStateStage because we want any ops that
-            # ConnectionStateStage creates to go through the ConnectionLockStage gate
+            # AutoCompleteStage needs to be after ConnectionStateStage because we want any ops that
+            # ConnectionStateStage creates to have the chance to be auto-completed.
             #
-            .append_stage(pipeline_stages_base.ConnectionLockStage())
+            .append_stage(pipeline_stages_base.AutoCompleteStage())
             #
             # RetryStage needs to be near the end because it's retrying low-level MQTT operations.
             #

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/mqtt_pipeline.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/mqtt_pipeline.py
@@ -100,11 +100,6 @@ class MQTTPipeline(object):
             #
             .append_stage(pipeline_stages_base.ConnectionStateStage())
             #
-            # AutoCompleteStage needs to be after ConnectionStateStage because we want any ops that
-            # ConnectionStateStage creates to have the chance to be auto-completed.
-            #
-            .append_stage(pipeline_stages_base.AutoCompleteStage())
-            #
             # RetryStage needs to be near the end because it's retrying low-level MQTT operations.
             #
             .append_stage(pipeline_stages_base.RetryStage())

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/mqtt_pipeline.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/mqtt_pipeline.py
@@ -87,11 +87,6 @@ class MQTTPipeline(object):
             #
             .append_stage(pipeline_stages_base.ConnectionStateStage())
             #
-            # AutoCompleteStage needs to be after ConnectionStateStage because we want any ops that
-            # ConnectionStateStage creates to have the chance to be auto-completed.
-            #
-            .append_stage(pipeline_stages_base.AutoCompleteStage())
-            #
             # RetryStage needs to be near the end because it's retrying low-level MQTT operations.
             #
             .append_stage(pipeline_stages_base.RetryStage())

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/mqtt_pipeline.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/mqtt_pipeline.py
@@ -87,10 +87,10 @@ class MQTTPipeline(object):
             #
             .append_stage(pipeline_stages_base.ConnectionStateStage())
             #
-            # ConnectionLockStage needs to be after ConnectionStateStage because we want any ops that
-            # ConnectionStateStage creates to go through the ConnectionLockStage gate
+            # AutoCompleteStage needs to be after ConnectionStateStage because we want any ops that
+            # ConnectionStateStage creates to have the chance to be auto-completed.
             #
-            .append_stage(pipeline_stages_base.ConnectionLockStage())
+            .append_stage(pipeline_stages_base.AutoCompleteStage())
             #
             # RetryStage needs to be near the end because it's retrying low-level MQTT operations.
             #

--- a/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
+++ b/azure-iot-device/tests/common/pipeline/test_pipeline_stages_base.py
@@ -2750,7 +2750,7 @@ class TestConnectionStateStageRunOpWithConnectOperation(
     def test_op_completes_success(self, stage, op):
         stage.nucleus.connection_state = ConnectionState.DISCONNECTED
         stage.run_op(op)
-        assert stage.nucleus.connection_state == ConnectionState.CONNECTING
+        assert stage.nucleus.connection_state is ConnectionState.CONNECTING
         op.complete()
 
         # NOTE: This is a very weird test in that this would never happen like this "in the wild"
@@ -2762,7 +2762,7 @@ class TestConnectionStateStageRunOpWithConnectOperation(
         # to show this, we will NOT emulate the state change that occurs from the event. Just
         # remember that in practice, the state would not actually still be the modified state, but
         # instead the desired goal state
-        assert stage.nucleus.connection_state == ConnectionState.CONNECTING
+        assert stage.nucleus.connection_state is ConnectionState.CONNECTING
 
     @pytest.mark.it(
         "Re-runs all of the ops in the `waiting_ops` queue (if any) upon completion of the op after it is sent down"
@@ -2794,7 +2794,7 @@ class TestConnectionStateStageRunOpWithConnectOperation(
     ):
         stage.nucleus.connection_state = ConnectionState.DISCONNECTED
         stage.run_op(op)
-        assert stage.nucleus.connection_state == ConnectionState.CONNECTING
+        assert stage.nucleus.connection_state is ConnectionState.CONNECTING
         assert stage.send_op_down.call_count == 1
         assert stage.send_op_down.call_args == mocker.call(op)
 
@@ -2882,7 +2882,7 @@ class TestConnectionStateStageRunOpWithDisconnectOperation(
         stage.run_op(op)
 
         assert op.completed
-        assert stage.nucleus.connection_state == ConnectionState.DISCONNECTED
+        assert stage.nucleus.connection_state is ConnectionState.DISCONNECTED
         assert stage.send_op_down.call_count == 0
 
     @pytest.mark.it(
@@ -2891,7 +2891,7 @@ class TestConnectionStateStageRunOpWithDisconnectOperation(
     def test_disconnected_state_change(self, mocker, stage, op):
         stage.nucleus.connection_state = ConnectionState.CONNECTED
         stage.run_op(op)
-        assert stage.nucleus.connection_state == ConnectionState.DISCONNECTING
+        assert stage.nucleus.connection_state is ConnectionState.DISCONNECTING
         assert stage.send_op_down.call_count == 1
         assert stage.send_op_down.call_args == mocker.call(op)
 
@@ -2901,11 +2901,11 @@ class TestConnectionStateStageRunOpWithDisconnectOperation(
     def test_op_completes_error(self, stage, op, arbitrary_exception):
         stage.nucleus.connection_state = ConnectionState.CONNECTED
         stage.run_op(op)
-        assert stage.nucleus.connection_state == ConnectionState.DISCONNECTING
+        assert stage.nucleus.connection_state is ConnectionState.DISCONNECTING
 
         op.complete(arbitrary_exception)
 
-        assert stage.nucleus.connection_state == ConnectionState.DISCONNECTED
+        assert stage.nucleus.connection_state is ConnectionState.DISCONNECTED
 
     @pytest.mark.it(
         "Does not change the state if the operation sent down the pipeline completes successfully"
@@ -2913,7 +2913,7 @@ class TestConnectionStateStageRunOpWithDisconnectOperation(
     def test_op_completes_success(self, stage, op):
         stage.nucleus.connection_state = ConnectionState.CONNECTED
         stage.run_op(op)
-        assert stage.nucleus.connection_state == ConnectionState.DISCONNECTING
+        assert stage.nucleus.connection_state is ConnectionState.DISCONNECTING
 
         op.complete()
 
@@ -2926,7 +2926,7 @@ class TestConnectionStateStageRunOpWithDisconnectOperation(
         # to show this, we will NOT emulate the state change that occurs from the event. Just
         # remember that in practice, the state would not actually still be the modified state, but
         # instead the desired goal state
-        assert stage.nucleus.connection_state == ConnectionState.DISCONNECTING
+        assert stage.nucleus.connection_state is ConnectionState.DISCONNECTING
 
     @pytest.mark.it(
         "Re-runs all the waiting ops in the `waiting_ops` queue (if any) upon completion of the op after it is sent down"
@@ -2958,7 +2958,7 @@ class TestConnectionStateStageRunOpWithDisconnectOperation(
     ):
         stage.nucleus.connection_state = ConnectionState.CONNECTED
         stage.run_op(op)
-        assert stage.nucleus.connection_state == ConnectionState.DISCONNECTING
+        assert stage.nucleus.connection_state is ConnectionState.DISCONNECTING
         assert stage.send_op_down.call_count == 1
         assert stage.send_op_down.call_args == mocker.call(op)
 
@@ -3024,7 +3024,7 @@ class TestConnectionStateStageRunOpWithReauthorizeConnectionOperation(
     def test_connected_state_change(self, mocker, stage, op):
         stage.nucleus.connection_state = ConnectionState.CONNECTED
         stage.run_op(op)
-        assert stage.nucleus.connection_state == ConnectionState.REAUTHORIZING
+        assert stage.nucleus.connection_state is ConnectionState.REAUTHORIZING
         assert stage.send_op_down.call_count == 1
         assert stage.send_op_down.call_args == mocker.call(op)
 
@@ -3034,7 +3034,7 @@ class TestConnectionStateStageRunOpWithReauthorizeConnectionOperation(
     def test_disconnected_state_change(self, mocker, stage, op):
         stage.nucleus.connection_state = ConnectionState.DISCONNECTED
         stage.run_op(op)
-        assert stage.nucleus.connection_state == ConnectionState.REAUTHORIZING
+        assert stage.nucleus.connection_state is ConnectionState.REAUTHORIZING
         assert stage.send_op_down.call_count == 1
         assert stage.send_op_down.call_args == mocker.call(op)
 
@@ -3065,7 +3065,7 @@ class TestConnectionStateStageRunOpWithReauthorizeConnectionOperation(
 
         op.complete(arbitrary_exception)
 
-        assert stage.nucleus.connection_state == ConnectionState.DISCONNECTED
+        assert stage.nucleus.connection_state is ConnectionState.DISCONNECTED
 
     @pytest.mark.it(
         "Does not change the state if the operation sent down the pipeline completes successfully"
@@ -3133,7 +3133,7 @@ class TestConnectionStateStageRunOpWithReauthorizeConnectionOperation(
     ):
         stage.nucleus.connection_state = ConnectionState.CONNECTED
         stage.run_op(op)
-        assert stage.nucleus.connection_state == ConnectionState.REAUTHORIZING
+        assert stage.nucleus.connection_state is ConnectionState.REAUTHORIZING
         assert stage.send_op_down.call_count == 1
         assert stage.send_op_down.call_args == mocker.call(op)
 

--- a/azure-iot-device/tests/iothub/pipeline/test_mqtt_pipeline.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_mqtt_pipeline.py
@@ -116,7 +116,7 @@ class TestMQTTPipelineInstantiation(object):
             pipeline_stages_iothub_mqtt.IoTHubMQTTTranslationStage,
             pipeline_stages_base.AutoConnectStage,
             pipeline_stages_base.ConnectionStateStage,
-            pipeline_stages_base.ConnectionLockStage,
+            pipeline_stages_base.AutoCompleteStage,
             pipeline_stages_base.RetryStage,
             pipeline_stages_base.OpTimeoutStage,
             pipeline_stages_mqtt.MQTTTransportStage,

--- a/azure-iot-device/tests/iothub/pipeline/test_mqtt_pipeline.py
+++ b/azure-iot-device/tests/iothub/pipeline/test_mqtt_pipeline.py
@@ -116,7 +116,6 @@ class TestMQTTPipelineInstantiation(object):
             pipeline_stages_iothub_mqtt.IoTHubMQTTTranslationStage,
             pipeline_stages_base.AutoConnectStage,
             pipeline_stages_base.ConnectionStateStage,
-            pipeline_stages_base.AutoCompleteStage,
             pipeline_stages_base.RetryStage,
             pipeline_stages_base.OpTimeoutStage,
             pipeline_stages_mqtt.MQTTTransportStage,

--- a/azure-iot-device/tests/provisioning/pipeline/test_mqtt_pipeline.py
+++ b/azure-iot-device/tests/provisioning/pipeline/test_mqtt_pipeline.py
@@ -108,7 +108,6 @@ class TestMQTTPipelineInstantiation(object):
             pipeline_stages_provisioning_mqtt.ProvisioningMQTTTranslationStage,
             pipeline_stages_base.AutoConnectStage,
             pipeline_stages_base.ConnectionStateStage,
-            pipeline_stages_base.AutoCompleteStage,
             pipeline_stages_base.RetryStage,
             pipeline_stages_base.OpTimeoutStage,
             pipeline_stages_mqtt.MQTTTransportStage,

--- a/azure-iot-device/tests/provisioning/pipeline/test_mqtt_pipeline.py
+++ b/azure-iot-device/tests/provisioning/pipeline/test_mqtt_pipeline.py
@@ -108,7 +108,7 @@ class TestMQTTPipelineInstantiation(object):
             pipeline_stages_provisioning_mqtt.ProvisioningMQTTTranslationStage,
             pipeline_stages_base.AutoConnectStage,
             pipeline_stages_base.ConnectionStateStage,
-            pipeline_stages_base.ConnectionLockStage,
+            pipeline_stages_base.AutoCompleteStage,
             pipeline_stages_base.RetryStage,
             pipeline_stages_base.OpTimeoutStage,
             pipeline_stages_mqtt.MQTTTransportStage,


### PR DESCRIPTION
* All remaining `ConnectionLockStage` functionality that was not already implemented by the `ConnectionStateStage` has now been moved there
* It's about time