### PR TITLE
chore: Edit logger.error calls

### DIFF
--- a/azure-iot-device/azure/iot/device/common/handle_exceptions.py
+++ b/azure-iot-device/azure/iot/device/common/handle_exceptions.py
@@ -25,8 +25,8 @@ def handle_background_exception(e):
 
     # @FUTURE: We should add a mechanism which allows applications to receive these
     # exceptions so they can respond accordingly
-    logger.error(msg="Exception caught in background thread.  Unable to handle.")
-    logger.error(traceback.format_exception_only(type(e), e))
+    logger.warning(msg="Exception caught in background thread.  Unable to handle.")
+    logger.warning(traceback.format_exception_only(type(e), e))
 
 
 def swallow_unraised_exception(e, log_msg=None, log_lvl="warning"):

--- a/azure-iot-device/azure/iot/device/common/mqtt_transport.py
+++ b/azure-iot-device/azure/iot/device/common/mqtt_transport.py
@@ -182,20 +182,22 @@ class MQTTTransport(object):
                             _create_error_from_connack_rc_code(rc)
                         )
                     except Exception:
-                        logger.error("Unexpected error calling on_mqtt_connection_failure_handler")
-                        logger.error(traceback.format_exc())
+                        logger.warning(
+                            "Unexpected error calling on_mqtt_connection_failure_handler"
+                        )
+                        logger.warning(traceback.format_exc())
                 else:
-                    logger.error(
+                    logger.warning(
                         "connection failed, but no on_mqtt_connection_failure_handler handler callback provided"
                     )
             elif this.on_mqtt_connected_handler:
                 try:
                     this.on_mqtt_connected_handler()
                 except Exception:
-                    logger.error("Unexpected error calling on_mqtt_connected_handler")
-                    logger.error(traceback.format_exc())
+                    logger.warning("Unexpected error calling on_mqtt_connected_handler")
+                    logger.warning(traceback.format_exc())
             else:
-                logger.error("No event handler callback set for on_mqtt_connected_handler")
+                logger.debug("No event handler callback set for on_mqtt_connected_handler")
 
         def on_disconnect(client, userdata, rc):
             this = self_weakref()
@@ -220,10 +222,10 @@ class MQTTTransport(object):
                     try:
                         this.on_mqtt_disconnected_handler(cause)
                     except Exception:
-                        logger.error("Unexpected error calling on_mqtt_disconnected_handler")
-                        logger.error(traceback.format_exc())
+                        logger.warning("Unexpected error calling on_mqtt_disconnected_handler")
+                        logger.warning(traceback.format_exc())
                 else:
-                    logger.error("No event handler callback set for on_mqtt_disconnected_handler")
+                    logger.warning("No event handler callback set for on_mqtt_disconnected_handler")
 
         def on_subscribe(client, userdata, mid, granted_qos):
             this = self_weakref()
@@ -254,10 +256,10 @@ class MQTTTransport(object):
                 try:
                     this.on_mqtt_message_received_handler(mqtt_message.topic, mqtt_message.payload)
                 except Exception:
-                    logger.error("Unexpected error calling on_mqtt_message_received_handler")
-                    logger.error(traceback.format_exc())
+                    logger.warning("Unexpected error calling on_mqtt_message_received_handler")
+                    logger.warning(traceback.format_exc())
             else:
-                logger.error(
+                logger.debug(
                     "No event handler callback set for on_mqtt_message_received_handler - DROPPING MESSAGE"
                 )
 
@@ -601,8 +603,8 @@ class OperationManager(object):
                 try:
                     callback()
                 except Exception:
-                    logger.error("Unexpected error calling callback for MID: {}".format(mid))
-                    logger.error(traceback.format_exc())
+                    logger.debug("Unexpected error calling callback for MID: {}".format(mid))
+                    logger.debug(traceback.format_exc())
             else:
                 # Not entirely unexpected because of QOS=1
                 logger.debug("No callback for MID: {}".format(mid))
@@ -644,8 +646,8 @@ class OperationManager(object):
                 try:
                     callback()
                 except Exception:
-                    logger.error("Unexpected error calling callback for MID: {}".format(mid))
-                    logger.error(traceback.format_exc())
+                    logger.debug("Unexpected error calling callback for MID: {}".format(mid))
+                    logger.debug(traceback.format_exc())
             else:
                 # fully expected.  QOS=1 means we might get 2 PUBACKs
                 logger.debug("No callback set for MID: {}".format(mid))
@@ -674,7 +676,7 @@ class OperationManager(object):
                 try:
                     callback(cancelled=True)
                 except Exception:
-                    logger.error("Unexpected error calling callback for MID: {}".format(mid))
-                    logger.error(traceback.format_exc())
+                    logger.debug("Unexpected error calling callback for MID: {}".format(mid))
+                    logger.debug(traceback.format_exc())
             else:
                 logger.debug("Cancelling {} - No callback set for MID".format(mid))

--- a/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
+++ b/azure-iot-device/azure/iot/device/common/pipeline/pipeline_stages_base.py
@@ -149,16 +149,16 @@ class PipelineStage(abc.ABC):
         except Exception as e:
             # Do not use exc_info parameter on logger.* calls. This causes pytest to save the
             # traceback which saves stack frames which shows up as a leak
-            logger.error(
+            logger.warning(
                 msg="{}: Unexpected error in ._handle_pipeline_event() call: {}".format(self, e)
             )
             if self.previous:
-                logger.error("{}: Raising background exception")
+                logger.warning("{}: Raising background exception")
                 self.report_background_exception(e)
             else:
                 # Nothing else we can do but log this. There exists no stage we can send the
                 # exception to, and raising would send the error back down the pipeline.
-                logger.error(
+                logger.warning(
                     "{}: Cannot report a background exception because there is no previous stage!"
                 )
 
@@ -187,7 +187,7 @@ class PipelineStage(abc.ABC):
             self.next.run_op(op)
         else:
             # This shouldn't happen if the pipeline was created correctly
-            logger.error(
+            logger.warning(
                 "{}({}): no next stage.cannot send op down. completing with error".format(
                     self.name, op.name
                 )
@@ -344,7 +344,7 @@ class PipelineRootStage(PipelineStage):
                 )
             else:
                 # unexpected condition: we should be handling all pipeline events
-                logger.error("incoming {} event with no handler.  dropping.".format(event.name))
+                logger.debug("incoming {} event with no handler.  dropping.".format(event.name))
 
 
 # NOTE: This stage could be a candidate for being refactored into some kind of other

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/mqtt_pipeline.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/mqtt_pipeline.py
@@ -126,28 +126,28 @@ class MQTTPipeline(object):
                 if self.on_c2d_message_received:
                     self.on_c2d_message_received(event.message)
                 else:
-                    logger.error("C2D message event received with no handler.  dropping.")
+                    logger.debug("C2D message event received with no handler.  dropping.")
 
             elif isinstance(event, pipeline_events_iothub.InputMessageEvent):
                 if self.on_input_message_received:
                     self.on_input_message_received(event.message)
                 else:
-                    logger.error("input message event received with no handler.  dropping.")
+                    logger.debug("input message event received with no handler.  dropping.")
 
             elif isinstance(event, pipeline_events_iothub.MethodRequestEvent):
                 if self.on_method_request_received:
                     self.on_method_request_received(event.method_request)
                 else:
-                    logger.error("Method request event received with no handler. Dropping.")
+                    logger.debug("Method request event received with no handler. Dropping.")
 
             elif isinstance(event, pipeline_events_iothub.TwinDesiredPropertiesPatchEvent):
                 if self.on_twin_patch_received:
                     self.on_twin_patch_received(event.patch)
                 else:
-                    logger.error("Twin patch event received with no handler. Dropping.")
+                    logger.debug("Twin patch event received with no handler. Dropping.")
 
             else:
-                logger.error("Dropping unknown pipeline event {}".format(event.name))
+                logger.debug("Dropping unknown pipeline event {}".format(event.name))
 
         def _on_connected():
             if self.on_connected:
@@ -520,7 +520,9 @@ class MQTTPipeline(object):
 
         def on_complete(op, error):
             if error:
-                logger.error("Subscribe for {} failed.  Not enabling feature".format(feature_name))
+                logger.warning(
+                    "Subscribe for {} failed.  Not enabling feature".format(feature_name)
+                )
             else:
                 self.feature_enabled[feature_name] = True
             callback(error=error)

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub_mqtt.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub_mqtt.py
@@ -168,7 +168,7 @@ class IoTHubMQTTTranslationStage(PipelineStage):
         elif feature == pipeline_constant.TWIN_PATCHES:
             return mqtt_topic_iothub.get_twin_patch_topic_for_subscribe()
         else:
-            logger.error("Cannot retrieve MQTT topic for subscription to invalid feature")
+            logger.warning("Cannot retrieve MQTT topic for subscription to invalid feature")
             raise pipeline_exceptions.OperationError(
                 "Trying to enable/disable invalid feature - {}".format(feature)
             )

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/mqtt_pipeline.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/mqtt_pipeline.py
@@ -109,7 +109,7 @@ class MQTTPipeline(object):
 
         def _on_pipeline_event(event):
             # error because no events should
-            logger.error("Dropping unknown pipeline event {}".format(event.name))
+            logger.debug("Dropping unknown pipeline event {}".format(event.name))
 
         def _on_connected():
             if self.on_connected:

--- a/device_e2e/aio/task_cleanup.py
+++ b/device_e2e/aio/task_cleanup.py
@@ -25,12 +25,12 @@ async def cleanup_tasks(task_list):
             await task_result
             tasks_left -= 1
         except asyncio.TimeoutError:
-            logger.error(
+            logger.warning(
                 "Task cleanup timeout with {} tasks remaining incomplete".format(tasks_left)
             )
             raise
         except Exception as e:
-            logger.error("Cleaning up task that failed with [{}]".format(str(e) or type(e)))
+            logger.debug("Cleaning up task that failed with [{}]".format(str(e) or type(e)))
             tasks_left -= 1
 
     logger.info("-------------------------")

--- a/device_e2e/conftest.py
+++ b/device_e2e/conftest.py
@@ -218,9 +218,9 @@ def pytest_runtest_setup(item):
 @pytest.hookimpl(hookwrapper=True)
 def pytest_exception_interact(node, call, report):
     e = call.excinfo.value
-    logger.error("------------------------------------------------------")
-    logger.error("EXCEPTION RAISED in {} phase: {}".format(report.when, str(e) or type(e)))
-    logger.error("------------------------------------------------------")
+    logger.warning("------------------------------------------------------")
+    logger.warning("EXCEPTION RAISED in {} phase: {}".format(report.when, str(e) or type(e)))
+    logger.warning("------------------------------------------------------")
 
     if hasattr(node, "outer_leak_tracker"):
         logger.info("Skipping leak tracking because of Exception {}".format(str(e) or type(e)))

--- a/device_e2e/iptables.py
+++ b/device_e2e/iptables.py
@@ -44,9 +44,9 @@ def run_shell_command(cmd):
     try:
         return subprocess.check_output(cmd.split(" ")).decode("utf-8").splitlines()
     except subprocess.CalledProcessError as e:
-        logger.error("Error spawning {}".format(e.cmd))
-        logger.error("Process returned {}".format(e.returncode))
-        logger.error("process output: {}".format(e.output))
+        logger.warning("Error spawning {}".format(e.cmd))
+        logger.warning("Process returned {}".format(e.returncode))
+        logger.warning("process output: {}".format(e.output))
         raise
 
 

--- a/device_e2e/leak_tracker.py
+++ b/device_e2e/leak_tracker.py
@@ -275,7 +275,7 @@ class LeakTracker(object):
         """
 
         logger.info("-----------------------------------------------")
-        logger.error("Test failure.  {} objects have leaked:".format(len(leaked_objects)))
+        logger.warning("Test failure.  {} objects have leaked:".format(len(leaked_objects)))
         logger.info("(Default text format is <type(obj): str(obj)>")
 
         id_to_name_map = {}

--- a/device_e2e/service_helper_sync.py
+++ b/device_e2e/service_helper_sync.py
@@ -237,7 +237,7 @@ class ServiceHelperSync(object):
 
     def _eventhub_thread(self):
         def on_error(partition_context, error):
-            logger.error("EventHub on_error: {}".format(str(error) or type(error)))
+            logger.warning("EventHub on_error: {}".format(str(error) or type(error)))
 
         def on_partition_initialize(partition_context):
             logger.warning("EventHub on_partition_initialize")
@@ -278,7 +278,7 @@ class ServiceHelperSync(object):
                         else:
                             self._store_patch_arrival(converted_event)
             except Exception:
-                logger.error("Error on on_event_batch", exc_info=True)
+                logger.warning("Error on on_event_batch", exc_info=True)
                 raise
 
         try:
@@ -292,5 +292,5 @@ class ServiceHelperSync(object):
                     on_partition_close=on_partition_close,
                 )
         except Exception:
-            logger.error("_eventhub_thread exception", exc_info=True)
+            logger.debug("_eventhub_thread exception", exc_info=True)
             raise


### PR DESCRIPTION
- Changes many logger.error calls to info or debug
- Error calls changed do not need to be flagged as errors, those that do are left unchanged
