### PR TITLE
fix: Updated TLS constant

### DIFF
--- a/azure-iot-device/azure/iot/device/common/http_transport.py
+++ b/azure-iot-device/azure/iot/device/common/http_transport.py
@@ -69,7 +69,7 @@ class HTTPTransport(object):
         This method creates the SSLContext object used to authenticate the connection. The generated context is used by the http_client and is necessary when authenticating using a self-signed X509 cert or trusted X509 cert
         """
         logger.debug("creating a SSL context")
-        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLSv1_2)
+        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
 
         if self._server_verification_cert:
             ssl_context.load_verify_locations(cadata=self._server_verification_cert)

--- a/azure-iot-device/azure/iot/device/common/mqtt_transport.py
+++ b/azure-iot-device/azure/iot/device/common/mqtt_transport.py
@@ -321,7 +321,7 @@ class MQTTTransport(object):
         This method creates the SSLContext object used by Paho to authenticate the connection.
         """
         logger.debug("creating a SSL context")
-        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLSv1_2)
+        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
 
         if self._server_verification_cert:
             logger.debug("configuring SSL context with custom server verification cert")

--- a/tests/unit/common/test_http_transport.py
+++ b/tests/unit/common/test_http_transport.py
@@ -96,7 +96,7 @@ class TestInstantiation(object):
         assert http_transport_object._proxies["https"] == expected_proxy_string
 
     @pytest.mark.it(
-        "Configures TLS/SSL context to use TLS 1.2, require certificates and check hostname"
+        "Configures TLS/SSL context to use client-side connection, require certificates and check hostname"
     )
     def test_configures_tls_context(self, mocker):
         mock_ssl_context_constructor = mocker.patch.object(ssl, "SSLContext")
@@ -105,7 +105,9 @@ class TestInstantiation(object):
         HTTPTransport(hostname=fake_hostname)
         # Verify correctness of TLS/SSL Context
         assert mock_ssl_context_constructor.call_count == 1
-        assert mock_ssl_context_constructor.call_args == mocker.call(protocol=ssl.PROTOCOL_TLSv1_2)
+        assert mock_ssl_context_constructor.call_args == mocker.call(
+            protocol=ssl.PROTOCOL_TLS_CLIENT
+        )
         assert mock_ssl_context.check_hostname is True
         assert mock_ssl_context.verify_mode == ssl.CERT_REQUIRED
 

--- a/tests/unit/common/test_mqtt_transport.py
+++ b/tests/unit/common/test_mqtt_transport.py
@@ -256,7 +256,7 @@ class TestInstantiation(object):
         )
 
     @pytest.mark.it(
-        "Configures TLS/SSL context to use TLS 1.2, require certificates and check hostname"
+        "Configures TLS/SSL context to use client-side connection, require certificates and check hostname"
     )
     def test_configures_tls_context(self, mocker):
         mock_mqtt_client = mocker.patch.object(mqtt, "Client").return_value
@@ -267,7 +267,9 @@ class TestInstantiation(object):
 
         # Verify correctness of TLS/SSL Context
         assert mock_ssl_context_constructor.call_count == 1
-        assert mock_ssl_context_constructor.call_args == mocker.call(protocol=ssl.PROTOCOL_TLSv1_2)
+        assert mock_ssl_context_constructor.call_args == mocker.call(
+            protocol=ssl.PROTOCOL_TLS_CLIENT
+        )
         assert mock_ssl_context.check_hostname is True
         assert mock_ssl_context.verify_mode == ssl.CERT_REQUIRED
 


### PR DESCRIPTION
In Python 3.6 the constant `PROTOCOL_TLSv1_2` has been deprecated