### PR TITLE
[V3] fix: re-enabled (some) memory leak testing in E2E

### DIFF
--- a/azure-iot-device/azure/iot/device/provisioning/abstract_provisioning_device_client.py
+++ b/azure-iot-device/azure/iot/device/provisioning/abstract_provisioning_device_client.py
@@ -224,6 +224,11 @@ class AbstractProvisioningDeviceClient(abc.ABC):
         return cls(mqtt_provisioning_pipeline)
 
     @abc.abstractmethod
+    def shutdown(self):
+        """Shut down the client."""
+        pass
+
+    @abc.abstractmethod
     def register(self):
         """
         Register the device with the Device Provisioning Service.

--- a/azure-iot-device/azure/iot/device/provisioning/aio/async_provisioning_device_client.py
+++ b/azure-iot-device/azure/iot/device/provisioning/aio/async_provisioning_device_client.py
@@ -35,8 +35,18 @@ async def handle_result(callback):
         raise exceptions.CredentialError("Credentials invalid, could not connect") from e
     except pipeline_exceptions.ProtocolClientError as e:
         raise exceptions.ClientError("Error in the IoTHub client") from e
+    except pipeline_exceptions.TlsExchangeAuthError as e:
+        raise exceptions.ClientError(
+            "Error in the provisioning client due to TLS exchanges."
+        ) from e
+    except pipeline_exceptions.ProtocolProxyError as e:
+        raise exceptions.ClientError(
+            "Error in the provisioning client raised due to proxy connections."
+        ) from e
     except pipeline_exceptions.OperationTimeout as e:
         raise exceptions.OperationTimeout("Could not complete operation before timeout") from e
+    except pipeline_exceptions.OperationCancelled as e:
+        raise exceptions.OperationCancelled("Operation was cancelled before completion") from e
     except pipeline_exceptions.PipelineNotRunning as e:
         raise exceptions.ClientError("Client has already been shut down") from e
     except Exception as e:
@@ -49,6 +59,20 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
     using Symmetric Key or X509 authentication.
     """
 
+    async def shutdown(self):
+        """Shut down the client for graceful exit.
+
+        Once this method is called, any attempts at further client calls will result in a
+        ClientError being raised
+
+        :raises: :class:`azure.iot.device.exceptions.ClientError` if there is an unexpected failure
+            during execution.
+        """
+        shutdown_async = async_adapter.emulate_async(self._pipeline.shutdown)
+        callback = async_adapter.AwaitableCallback()
+        await shutdown_async(callback=callback)
+        await handle_result(callback)
+
     async def register(self):
         """
         Register the device with the provisioning service.
@@ -56,8 +80,6 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
         Before returning the client will also disconnect from the provisioning service.
         If a registration attempt is made while a previous registration is in progress it may
         throw an error.
-
-        Once the device is successfully registered, the client will no longer be operable.
 
         :returns: RegistrationResult indicating the result of the registration.
         :rtype: :class:`azure.iot.device.RegistrationResult`
@@ -77,41 +99,50 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
         logger.info("Registering with Provisioning Service...")
 
         # Connect
-        if not self._pipeline._nucleus.connected:
-            connect_async = async_adapter.emulate_async(self._pipeline.connect)
-            connect_complete = async_adapter.AwaitableCallback()
-            await connect_async(callback=connect_complete)
-            result = await handle_result(connect_complete)
+        # NOTE: The client should always be disconnected when calling this API, so we have to
+        # connect every time. This is because of the finally block below that disconnects even
+        # on failure. However, even if somehow the client is already connected, there shouldn't
+        # be a problem - this connect will still succeed, while maintaining the existing connection
+        logger.debug("Starting pipeline connect operation")
+        connect_async = async_adapter.emulate_async(self._pipeline.connect)
+        connect_complete = async_adapter.AwaitableCallback()
+        await connect_async(callback=connect_complete)
+        await handle_result(connect_complete)
+        logger.debug("Completed pipeline connect operation")
 
-        # Enable Responses
-        if not self._pipeline.responses_enabled[dps_constant.REGISTER]:
-            await self._enable_responses()
+        try:
+            # Enable (if necessary)
+            if not self._pipeline.responses_enabled[dps_constant.REGISTER]:
+                logger.debug("Starting pipeline enable operation")
+                enable_async = async_adapter.emulate_async(self._pipeline.enable_responses)
+                enable_complete = async_adapter.AwaitableCallback()
+                await enable_async(callback=enable_complete)
+                await handle_result(enable_complete)
+                logger.debug("Completed pipeline enable operation")
 
-        # Register
-        register_async = async_adapter.emulate_async(self._pipeline.register)
-        register_complete = async_adapter.AwaitableCallback(return_arg_name="result")
-        await register_async(payload=self._provisioning_payload, callback=register_complete)
-        result = await handle_result(register_complete)
-
-        log_on_register_complete(result)
-
-        if result is not None and result.status == "assigned":
-            logger.debug("Beginning pipeline shutdown operation")
-            shutdown_async = async_adapter.emulate_async(self._pipeline.shutdown)
-            callback = async_adapter.AwaitableCallback()
-            await shutdown_async(callback=callback)
-            await handle_result(callback)
-            logger.debug("Completed pipeline shutdown operation")
+            # Register
+            logger.debug("Starting pipeline register operation")
+            register_async = async_adapter.emulate_async(self._pipeline.register)
+            register_complete = async_adapter.AwaitableCallback(return_arg_name="result")
+            await register_async(payload=self._provisioning_payload, callback=register_complete)
+            result = await handle_result(register_complete)
+            log_on_register_complete(result)
+            logger.debug("Completed pipeline register operation")
+        except Exception:
+            raise
+        finally:
+            # Disconnect
+            try:
+                # This shouldn't fail, but we put it in this block anyway to ensure that
+                # the result can still be returned in the case there is failure for some reason.
+                # This is okay to do because even in the case of failure, a disconnect occurs.
+                logger.debug("Starting pipeline disconnect operation")
+                disconnect_async = async_adapter.emulate_async(self._pipeline.disconnect)
+                disconnect_complete = async_adapter.AwaitableCallback()
+                await disconnect_async(callback=disconnect_complete)
+                await handle_result(disconnect_complete)
+                logger.debug("Completed pipeline disconnect operation")
+            except Exception as e:
+                logger.debug("Pipeline disconnect operation raised exception: {}".format(str(e)))
 
         return result
-
-    async def _enable_responses(self):
-        """Enable to receive responses from Device Provisioning Service."""
-        logger.info("Enabling reception of response from Device Provisioning Service...")
-        subscribe_async = async_adapter.emulate_async(self._pipeline.enable_responses)
-
-        subscription_complete = async_adapter.AwaitableCallback()
-        await subscribe_async(callback=subscription_complete)
-        await handle_result(subscription_complete)
-
-        logger.info("Successfully subscribed to Device Provisioning Service to receive responses")

--- a/azure-iot-device/azure/iot/device/provisioning/pipeline/exceptions.py
+++ b/azure-iot-device/azure/iot/device/provisioning/pipeline/exceptions.py
@@ -18,4 +18,6 @@ from azure.iot.device.common.transport_exceptions import (  # noqa: F401
     # But for now, this is a stopgap.
     UnauthorizedError,
     ProtocolClientError,
+    TlsExchangeAuthError,
+    ProtocolProxyError,
 )

--- a/azure-iot-device/azure/iot/device/provisioning/provisioning_device_client.py
+++ b/azure-iot-device/azure/iot/device/provisioning/provisioning_device_client.py
@@ -33,8 +33,18 @@ def handle_result(callback):
         raise exceptions.CredentialError("Credentials invalid, could not connect") from e
     except pipeline_exceptions.ProtocolClientError as e:
         raise exceptions.ClientError("Error in the provisioning client") from e
+    except pipeline_exceptions.TlsExchangeAuthError as e:
+        raise exceptions.ClientError(
+            "Error in the provisioning client due to TLS exchanges."
+        ) from e
+    except pipeline_exceptions.ProtocolProxyError as e:
+        raise exceptions.ClientError(
+            "Error in the provisioning client raised due to proxy connections."
+        ) from e
     except pipeline_exceptions.OperationTimeout as e:
         raise exceptions.OperationTimeout("Could not complete operation before timeout") from e
+    except pipeline_exceptions.OperationCancelled as e:
+        raise exceptions.OperationCancelled("Operation was cancelled before completion") from e
     except pipeline_exceptions.PipelineNotRunning as e:
         raise exceptions.ClientError("Client has already been shut down") from e
     except Exception as e:
@@ -47,6 +57,19 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
     using Symmetric Key or X509 authentication.
     """
 
+    def shutdown(self):
+        """Shut down the client for graceful exit.
+
+        Once this method is called, any attempts at further client calls will result in a
+        ClientError being raised
+
+        :raises: :class:`azure.iot.device.exceptions.ClientError` if there is an unexpected failure
+            during execution.
+        """
+        shutdown_complete = EventedCallback()
+        self._pipeline.shutdown(callback=shutdown_complete)
+        handle_result(shutdown_complete)
+
     def register(self):
         """
         Register the device with the provisioning service
@@ -56,8 +79,6 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
         Before returning, the client will also disconnect from the provisioning service.
         If a registration attempt is made while a previous registration is in progress it may
         throw an error.
-
-        Once the device is successfully registered, the client will no longer be operable.
 
         :returns: RegistrationResult indicating the result of the registration.
         :rtype: :class:`azure.iot.device.RegistrationResult`
@@ -77,44 +98,47 @@ class ProvisioningDeviceClient(AbstractProvisioningDeviceClient):
         logger.info("Registering with Provisioning Service...")
 
         # Connect
-        if not self._pipeline._nucleus.connected:
-            connect_complete = EventedCallback()
-            self._pipeline.connect(callback=connect_complete)
-            result = handle_result(connect_complete)
+        # NOTE: The client should always be disconnected when calling this API, so we have to
+        # connect every time. This is because of the finally block below that disconnects even
+        # on failure. However, even if somehow the client is already connected, there shouldn't
+        # be a problem - this connect will still succeed, while maintaining the existing connection
+        logger.debug("Starting pipeline connect operation")
+        connect_complete = EventedCallback()
+        self._pipeline.connect(callback=connect_complete)
+        handle_result(connect_complete)
+        logger.debug("Completed pipeline connect operation")
 
-        # Enable Responses
-        if not self._pipeline.responses_enabled[dps_constant.REGISTER]:
-            self._enable_responses()
+        try:
+            #  Enable (if necessary)
+            if not self._pipeline.responses_enabled[dps_constant.REGISTER]:
+                logger.debug("Starting pipeline enable operation")
+                enable_complete = EventedCallback()
+                self._pipeline.enable_responses(callback=enable_complete)
+                handle_result(enable_complete)
+                logger.debug("Completed pipeline enable operation")
 
-        # Register
-        register_complete = EventedCallback(return_arg_name="result")
-        self._pipeline.register(payload=self._provisioning_payload, callback=register_complete)
-        result = handle_result(register_complete)
-
-        log_on_register_complete(result)
-
-        # Implicitly shut down the pipeline upon successful completion
-        if result is not None and result.status == "assigned":
-            logger.debug("Beginning pipeline shutdown operation")
-            shutdown_complete = EventedCallback()
-            self._pipeline.shutdown(callback=shutdown_complete)
-            handle_result(shutdown_complete)
-            logger.debug("Completed pipeline shutdown operation")
+            # Register
+            logger.debug("Starting pipeline register operation")
+            register_complete = EventedCallback(return_arg_name="result")
+            self._pipeline.register(payload=self._provisioning_payload, callback=register_complete)
+            result = handle_result(register_complete)
+            log_on_register_complete(result)
+            logger.debug("Completed pipeline register operation")
+        except Exception:
+            raise
+        finally:
+            # Disconnect
+            try:
+                logger.debug("Starting pipeline disconnect operation")
+                disconnect_complete = EventedCallback()
+                self._pipeline.disconnect(callback=disconnect_complete)
+                handle_result(disconnect_complete)
+                logger.debug("Completed pipeline disconnect operation")
+            except Exception as e:
+                # This shouldn't fail, but we put it in this block anyway to ensure that
+                # the result can still be returned in the case there is failure for some reason.
+                # This is okay to do because even in the case of failure, a disconnect occurs.
+                # self._pipeline_disconnect()
+                logger.debug("Pipeline disconnect operation raised exception: {}".format(str(e)))
 
         return result
-
-    def _enable_responses(self):
-        """Enable to receive responses from Device Provisioning Service.
-
-        This is a synchronous call, meaning that this function will not return until the feature
-        has been enabled.
-
-        """
-        logger.info("Enabling reception of response from Device Provisioning Service...")
-
-        subscription_complete = EventedCallback()
-        self._pipeline.enable_responses(callback=subscription_complete)
-
-        handle_result(subscription_complete)
-
-        logger.info("Successfully subscribed to Device Provisioning Service to receive responses")

--- a/tests/e2e/provisioning_e2e/tests/test_async_certificate_enrollments.py
+++ b/tests/e2e/provisioning_e2e/tests/test_async_certificate_enrollments.py
@@ -300,4 +300,6 @@ async def result_from_register(registration_id, device_cert_file, device_key_fil
         websockets=protocol_boolean_mapping[protocol],
     )
 
-    return await provisioning_device_client.register()
+    result = await provisioning_device_client.register()
+    await provisioning_device_client.shutdown()
+    return result

--- a/tests/e2e/provisioning_e2e/tests/test_async_symmetric_enrollments.py
+++ b/tests/e2e/provisioning_e2e/tests/test_async_symmetric_enrollments.py
@@ -127,4 +127,6 @@ async def result_from_register(registration_id, symmetric_key, protocol):
         websockets=protocol_boolean_mapping[protocol],
     )
 
-    return await provisioning_device_client.register()
+    result = await provisioning_device_client.register()
+    await provisioning_device_client.shutdown()
+    return result

--- a/tests/e2e/provisioning_e2e/tests/test_sync_certificate_enrollments.py
+++ b/tests/e2e/provisioning_e2e/tests/test_sync_certificate_enrollments.py
@@ -299,4 +299,6 @@ def result_from_register(registration_id, device_cert_file, device_key_file, pro
         websockets=protocol_boolean_mapping[protocol],
     )
 
-    return provisioning_device_client.register()
+    result = provisioning_device_client.register()
+    provisioning_device_client.shutdown()
+    return result

--- a/tests/e2e/provisioning_e2e/tests/test_sync_symmetric_enrollments.py
+++ b/tests/e2e/provisioning_e2e/tests/test_sync_symmetric_enrollments.py
@@ -117,4 +117,6 @@ def result_from_register(registration_id, symmetric_key, protocol):
         websockets=protocol_boolean_mapping[protocol],
     )
 
-    return provisioning_device_client.register()
+    result = provisioning_device_client.register()
+    provisioning_device_client.shutdown()
+    return result

--- a/tests/unit/provisioning/aio/test_async_provisioning_device_client.py
+++ b/tests/unit/provisioning/aio/test_async_provisioning_device_client.py
@@ -23,6 +23,58 @@ logging.basicConfig(level=logging.DEBUG)
 pytestmark = pytest.mark.asyncio
 
 
+# NOTE: Not all of these errors are possible in practice on all pipeline operations.
+# However, we will test all of them on all pipeline operations for safety + maintainability
+POSSIBLE_CLIENT_ERRORS = [
+    pytest.param(
+        pipeline_exceptions.ConnectionDroppedError,
+        client_exceptions.ConnectionDroppedError,
+        id="ConnectionDroppedError->ConnectionDroppedError",
+    ),
+    pytest.param(
+        pipeline_exceptions.ConnectionFailedError,
+        client_exceptions.ConnectionFailedError,
+        id="ConnectionFailedError->ConnectionFailedError",
+    ),
+    pytest.param(
+        pipeline_exceptions.UnauthorizedError,
+        client_exceptions.CredentialError,
+        id="UnauthorizedError->CredentialError",
+    ),
+    pytest.param(
+        pipeline_exceptions.ProtocolClientError,
+        client_exceptions.ClientError,
+        id="ProtocolClientError->ClientError",
+    ),
+    pytest.param(
+        pipeline_exceptions.TlsExchangeAuthError,
+        client_exceptions.ClientError,
+        id="TlsExchangeAuthError->ClientError",
+    ),
+    pytest.param(
+        pipeline_exceptions.ProtocolProxyError,
+        client_exceptions.ClientError,
+        id="ProtocolProxyError->ClientError",
+    ),
+    pytest.param(
+        pipeline_exceptions.OperationTimeout,
+        client_exceptions.OperationTimeout,
+        id="OperationTimeout->OperationTimeout",
+    ),
+    pytest.param(
+        pipeline_exceptions.OperationCancelled,
+        client_exceptions.OperationCancelled,
+        id="OperationCancelled->OperationCancelled",
+    ),
+    pytest.param(
+        pipeline_exceptions.PipelineNotRunning,
+        client_exceptions.ClientError,
+        id="PipelineNotRunning->ClientError",
+    ),
+    pytest.param(Exception, client_exceptions.ClientError, id="Exception->ClientError"),
+]
+
+
 async def create_completed_future(result=None):
     f = asyncio.Future()
     f.set_result(result)
@@ -62,295 +114,301 @@ class TestProvisioningClientCreateFromX509Certificate(
     pass
 
 
-@pytest.mark.describe("ProvisioningDeviceClient (Async) - .register()")
-class TestClientRegister(object):
-    @pytest.mark.it("Implicitly connects to the provisioning service if not already connected")
-    async def test_connects_provisioning_only_if_not_already_connected(
-        self, mocker, provisioning_pipeline, registration_result
-    ):
-        # Override callback to pass successful result
-        def connect_complete_success_callback(callback):
-            callback()
-
-        mocker.patch.object(
-            provisioning_pipeline, "connect", side_effect=connect_complete_success_callback
-        )
-
-        # Not yet connected (does a connection)
-        provisioning_pipeline._nucleus.connected = False
-        assert provisioning_pipeline.connect.call_count == 0
+@pytest.mark.describe("ProvisioningDeviceClient (Async) - .shutdown()")
+class TestClientShutdown(object):
+    @pytest.mark.it("Begins a 'shutdown' pipeline operation")
+    async def test_calls_pipeline_shutdown(self, provisioning_pipeline):
         client = ProvisioningDeviceClient(provisioning_pipeline)
-        await client.register()
-        assert provisioning_pipeline.connect.call_count == 1
-
-        # Reset mock
-        provisioning_pipeline.connect.reset_mock()
-
-        # Already connected (does not do a connection)
-        provisioning_pipeline._nucleus.connected = True
-        assert provisioning_pipeline.connect.call_count == 0
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        await client.register()
-        assert provisioning_pipeline.connect.call_count == 0
-
-    @pytest.mark.it("Implicitly enables responses from provisioning service if not already enabled")
-    async def test_enables_provisioning_only_if_not_already_enabled(
-        self, mocker, provisioning_pipeline, registration_result
-    ):
-        # Override callback to pass successful result
-        def register_complete_success_callback(payload, callback):
-            callback(result=registration_result)
-
-        mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_success_callback
-        )
-
-        provisioning_pipeline.responses_enabled.__getitem__.return_value = False
-
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        await client.register()
-
-        assert provisioning_pipeline.enable_responses.call_count == 1
-
-        provisioning_pipeline.enable_responses.reset_mock()
-
-        provisioning_pipeline.responses_enabled.__getitem__.return_value = True
-        await client.register()
-        assert provisioning_pipeline.enable_responses.call_count == 0
-
-    @pytest.mark.it("Begins a 'register' pipeline operation")
-    async def test_register_calls_pipeline_register(
-        self, provisioning_pipeline, mocker, registration_result
-    ):
-        def register_complete_success_callback(payload, callback):
-            callback(result=registration_result)
-
-        mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_success_callback
-        )
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        await client.register()
-        assert provisioning_pipeline.register.call_count == 1
-
-    @pytest.mark.it(
-        "Begins a 'shutdown' pipeline operation if the registration result is successful"
-    )
-    async def test_shutdown_upon_success(self, mocker, provisioning_pipeline, registration_result):
-        # success result
-        registration_result._status = "assigned"
-
-        def register_complete_success_callback(payload, callback):
-            callback(result=registration_result)
-
-        mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_success_callback
-        )
-
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        await client.register()
-
+        await client.shutdown()
         assert provisioning_pipeline.shutdown.call_count == 1
 
     @pytest.mark.it(
-        "Does NOT begin a 'shutdown' pipeline operation if the registration result is NOT successful"
+        "Waits for the completion of the 'shutdown' pipeline operation before returning"
     )
-    async def test_no_shutdown_upon_fail(self, mocker, provisioning_pipeline, registration_result):
-        # fail result
-        registration_result._status = "not assigned"
-
-        def register_complete_fail_callback(payload, callback):
-            callback(result=registration_result)
-
-        mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_fail_callback
-        )
-
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        await client.register()
-
-        assert provisioning_pipeline.shutdown.call_count == 0
-
-    @pytest.mark.it(
-        "Waits for the completion of both the 'register' and 'shutdown' pipeline operations before returning, if the registration result is successful"
-    )
-    async def test_waits_for_pipeline_op_completions_on_success(
-        self, mocker, provisioning_pipeline, registration_result
-    ):
-        # success result
-        registration_result._status = "assigned"
-
-        # Set up mocks
-        cb_mock_register = mocker.MagicMock()
+    async def test_waits_for_pipeline_op_completion(self, mocker, provisioning_pipeline):
         cb_mock_shutdown = mocker.MagicMock()
-        cb_mock_register.completion.return_value = await create_completed_future(
-            registration_result
-        )
         cb_mock_shutdown.completion.return_value = await create_completed_future(None)
         mocker.patch.object(async_adapter, "AwaitableCallback").side_effect = [
-            cb_mock_register,
             cb_mock_shutdown,
         ]
 
-        # Run test
         client = ProvisioningDeviceClient(provisioning_pipeline)
-        await client.register()
-
-        # Calls made as expected
-        assert provisioning_pipeline.register.call_count == 1
+        await client.shutdown()
         assert provisioning_pipeline.shutdown.call_count == 1
-        # Callbacks sent to pipeline as expected
-        assert provisioning_pipeline.register.call_args == mocker.call(
-            payload=mocker.ANY, callback=cb_mock_register
-        )
         assert provisioning_pipeline.shutdown.call_args == mocker.call(callback=cb_mock_shutdown)
-        # Callback completions were waited upon as expected
-        assert cb_mock_register.completion.call_count == 1
         assert cb_mock_shutdown.completion.call_count == 1
-
-    @pytest.mark.it(
-        "Waits for the completion of just the 'register' pipeline operation before returning, if the registration result is NOT successful"
-    )
-    async def test_waits_for_pipeline_op_completion_on_failure(
-        self, mocker, provisioning_pipeline, registration_result
-    ):
-        # fail result
-        registration_result._status = "not assigned"
-
-        # Set up mocks
-        cb_mock_register = mocker.MagicMock()
-        cb_mock_shutdown = mocker.MagicMock()
-        cb_mock_register.completion.return_value = await create_completed_future(
-            registration_result
-        )
-        cb_mock_shutdown.completion.return_value = await create_completed_future(None)
-        mocker.patch.object(async_adapter, "AwaitableCallback").side_effect = [
-            cb_mock_register,
-            cb_mock_shutdown,
-        ]
-
-        # Run test
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        await client.register()
-
-        # Calls made as expected
-        assert provisioning_pipeline.register.call_count == 1
-        assert provisioning_pipeline.shutdown.call_count == 0
-        # Callbacks sent to pipeline as expected
-        assert provisioning_pipeline.register.call_args == mocker.call(
-            payload=mocker.ANY, callback=cb_mock_register
-        )
-        # Callback completions were waited upon as expected
-        assert cb_mock_register.completion.call_count == 1
-        assert cb_mock_shutdown.completion.call_count == 0
-
-    @pytest.mark.it("Returns the registration result that the pipeline returned")
-    async def test_verifies_registration_result_returned(
-        self, mocker, provisioning_pipeline, registration_result
-    ):
-        result = registration_result
-
-        def register_complete_success_callback(payload, callback):
-            callback(result=result)
-
-        mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_success_callback
-        )
-
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        result_returned = await client.register()
-        assert result_returned == result
-
-    @pytest.mark.it(
-        "Raises a client error if the `register` pipeline operation calls back with a pipeline error"
-    )
-    @pytest.mark.parametrize(
-        "pipeline_error,client_error",
-        [
-            pytest.param(
-                pipeline_exceptions.ConnectionDroppedError,
-                client_exceptions.ConnectionDroppedError,
-                id="ConnectionDroppedError->ConnectionDroppedError",
-            ),
-            pytest.param(
-                pipeline_exceptions.ConnectionFailedError,
-                client_exceptions.ConnectionFailedError,
-                id="ConnectionFailedError->ConnectionFailedError",
-            ),
-            pytest.param(
-                pipeline_exceptions.UnauthorizedError,
-                client_exceptions.CredentialError,
-                id="UnauthorizedError->CredentialError",
-            ),
-            pytest.param(
-                pipeline_exceptions.ProtocolClientError,
-                client_exceptions.ClientError,
-                id="ProtocolClientError->ClientError",
-            ),
-            pytest.param(
-                pipeline_exceptions.OperationTimeout,
-                client_exceptions.OperationTimeout,
-                id="OperationTimeout->OperationTimeout",
-            ),
-            pytest.param(Exception, client_exceptions.ClientError, id="Exception->ClientError"),
-        ],
-    )
-    async def test_raises_error_on_register_pipeline_op_error(
-        self, mocker, client_error, pipeline_error, provisioning_pipeline
-    ):
-        error = pipeline_error()
-
-        def register_complete_failure_callback(payload, callback):
-            callback(result=None, error=error)
-
-        mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_failure_callback
-        )
-
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-
-        with pytest.raises(client_error) as e_info:
-            await client.register()
-
-        assert e_info.value.__cause__ is error
-        assert provisioning_pipeline.register.call_count == 1
 
     @pytest.mark.it(
         "Raises a client error if the `shutdown` pipeline operation calls back with a pipeline error"
     )
-    @pytest.mark.parametrize(
-        "pipeline_error,client_error",
-        [
-            # The only expected errors are unexpected ones
-            pytest.param(Exception, client_exceptions.ClientError, id="Exception->ClientError")
-        ],
-    )
-    async def test_raises_error_on_shutdown_pipeline_op_error(
-        self, mocker, pipeline_error, client_error, provisioning_pipeline, registration_result
+    @pytest.mark.parametrize("pipeline_error,client_error", POSSIBLE_CLIENT_ERRORS)
+    async def test_raises_error_on_pipeline_op_error(
+        self, mocker, provisioning_pipeline, pipeline_error, client_error
     ):
-        # success result is required to trigger shutdown
-        registration_result._status = "assigned"
-
         error = pipeline_error()
 
-        def register_complete_success_callback(payload, callback):
-            callback(result=registration_result)
-
-        def shutdown_failure_callback(callback):
-            callback(result=None, error=error)
+        def shutdown_complete_failure_callback(callback):
+            callback(error=error)
 
         mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_success_callback
-        )
-        mocker.patch.object(
-            provisioning_pipeline, "shutdown", side_effect=shutdown_failure_callback
+            provisioning_pipeline, "shutdown", side_effect=shutdown_complete_failure_callback
         )
 
         client = ProvisioningDeviceClient(provisioning_pipeline)
         with pytest.raises(client_error) as e_info:
-            await client.register()
+            await client.shutdown()
 
         assert e_info.value.__cause__ is error
+        assert provisioning_pipeline.shutdown.call_count == 1
+
+
+@pytest.mark.describe("ProvisioningDeviceClient (Async) - .register()")
+class TestClientRegister(object):
+    @pytest.fixture
+    def client(self, provisioning_pipeline):
+        return ProvisioningDeviceClient(provisioning_pipeline)
+
+    @pytest.mark.it(
+        "Runs `connect`, `enable`, `register` and `disconnect` pipeline operations in sequence, if the registration response feature is not yet enabled"
+    )
+    async def test_pipeline_operations_responses_disabled(
+        self, mocker, client, provisioning_pipeline, registration_result
+    ):
+        # Set the pipeline to have responses not yet enabled
+        provisioning_pipeline.responses_enabled.__getitem__.return_value = False
+        # Create a manager mock to track all pipeline calls
+        manager_mock = mocker.MagicMock()
+        manager_mock.attach_mock(provisioning_pipeline.connect, "connect")
+        manager_mock.attach_mock(provisioning_pipeline.enable_responses, "enable_responses")
+        manager_mock.attach_mock(provisioning_pipeline.register, "register")
+        manager_mock.attach_mock(provisioning_pipeline.disconnect, "disconnect")
+
+        # Pipeline operations have not yet been called
+        assert provisioning_pipeline.connect.call_count == 0
+        assert provisioning_pipeline.enable_responses.call_count == 0
+        assert provisioning_pipeline.register.call_count == 0
+        assert provisioning_pipeline.disconnect.call_count == 0
+
+        await client.register()
+
+        # Pipeline operations were called in sequence
+        assert provisioning_pipeline.connect.call_count == 1
+        assert provisioning_pipeline.enable_responses.call_count == 1
         assert provisioning_pipeline.register.call_count == 1
+        assert provisioning_pipeline.disconnect.call_count == 1
+        assert manager_mock.mock_calls == [
+            mocker.call.connect(callback=mocker.ANY),
+            mocker.call.enable_responses(callback=mocker.ANY),
+            mocker.call.register(payload=mocker.ANY, callback=mocker.ANY),
+            mocker.call.disconnect(callback=mocker.ANY),
+        ]
+
+    @pytest.mark.it(
+        "Runs `connect`, `register` and `disconnect` pipeline operations in sequence, if the registration response feature is already enabled"
+    )
+    async def test_pipeline_operations_responses_enabled(
+        self, mocker, client, provisioning_pipeline, registration_result
+    ):
+        # Set the pipeline to have responses already enabled
+        provisioning_pipeline.responses_enabled.__getitem__.return_value = True
+        # Create a manager mock to track all pipeline calls
+        manager_mock = mocker.MagicMock()
+        manager_mock.attach_mock(provisioning_pipeline.connect, "connect")
+        manager_mock.attach_mock(provisioning_pipeline.enable_responses, "enable_responses")
+        manager_mock.attach_mock(provisioning_pipeline.register, "register")
+        manager_mock.attach_mock(provisioning_pipeline.disconnect, "disconnect")
+
+        # Pipeline operations have not yet been called
+        assert provisioning_pipeline.connect.call_count == 0
+        assert provisioning_pipeline.enable_responses.call_count == 0
+        assert provisioning_pipeline.register.call_count == 0
+        assert provisioning_pipeline.disconnect.call_count == 0
+
+        await client.register()
+
+        # Enabling responses was not called
+        assert provisioning_pipeline.enable_responses.call_count == 0
+        # Pipeline operations were called in sequence
+        assert provisioning_pipeline.connect.call_count == 1
+        assert provisioning_pipeline.register.call_count == 1
+        assert provisioning_pipeline.disconnect.call_count == 1
+        assert manager_mock.mock_calls == [
+            mocker.call.connect(callback=mocker.ANY),
+            mocker.call.register(payload=mocker.ANY, callback=mocker.ANY),
+            mocker.call.disconnect(callback=mocker.ANY),
+        ]
+
+    @pytest.mark.it("Waits for the completion of all pipeline operations before returning")
+    async def test_pipeline_operations_completed(self, mocker, client, provisioning_pipeline):
+        # Set the pipeline to have responses not yet enabled
+        provisioning_pipeline.responses_enabled.__getitem__.return_value = False
+        cb_mock_connect = mocker.MagicMock()
+        cb_mock_connect.completion.return_value = await create_completed_future(None)
+        cb_mock_enable = mocker.MagicMock()
+        cb_mock_enable.completion.return_value = await create_completed_future(None)
+        cb_mock_register = mocker.MagicMock()
+        cb_mock_register.completion.return_value = await create_completed_future(None)
+        cb_mock_disconnect = mocker.MagicMock()
+        cb_mock_disconnect.completion.return_value = await create_completed_future(None)
+
+        mocker.patch.object(async_adapter, "AwaitableCallback").side_effect = [
+            cb_mock_connect,
+            cb_mock_enable,
+            cb_mock_register,
+            cb_mock_disconnect,
+        ]
+
+        await client.register()
+
+        # All pipeline op completions were waited upon
+        assert provisioning_pipeline.connect.call_count == 1
+        assert provisioning_pipeline.connect.call_args == mocker.call(callback=cb_mock_connect)
+        assert cb_mock_connect.completion.call_count == 1
+        assert provisioning_pipeline.enable_responses.call_count == 1
+        assert provisioning_pipeline.enable_responses.call_args == mocker.call(
+            callback=cb_mock_enable
+        )
+        assert cb_mock_enable.completion.call_count == 1
+        assert provisioning_pipeline.register.call_count == 1
+        assert provisioning_pipeline.register.call_args == mocker.call(
+            payload=mocker.ANY, callback=cb_mock_register
+        )
+        assert cb_mock_register.completion.call_count == 1
+        assert provisioning_pipeline.disconnect.call_count == 1
+        assert provisioning_pipeline.disconnect.call_args == mocker.call(
+            callback=cb_mock_disconnect
+        )
+        assert cb_mock_disconnect.completion.call_count == 1
+
+    @pytest.mark.it("Provides the provisioning payload to the pipeline `register` operation")
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            pytest.param(None, id="No payload set on client"),
+            pytest.param("Some Payload", id="Custom payload set on client"),
+        ],
+    )
+    async def test_register_with_payload(self, mocker, client, provisioning_pipeline, payload):
+        if payload:
+            client.provisioning_payload = payload
+        else:
+            assert client.provisioning_payload is None
+
+        await client.register()
+
+        assert provisioning_pipeline.register.call_count == 1
+        assert provisioning_pipeline.register.call_args == mocker.call(
+            payload=client.provisioning_payload, callback=mocker.ANY
+        )
+
+    @pytest.mark.it("Returns the registration result returned by the pipeline `register` operation")
+    @pytest.mark.parametrize(
+        "registration_success",
+        [
+            pytest.param(True, id="Registration succeeded (assigned)"),
+            pytest.param(False, id="Registration failed (not assigned)"),
+        ],
+    )
+    async def test_returns_registration_result(
+        self, client, provisioning_pipeline, registration_result, registration_success
+    ):
+        if registration_success:
+            registration_result._status = "assigned"
+        else:
+            registration_result._status = "not assigned"
+
+        def register_complete_callback(payload, callback):
+            callback(result=registration_result)
+
+        provisioning_pipeline.register.side_effect = register_complete_callback
+
+        result = await client.register()
+        assert result is registration_result
+
+    @pytest.mark.it(
+        "Raises a client error if the `connect` pipeline operation calls back with a pipeline error"
+    )
+    @pytest.mark.parametrize("pipeline_error,client_error", POSSIBLE_CLIENT_ERRORS)
+    async def test_connect_raises_error(
+        self, client, provisioning_pipeline, pipeline_error, client_error
+    ):
+        my_pipeline_error = pipeline_error()
+
+        def connect_complete_callback(callback):
+            callback(error=my_pipeline_error)
+
+        provisioning_pipeline.connect.side_effect = connect_complete_callback
+
+        with pytest.raises(client_error) as e_info:
+            await client.register()
+        assert e_info.value.__cause__ is my_pipeline_error
+        # Disconnect did not have to called because the connect never succeeded
+        assert provisioning_pipeline.disconnect.call_count == 0
+
+    @pytest.mark.it(
+        "Raises a client error and disconnects if the `enable` pipeline operation calls back with a pipeline error"
+    )
+    @pytest.mark.parametrize("pipeline_error,client_error", POSSIBLE_CLIENT_ERRORS)
+    async def test_enable_raises_error(
+        self, client, provisioning_pipeline, pipeline_error, client_error
+    ):
+        # Set the pipeline to have responses not yet enabled
+        provisioning_pipeline.responses_enabled.__getitem__.return_value = False
+
+        my_pipeline_error = pipeline_error()
+
+        def enable_complete_callback(callback):
+            callback(error=my_pipeline_error)
+
+        provisioning_pipeline.enable_responses.side_effect = enable_complete_callback
+
+        with pytest.raises(client_error) as e_info:
+            await client.register()
+        assert e_info.value.__cause__ is my_pipeline_error
+        # Disconnect was called to clean up failure
+        assert provisioning_pipeline.disconnect.call_count == 1
+
+    @pytest.mark.it(
+        "Raises a client error and disconnects if the `register` pipeline operation calls back with a pipeline error"
+    )
+    @pytest.mark.parametrize("pipeline_error,client_error", POSSIBLE_CLIENT_ERRORS)
+    async def test_register_raises_error(
+        self, client, provisioning_pipeline, pipeline_error, client_error
+    ):
+        my_pipeline_error = pipeline_error()
+
+        def register_complete_callback(payload, callback):
+            callback(error=my_pipeline_error, result=None)
+
+        provisioning_pipeline.register.side_effect = register_complete_callback
+
+        with pytest.raises(client_error) as e_info:
+            await client.register()
+        assert e_info.value.__cause__ is my_pipeline_error
+        # Disconnect was called to clean up failure
+        assert provisioning_pipeline.disconnect.call_count == 1
+
+    @pytest.mark.it(
+        "Still returns the registration result even if the `disconnect` pipeline operation calls back with a pipeline error"
+    )
+    @pytest.mark.parametrize("pipeline_error,client_error", POSSIBLE_CLIENT_ERRORS)
+    async def test_disconnect_raises_error(
+        self, client, provisioning_pipeline, registration_result, pipeline_error, client_error
+    ):
+        my_pipeline_error = pipeline_error()
+
+        def register_complete_callback(payload, callback):
+            callback(result=registration_result)
+
+        provisioning_pipeline.register.side_effect = register_complete_callback
+
+        def disconnect_complete_callback(callback):
+            callback(error=my_pipeline_error)
+
+        provisioning_pipeline.disconnect.side_effect = disconnect_complete_callback
+
+        result = await client.register()
+        assert result is registration_result
 
 
 @pytest.mark.describe("ProvisioningDeviceClient (Async) - .set_provisioning_payload()")

--- a/tests/unit/provisioning/shared_client_fixtures.py
+++ b/tests/unit/provisioning/shared_client_fixtures.py
@@ -16,7 +16,7 @@ from azure.iot.device.common.models.x509 import X509
 fake_x509_cert_file_value = "fake_cert_file"
 fake_x509_cert_key_file = "fake_cert_key_file"
 fake_pass_phrase = "fake_pass_phrase"
-fake_status = "200"
+fake_status = "assigned"
 fake_sub_status = "OK"
 fake_operation_id = "fake_operation_id"
 fake_device_id = "MyDevice"

--- a/tests/unit/provisioning/test_sync_provisioning_device_client.py
+++ b/tests/unit/provisioning/test_sync_provisioning_device_client.py
@@ -18,6 +18,58 @@ from .shared_client_tests import (
 logging.basicConfig(level=logging.DEBUG)
 
 
+# NOTE: Not all of these errors are possible in practice on all pipeline operations.
+# However, we will test all of them on all pipeline operations for safety + maintainability
+POSSIBLE_CLIENT_ERRORS = [
+    pytest.param(
+        pipeline_exceptions.ConnectionDroppedError,
+        client_exceptions.ConnectionDroppedError,
+        id="ConnectionDroppedError->ConnectionDroppedError",
+    ),
+    pytest.param(
+        pipeline_exceptions.ConnectionFailedError,
+        client_exceptions.ConnectionFailedError,
+        id="ConnectionFailedError->ConnectionFailedError",
+    ),
+    pytest.param(
+        pipeline_exceptions.UnauthorizedError,
+        client_exceptions.CredentialError,
+        id="UnauthorizedError->CredentialError",
+    ),
+    pytest.param(
+        pipeline_exceptions.ProtocolClientError,
+        client_exceptions.ClientError,
+        id="ProtocolClientError->ClientError",
+    ),
+    pytest.param(
+        pipeline_exceptions.TlsExchangeAuthError,
+        client_exceptions.ClientError,
+        id="TlsExchangeAuthError->ClientError",
+    ),
+    pytest.param(
+        pipeline_exceptions.ProtocolProxyError,
+        client_exceptions.ClientError,
+        id="ProtocolProxyError->ClientError",
+    ),
+    pytest.param(
+        pipeline_exceptions.OperationTimeout,
+        client_exceptions.OperationTimeout,
+        id="OperationTimeout->OperationTimeout",
+    ),
+    pytest.param(
+        pipeline_exceptions.OperationCancelled,
+        client_exceptions.OperationCancelled,
+        id="OperationCancelled->OperationCancelled",
+    ),
+    pytest.param(
+        pipeline_exceptions.PipelineNotRunning,
+        client_exceptions.ClientError,
+        id="PipelineNotRunning->ClientError",
+    ),
+    pytest.param(Exception, client_exceptions.ClientError, id="Exception->ClientError"),
+]
+
+
 class ProvisioningClientTestsConfig(object):
     """Defines fixtures for synchronous ProvisioningDeviceClient tests"""
 
@@ -51,287 +103,290 @@ class TestProvisioningClientCreateFromX509Certificate(
     pass
 
 
-@pytest.mark.describe("ProvisioningDeviceClient (Sync) - .register()")
-class TestClientRegister(object):
-    @pytest.mark.it("Implicitly connects to the provisioning service if not already connected")
-    def test_connects_provisioning_only_if_not_already_connected(
-        self, mocker, provisioning_pipeline, registration_result
-    ):
-        # Override callback to pass successful result
-        def connect_complete_success_callback(callback):
-            callback()
-
-        mocker.patch.object(
-            provisioning_pipeline, "connect", side_effect=connect_complete_success_callback
-        )
-
-        # Not yet connected (does a connection)
-        provisioning_pipeline._nucleus.connected = False
-        assert provisioning_pipeline.connect.call_count == 0
+@pytest.mark.describe("ProvisioningDeviceClient (Sync) - .shutdown()")
+class TestClientShutdown(object):
+    @pytest.mark.it("Begins a 'shutdown' pipeline operation")
+    def test_calls_pipeline_shutdown(self, provisioning_pipeline):
         client = ProvisioningDeviceClient(provisioning_pipeline)
-        client.register()
-        assert provisioning_pipeline.connect.call_count == 1
-
-        # Reset mock
-        provisioning_pipeline.connect.reset_mock()
-
-        # Already connected (does not do a connection)
-        provisioning_pipeline._nucleus.connected = True
-        assert provisioning_pipeline.connect.call_count == 0
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        client.register()
-        assert provisioning_pipeline.connect.call_count == 0
-
-    @pytest.mark.it("Implicitly enables responses from provisioning service if not already enabled")
-    def test_enables_provisioning_only_if_not_already_enabled(
-        self, mocker, provisioning_pipeline, registration_result
-    ):
-        # Override callback to pass successful result
-        def register_complete_success_callback(payload, callback):
-            callback(result=registration_result)
-
-        mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_success_callback
-        )
-
-        provisioning_pipeline.responses_enabled.__getitem__.return_value = False
-
-        # assert provisioning_pipeline.responses_enabled is False
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        client.register()
-
-        assert provisioning_pipeline.enable_responses.call_count == 1
-
-        provisioning_pipeline.enable_responses.reset_mock()
-
-        provisioning_pipeline.responses_enabled.__getitem__.return_value = True
-        client.register()
-        assert provisioning_pipeline.enable_responses.call_count == 0
-
-    @pytest.mark.it("Begins a 'register' pipeline operation")
-    def test_register_calls_pipeline_register(
-        self, provisioning_pipeline, mocker, registration_result
-    ):
-        def register_complete_success_callback(payload, callback):
-            callback(result=registration_result)
-
-        mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_success_callback
-        )
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        client.register()
-        assert provisioning_pipeline.register.call_count == 1
-
-    @pytest.mark.it(
-        "Begins a 'shutdown' pipeline operation if the registration result is successful"
-    )
-    def test_shutdown_upon_success(self, mocker, provisioning_pipeline, registration_result):
-        # success result
-        registration_result._status = "assigned"
-
-        def register_complete_success_callback(payload, callback):
-            callback(result=registration_result)
-
-        mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_success_callback
-        )
-
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        client.register()
-
+        client.shutdown()
         assert provisioning_pipeline.shutdown.call_count == 1
 
     @pytest.mark.it(
-        "Does NOT begin a 'shutdown' pipeline operation if the registration result is NOT successful"
+        "Waits for the completion of the 'shutdown' pipeline operation before returning"
     )
-    def test_no_shutdown_upon_fail(self, mocker, provisioning_pipeline, registration_result):
-        # fail result
-        registration_result._status = "not assigned"
-
-        def register_complete_fail_callback(payload, callback):
-            callback(result=registration_result)
-
-        mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_fail_callback
-        )
-
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        client.register()
-
-        assert provisioning_pipeline.shutdown.call_count == 0
-
-    @pytest.mark.it(
-        "Waits for the completion of both the 'register' and 'shutdown' pipeline operations before returning, if the registration result is successful"
-    )
-    def test_waits_for_pipeline_op_completions_on_success(
-        self, mocker, provisioning_pipeline, registration_result
-    ):
-        # success result
-        registration_result._status = "assigned"
-
-        # Set up mocks
-        cb_mock_register = mocker.MagicMock()
-        cb_mock_register.wait_for_completion.return_value = registration_result
-        cb_mock_shutdown = mocker.MagicMock()
-        mocker.patch(
+    def test_waits_for_pipeline_op_completion(self, mocker, provisioning_pipeline):
+        cb_mock_shutdown = mocker.patch(
             "azure.iot.device.provisioning.provisioning_device_client.EventedCallback"
-        ).side_effect = [cb_mock_register, cb_mock_shutdown]
+        ).return_value
 
-        # Run test
         client = ProvisioningDeviceClient(provisioning_pipeline)
-        client.register()
-
-        # Calls made as expected
-        assert provisioning_pipeline.register.call_count == 1
+        client.shutdown()
         assert provisioning_pipeline.shutdown.call_count == 1
-        # Callbacks sent to pipeline as expected
-        assert provisioning_pipeline.register.call_args == mocker.call(
-            payload=mocker.ANY, callback=cb_mock_register
-        )
         assert provisioning_pipeline.shutdown.call_args == mocker.call(callback=cb_mock_shutdown)
-        # Callback completions were waited upon as expected
-        assert cb_mock_register.wait_for_completion.call_count == 1
         assert cb_mock_shutdown.wait_for_completion.call_count == 1
-
-    @pytest.mark.it(
-        "Waits for the completion of just the 'register' pipeline operation before returning, if the registration result is NOT successful"
-    )
-    def test_waits_for_pipeline_op_completion_on_failure(
-        self, mocker, provisioning_pipeline, registration_result
-    ):
-        # fail result
-        registration_result._status = "not assigned"
-
-        # Set up mocks
-        cb_mock_register = mocker.MagicMock()
-        cb_mock_register.wait_for_completion.return_value = registration_result
-        cb_mock_shutdown = mocker.MagicMock()
-        mocker.patch(
-            "azure.iot.device.provisioning.provisioning_device_client.EventedCallback"
-        ).side_effect = [cb_mock_register, cb_mock_shutdown]
-
-        # Run test
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        client.register()
-
-        # Calls made as expected
-        assert provisioning_pipeline.register.call_count == 1
-        assert provisioning_pipeline.shutdown.call_count == 0
-        # Callbacks sent to pipeline as expected
-        assert provisioning_pipeline.register.call_args == mocker.call(
-            payload=mocker.ANY, callback=cb_mock_register
-        )
-        # Callback completions were waited upon as expected
-        assert cb_mock_register.wait_for_completion.call_count == 1
-        assert cb_mock_shutdown.wait_for_completion.call_count == 0
-
-    @pytest.mark.it("Returns the registration result that the pipeline returned")
-    def test_verifies_registration_result_returned(
-        self, mocker, provisioning_pipeline, registration_result
-    ):
-        result = registration_result
-
-        def register_complete_success_callback(payload, callback):
-            callback(result=result)
-
-        mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_success_callback
-        )
-
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        result_returned = client.register()
-        assert result_returned == result
-
-    @pytest.mark.it(
-        "Raises a client error if the `register` pipeline operation calls back with a pipeline error"
-    )
-    @pytest.mark.parametrize(
-        "pipeline_error,client_error",
-        [
-            pytest.param(
-                pipeline_exceptions.ConnectionDroppedError,
-                client_exceptions.ConnectionDroppedError,
-                id="ConnectionDroppedError->ConnectionDroppedError",
-            ),
-            pytest.param(
-                pipeline_exceptions.ConnectionFailedError,
-                client_exceptions.ConnectionFailedError,
-                id="ConnectionFailedError->ConnectionFailedError",
-            ),
-            pytest.param(
-                pipeline_exceptions.UnauthorizedError,
-                client_exceptions.CredentialError,
-                id="UnauthorizedError->CredentialError",
-            ),
-            pytest.param(
-                pipeline_exceptions.ProtocolClientError,
-                client_exceptions.ClientError,
-                id="ProtocolClientError->ClientError",
-            ),
-            pytest.param(
-                pipeline_exceptions.OperationTimeout,
-                client_exceptions.OperationTimeout,
-                id="OperationTimeout->OperationTimeout",
-            ),
-            pytest.param(Exception, client_exceptions.ClientError, id="Exception->ClientError"),
-        ],
-    )
-    def test_raises_error_on_register_pipeline_op_error(
-        self, mocker, pipeline_error, client_error, provisioning_pipeline
-    ):
-        error = pipeline_error()
-
-        def register_complete_failure_callback(payload, callback):
-            callback(result=None, error=error)
-
-        mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_failure_callback
-        )
-
-        client = ProvisioningDeviceClient(provisioning_pipeline)
-        with pytest.raises(client_error) as e_info:
-            client.register()
-
-        assert e_info.value.__cause__ is error
-        assert provisioning_pipeline.register.call_count == 1
 
     @pytest.mark.it(
         "Raises a client error if the `shutdown` pipeline operation calls back with a pipeline error"
     )
-    @pytest.mark.parametrize(
-        "pipeline_error,client_error",
-        [
-            # The only expected errors are unexpected ones
-            pytest.param(Exception, client_exceptions.ClientError, id="Exception->ClientError")
-        ],
-    )
-    def test_raises_error_on_shutdown_pipeline_op_error(
-        self, mocker, pipeline_error, client_error, provisioning_pipeline, registration_result
+    @pytest.mark.parametrize("pipeline_error,client_error", POSSIBLE_CLIENT_ERRORS)
+    def test_raises_error_on_pipeline_op_error(
+        self, mocker, provisioning_pipeline, pipeline_error, client_error
     ):
-        # success result is required to trigger shutdown
-        registration_result._status = "assigned"
-
         error = pipeline_error()
 
-        def register_complete_success_callback(payload, callback):
-            callback(result=registration_result)
-
-        def shutdown_failure_callback(callback):
-            callback(result=None, error=error)
+        def shutdown_complete_failure_callback(callback):
+            callback(error=error)
 
         mocker.patch.object(
-            provisioning_pipeline, "register", side_effect=register_complete_success_callback
-        )
-        mocker.patch.object(
-            provisioning_pipeline, "shutdown", side_effect=shutdown_failure_callback
+            provisioning_pipeline, "shutdown", side_effect=shutdown_complete_failure_callback
         )
 
         client = ProvisioningDeviceClient(provisioning_pipeline)
         with pytest.raises(client_error) as e_info:
-            client.register()
+            client.shutdown()
 
         assert e_info.value.__cause__ is error
+        assert provisioning_pipeline.shutdown.call_count == 1
+
+
+@pytest.mark.describe("ProvisioningDeviceClient (Sync) - .register()")
+class TestClientRegister(object):
+    @pytest.fixture
+    def client(self, provisioning_pipeline):
+        return ProvisioningDeviceClient(provisioning_pipeline)
+
+    @pytest.mark.it(
+        "Runs `connect`, `enable`, `register` and `disconnect` pipeline operations in sequence, if the registration response feature is not yet enabled"
+    )
+    def test_pipeline_operations_responses_disabled(
+        self, mocker, client, provisioning_pipeline, registration_result
+    ):
+        # Set the pipeline to have responses not yet enabled
+        provisioning_pipeline.responses_enabled.__getitem__.return_value = False
+        # Create a manager mock to track all pipeline calls
+        manager_mock = mocker.MagicMock()
+        manager_mock.attach_mock(provisioning_pipeline.connect, "connect")
+        manager_mock.attach_mock(provisioning_pipeline.enable_responses, "enable_responses")
+        manager_mock.attach_mock(provisioning_pipeline.register, "register")
+        manager_mock.attach_mock(provisioning_pipeline.disconnect, "disconnect")
+
+        # Pipeline operations have not yet been called
+        assert provisioning_pipeline.connect.call_count == 0
+        assert provisioning_pipeline.enable_responses.call_count == 0
+        assert provisioning_pipeline.register.call_count == 0
+        assert provisioning_pipeline.disconnect.call_count == 0
+
+        client.register()
+
+        # Pipeline operations were called in sequence
+        assert provisioning_pipeline.connect.call_count == 1
+        assert provisioning_pipeline.enable_responses.call_count == 1
         assert provisioning_pipeline.register.call_count == 1
+        assert provisioning_pipeline.disconnect.call_count == 1
+        assert manager_mock.mock_calls == [
+            mocker.call.connect(callback=mocker.ANY),
+            mocker.call.enable_responses(callback=mocker.ANY),
+            mocker.call.register(payload=mocker.ANY, callback=mocker.ANY),
+            mocker.call.disconnect(callback=mocker.ANY),
+        ]
+
+    @pytest.mark.it(
+        "Runs `connect`, `register` and `disconnect` pipeline operations in sequence, if the registration response feature is already enabled"
+    )
+    def test_pipeline_operations_responses_enabled(
+        self, mocker, client, provisioning_pipeline, registration_result
+    ):
+        # Set the pipeline to have responses already enabled
+        provisioning_pipeline.responses_enabled.__getitem__.return_value = True
+        # Create a manager mock to track all pipeline calls
+        manager_mock = mocker.MagicMock()
+        manager_mock.attach_mock(provisioning_pipeline.connect, "connect")
+        manager_mock.attach_mock(provisioning_pipeline.enable_responses, "enable_responses")
+        manager_mock.attach_mock(provisioning_pipeline.register, "register")
+        manager_mock.attach_mock(provisioning_pipeline.disconnect, "disconnect")
+
+        # Pipeline operations have not yet been called
+        assert provisioning_pipeline.connect.call_count == 0
+        assert provisioning_pipeline.enable_responses.call_count == 0
+        assert provisioning_pipeline.register.call_count == 0
+        assert provisioning_pipeline.disconnect.call_count == 0
+
+        client.register()
+
+        # Enabling responses was not called
+        assert provisioning_pipeline.enable_responses.call_count == 0
+        # Pipeline operations were called in sequence
+        assert provisioning_pipeline.connect.call_count == 1
+        assert provisioning_pipeline.register.call_count == 1
+        assert provisioning_pipeline.disconnect.call_count == 1
+        assert manager_mock.mock_calls == [
+            mocker.call.connect(callback=mocker.ANY),
+            mocker.call.register(payload=mocker.ANY, callback=mocker.ANY),
+            mocker.call.disconnect(callback=mocker.ANY),
+        ]
+
+    @pytest.mark.it("Waits for the completion of all pipeline operations before returning")
+    def test_pipeline_operations_completed(self, mocker, client, provisioning_pipeline):
+        # Set the pipeline to have responses not yet enabled
+        provisioning_pipeline.responses_enabled.__getitem__.return_value = False
+        cb_mock_connect = mocker.MagicMock()
+        cb_mock_enable = mocker.MagicMock()
+        cb_mock_register = mocker.MagicMock()
+        cb_mock_disconnect = mocker.MagicMock()
+
+        mocker.patch(
+            "azure.iot.device.provisioning.provisioning_device_client.EventedCallback"
+        ).side_effect = [cb_mock_connect, cb_mock_enable, cb_mock_register, cb_mock_disconnect]
+
+        client.register()
+
+        # All pipeline op completions were waited upon
+        assert provisioning_pipeline.connect.call_count == 1
+        assert provisioning_pipeline.connect.call_args == mocker.call(callback=cb_mock_connect)
+        assert cb_mock_connect.wait_for_completion.call_count == 1
+        assert provisioning_pipeline.enable_responses.call_count == 1
+        assert provisioning_pipeline.enable_responses.call_args == mocker.call(
+            callback=cb_mock_enable
+        )
+        assert cb_mock_enable.wait_for_completion.call_count == 1
+        assert provisioning_pipeline.register.call_count == 1
+        assert provisioning_pipeline.register.call_args == mocker.call(
+            payload=mocker.ANY, callback=cb_mock_register
+        )
+        assert cb_mock_register.wait_for_completion.call_count == 1
+        assert provisioning_pipeline.disconnect.call_count == 1
+        assert provisioning_pipeline.disconnect.call_args == mocker.call(
+            callback=cb_mock_disconnect
+        )
+        assert cb_mock_disconnect.wait_for_completion.call_count == 1
+
+    @pytest.mark.it("Provides the provisioning payload to the pipeline `register` operation")
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            pytest.param(None, id="No payload set on client"),
+            pytest.param("Some Payload", id="Custom payload set on client"),
+        ],
+    )
+    def test_register_with_payload(self, mocker, client, provisioning_pipeline, payload):
+        if payload:
+            client.provisioning_payload = payload
+        else:
+            assert client.provisioning_payload is None
+
+        client.register()
+
+        assert provisioning_pipeline.register.call_count == 1
+        assert provisioning_pipeline.register.call_args == mocker.call(
+            payload=client.provisioning_payload, callback=mocker.ANY
+        )
+
+    @pytest.mark.it("Returns the registration result returned by the pipeline `register` operation")
+    @pytest.mark.parametrize(
+        "registration_success",
+        [
+            pytest.param(True, id="Registration succeeded (assigned)"),
+            pytest.param(False, id="Registration failed (not assigned)"),
+        ],
+    )
+    def test_returns_registration_result(
+        self, client, provisioning_pipeline, registration_result, registration_success
+    ):
+        if registration_success:
+            registration_result._status = "assigned"
+        else:
+            registration_result._status = "not assigned"
+
+        def register_complete_callback(payload, callback):
+            callback(result=registration_result)
+
+        provisioning_pipeline.register.side_effect = register_complete_callback
+
+        result = client.register()
+        assert result is registration_result
+
+    @pytest.mark.it(
+        "Raises a client error if the `connect` pipeline operation calls back with a pipeline error"
+    )
+    @pytest.mark.parametrize("pipeline_error,client_error", POSSIBLE_CLIENT_ERRORS)
+    def test_connect_raises_error(
+        self, client, provisioning_pipeline, pipeline_error, client_error
+    ):
+        my_pipeline_error = pipeline_error()
+
+        def connect_complete_callback(callback):
+            callback(error=my_pipeline_error)
+
+        provisioning_pipeline.connect.side_effect = connect_complete_callback
+
+        with pytest.raises(client_error) as e_info:
+            client.register()
+        assert e_info.value.__cause__ is my_pipeline_error
+        # Disconnect did not have to called because the connect never succeeded
+        assert provisioning_pipeline.disconnect.call_count == 0
+
+    @pytest.mark.it(
+        "Raises a client error and disconnects if the `enable` pipeline operation calls back with a pipeline error"
+    )
+    @pytest.mark.parametrize("pipeline_error,client_error", POSSIBLE_CLIENT_ERRORS)
+    def test_enable_raises_error(self, client, provisioning_pipeline, pipeline_error, client_error):
+        # Set the pipeline to have responses not yet enabled
+        provisioning_pipeline.responses_enabled.__getitem__.return_value = False
+
+        my_pipeline_error = pipeline_error()
+
+        def enable_complete_callback(callback):
+            callback(error=my_pipeline_error)
+
+        provisioning_pipeline.enable_responses.side_effect = enable_complete_callback
+
+        with pytest.raises(client_error) as e_info:
+            client.register()
+        assert e_info.value.__cause__ is my_pipeline_error
+        # Disconnect was called to clean up failure
+        assert provisioning_pipeline.disconnect.call_count == 1
+
+    @pytest.mark.it(
+        "Raises a client error and disconnects if the `register` pipeline operation calls back with a pipeline error"
+    )
+    @pytest.mark.parametrize("pipeline_error,client_error", POSSIBLE_CLIENT_ERRORS)
+    def test_register_raises_error(
+        self, client, provisioning_pipeline, pipeline_error, client_error
+    ):
+        my_pipeline_error = pipeline_error()
+
+        def register_complete_callback(payload, callback):
+            callback(error=my_pipeline_error, result=None)
+
+        provisioning_pipeline.register.side_effect = register_complete_callback
+
+        with pytest.raises(client_error) as e_info:
+            client.register()
+        assert e_info.value.__cause__ is my_pipeline_error
+        # Disconnect was called to clean up failure
+        assert provisioning_pipeline.disconnect.call_count == 1
+
+    @pytest.mark.it(
+        "Still returns the registration result even if the `disconnect` pipeline operation calls back with a pipeline error"
+    )
+    @pytest.mark.parametrize("pipeline_error,client_error", POSSIBLE_CLIENT_ERRORS)
+    def test_disconnect_raises_error(
+        self, client, provisioning_pipeline, registration_result, pipeline_error, client_error
+    ):
+        my_pipeline_error = pipeline_error()
+
+        def register_complete_callback(payload, callback):
+            callback(result=registration_result)
+
+        provisioning_pipeline.register.side_effect = register_complete_callback
+
+        def disconnect_complete_callback(callback):
+            callback(error=my_pipeline_error)
+
+        provisioning_pipeline.disconnect.side_effect = disconnect_complete_callback
+
+        result = client.register()
+        assert result is registration_result
 
 
 @pytest.mark.describe("ProvisioningDeviceClient (Sync) - .set_provisioning_payload()")


### PR DESCRIPTION
* Enabled some memory leak tests that had previously been disabled
* Added a `flush_messages` fixture to the E2E infrastructure in order to avoid spurious leaks
* Other small enhancements to logging