### PR TITLE
[V3] Enhanced reused modules for V3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Python V3 Workspace
-v3_async_wip/tests/sandbox/
+v3_async_wip/sandbox/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/migration_guide.md
+++ b/migration_guide.md
@@ -93,7 +93,7 @@ All receives should now be done using the handlers in the table above.
 
 Some changes have been made to the `Message` object used for sending and receiving data.
 * The `.data` attribute is now called `.payload` for consistency with other objects in the API
-* The `message_id` parameter is no longer part of the constructor arguments. It should be manually added as an attribute
+* The `message_id` parameter is no longer part of the constructor arguments. It should be manually added as an attribute, just like all other attributes
 * The payload of a received Message is now a unicode string value instead of a bytestring value.
 It will be decoded according to the content encoding property sent along with the message.
 

--- a/migration_guide.md
+++ b/migration_guide.md
@@ -30,7 +30,7 @@ Note also that this change does *not* affect automatic reconnection attempts in 
 ## Receiving data from IoTHub
 Similarly to the above, there is an additional explicit step you must now make when trying to receive data. In addition to setting your handler, you must explicitly start/stop receiving. Note also that the above step of manually connecting must also be done before starting to receive data.
 
-Furthermore, note that the content of the message is now referred to by the 'payload' attribute on the message, rather than the 'data' attribute.
+Furthermore, note that the content of the message is now referred to by the 'payload' attribute on the message, rather than the 'data' attribute (see "Message" section below)
 
 ### V2
 ```python
@@ -88,6 +88,38 @@ Finally, it should be clarified that the following receive APIs that were deprec
 
 All receives should now be done using the handlers in the table above.
 
+
+## Message object - IoTHubDeviceClient/IoTHubModuleClient
+
+Some changes have been made to the `Message` object used for sending and receiving data.
+* The `.data` attribute is now called `.payload` for consistency with other objects in the API
+* The `message_id` parameter is no longer part of the constructor arguments. It should be manually added as an attribute
+* The payload of a received Message is now a unicode string value instead of a bytestring value.
+It will be decoded according to the content encoding property sent along with the message.
+
+### V2
+```python
+from azure.iot.device import Message
+
+payload = "this is a payload"
+message_id = "1234"
+m = Message(data=payload, message_id=message_id)
+
+assert m.data == payload
+assert m.message_id = message_id
+```
+
+### V3
+```python
+from azure.iot.device import Message
+
+payload = "this is a payload"
+message_id = "1234"
+m = Message(payload=payload)
+m.message_id = message_id
+
+assert m.payload == payload
+```
 
 ## Modified Client Options - IoTHubDeviceClient/IoTHubModuleClient
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-mock>=3.10.0
-pytest-asyncio>=0.17
+pytest-asyncio>=0.20.3
 pytest-testdox>=1.1.1
 pytest-cov
 pytest-timeout

--- a/v3_async_wip/tests/simple_e2e.py
+++ b/v3_async_wip/tests/simple_e2e.py
@@ -24,7 +24,7 @@ CONNECTION_STRING = os.getenv("IOTHUB_DEVICE_CONNECTION_STRING")
 HOSTNAME = mqtt_helper.get_hostname(CONNECTION_STRING)
 
 
-class Dropper(object):
+class Dropper:
     def __init__(self, transport):
         self.transport = transport
 

--- a/v3_async_wip/tests/test_config.py
+++ b/v3_async_wip/tests/test_config.py
@@ -4,4 +4,6 @@
 # license information.
 # --------------------------------------------------------------------------
 
-# TODO: Add
+"""This is a placeholder file. It will likely not be necessary if the config objects are converted
+into TypeDicts as is planned."""
+# TODO: Remove if no longer necessary, or complete

--- a/v3_async_wip/tests/test_config.py
+++ b/v3_async_wip/tests/test_config.py
@@ -1,0 +1,7 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+# TODO: Add

--- a/v3_async_wip/tests/test_iothub_mqtt_client.py
+++ b/v3_async_wip/tests/test_iothub_mqtt_client.py
@@ -27,8 +27,6 @@ from azure.iot.device.common.auth import sastoken as st
 from azure.iot.device.common import alarm
 
 
-# TODO: mock layer below
-
 FAKE_DEVICE_ID = "fake_device_id"
 FAKE_MODULE_ID = "fake_module_id"
 FAKE_HOSTNAME = "fake.hostname"
@@ -2393,6 +2391,3 @@ class TestIoTHubMQTTClientIncomingTwinResponse:
         resp1 = spy_response_factory.spy_return
         assert mock_ledger.match_response.call_count == 1
         assert mock_ledger.match_response.call_args == mocker.call(resp1)
-
-
-# TODO: Sas Renewal tests

--- a/v3_async_wip/tests/test_models.py
+++ b/v3_async_wip/tests/test_models.py
@@ -39,22 +39,32 @@ class TestMessage:
     @pytest.mark.it(
         "Instantiates with optional provided content type and content encoding set as attributes"
     )
-    def test_instantiates_with_optional_contenttype_encoding(self):
-        ctype = "application/json"
-        encoding = "utf-16"
-        msg = Message("some message", encoding, ctype)
-        assert msg.content_encoding == encoding
-        assert msg.content_type == ctype
+    @pytest.mark.parametrize("content_type", ["text/plain", "application/json"])
+    @pytest.mark.parametrize("content_encoding", ["utf-8", "utf-16", "utf-32"])
+    def test_instantiates_with_optional_contenttype_encoding(self, content_type, content_encoding):
+        msg = Message("some message", content_encoding, content_type)
+        assert msg.content_encoding == content_encoding
+        assert msg.content_type == content_type
 
     @pytest.mark.it("Defaults content encoding to 'utf-8' if not provided")
     def test_default_content_encoding(self):
         msg = Message("some message")
         assert msg.content_encoding == "utf-8"
 
+    @pytest.mark.it("Raises ValueError if unsupported content encoding provided")
+    def test_unsupported_content_encoding(self):
+        with pytest.raises(ValueError):
+            Message("some message", content_encoding="ascii")
+
     @pytest.mark.it("Defaults content type to 'text/plain' if not provided")
     def test_default_content_type(self):
         msg = Message("some message")
         assert msg.content_type == "text/plain"
+
+    @pytest.mark.it("Raises ValueError if unsupported content type provided")
+    def test_unsupported_content_type(self):
+        with pytest.raises(ValueError):
+            Message("some message", content_type="text/javascript")
 
     @pytest.mark.it("Instantiates with optional provided output name set as an attribute")
     def test_instantiates_with_optional_output_name(self):

--- a/v3_async_wip/tests/test_models.py
+++ b/v3_async_wip/tests/test_models.py
@@ -1,0 +1,167 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import pytest
+import logging
+from v3_async_wip.models import Message, MethodRequest, MethodResponse
+from v3_async_wip import constant
+
+logging.basicConfig(level=logging.DEBUG)
+
+FAKE_RID = "123"
+FAKE_METHOD_NAME = "some_method"
+FAKE_STATUS = 200
+
+
+json_serializable_payload_params = [
+    pytest.param("String payload", id="String Payload"),
+    pytest.param(123, id="Integer Payload"),
+    pytest.param(2.0, id="Float Payload"),
+    pytest.param(True, id="Boolean Payload"),
+    pytest.param({"dictionary": {"payload": "nested"}}, id="Dictionary Payload"),
+    pytest.param([1, 2, 3], id="List Payload"),
+    pytest.param((1, 2, 3), id="Tuple Payload"),
+    pytest.param(None, id="No Payload"),
+]
+
+
+@pytest.mark.describe("Message")
+class TestMessage:
+    @pytest.mark.it("Instantiates with the provided payload set as an attribute")
+    @pytest.mark.parametrize("payload", json_serializable_payload_params)
+    def test_instantiates_from_data(self, payload):
+        msg = Message(payload)
+        assert msg.payload == payload
+
+    @pytest.mark.it("Instantiates with optional provided message id set as an attribute")
+    def test_instantiates_with_optional_message_id(self):
+        message_id = "Postage12323"
+        msg = Message("some message", message_id)
+        assert msg.message_id == message_id
+
+    @pytest.mark.it(
+        "Instantiates with optional provided content type and content encoding set as attributes"
+    )
+    def test_instantiates_with_optional_contenttype_encoding(self):
+        ctype = "application/json"
+        encoding = "utf-16"
+        msg = Message("some message", None, encoding, ctype)
+        assert msg.content_encoding == encoding
+        assert msg.content_type == ctype
+
+    @pytest.mark.it("Instantiates with no custom properties set")
+    def test_default_custom_properties(self):
+        msg = Message("some message")
+        assert msg.custom_properties == {}
+
+    @pytest.mark.it("Instantiates with optional provided output name set as an attribute")
+    def test_instantiates_with_optional_output_name(self):
+        output_name = "some_output"
+        msg = Message("some message", output_name=output_name)
+        assert msg.output_name == output_name
+
+    @pytest.mark.it("Instantiates with no set input name")
+    def test_default_input_name(self):
+        msg = Message("some message")
+        assert msg.input_name is None
+
+    @pytest.mark.it("Instantiates with no set ack value")
+    def test_default_ack(self):
+        msg = Message("some message")
+        assert msg.ack is None
+
+    @pytest.mark.it("Instantiates with no set expiry time")
+    def test_default_expiry_time(self):
+        msg = Message("some message")
+        assert msg.expiry_time_utc is None
+
+    @pytest.mark.it("Instantiates with no set user id")
+    def test_default_user_id(self):
+        msg = Message("some message")
+        assert msg.user_id is None
+
+    @pytest.mark.it("Instantiates with no set correlation id")
+    def test_default_corr_id(self):
+        msg = Message("some message")
+        assert msg.correlation_id is None
+
+    @pytest.mark.it("Instantiates with no set iothub_interface_id (i.e. not as a security message)")
+    def test_default_security_msg_status(self):
+        msg = Message("some message")
+        assert msg.iothub_interface_id is None
+
+    @pytest.mark.it("Maintains iothub_interface_id (security message) as a read-only property")
+    def test_read_only_iothub_interface_id(self):
+        msg = Message("some message")
+        with pytest.raises(AttributeError):
+            msg.iothub_interface_id = "value"
+
+    @pytest.mark.it(
+        "Uses string representation of data/payload attribute as string representation of Message"
+    )
+    @pytest.mark.parametrize("payload", json_serializable_payload_params)
+    def test_str_rep(self, payload):
+        msg = Message(payload)
+        assert str(msg) == str(payload)
+
+    @pytest.mark.it("Can be set as a security message via API")
+    def test_setting_message_as_security_message(self):
+        ctype = "application/json"
+        encoding = "utf-16"
+        msg = Message("some message", None, encoding, ctype)
+        assert msg.iothub_interface_id is None
+        msg.set_as_security_message()
+        assert msg.iothub_interface_id == constant.SECURITY_MESSAGE_INTERFACE_ID
+
+
+@pytest.mark.describe("MethodRequest")
+class TestMethodRequest:
+    @pytest.mark.it("Instantiates with the provided 'request_id' set as an attribute")
+    def test_request_id(self):
+        m_req = MethodRequest(request_id=FAKE_RID, name=FAKE_METHOD_NAME, payload={})
+        assert m_req.request_id == FAKE_RID
+
+    @pytest.mark.it("Instantiates with the provided 'name' set as an attribute")
+    def test_name(self):
+        m_req = MethodRequest(request_id=FAKE_RID, name=FAKE_METHOD_NAME, payload={})
+        assert m_req.name == FAKE_METHOD_NAME
+
+    @pytest.mark.it("Instantiates with the provided 'payload' set as an attribute")
+    @pytest.mark.parametrize("payload", json_serializable_payload_params)
+    def test_payload(self, payload):
+        m_req = MethodRequest(request_id=FAKE_RID, name=FAKE_METHOD_NAME, payload=payload)
+        assert m_req.payload == payload
+
+
+@pytest.mark.describe("MethodResponse")
+class TestMethodResponse:
+    @pytest.mark.it("Instantiates with the provided 'request_id' set as an attribute")
+    def test_request_id(self):
+        m_resp = MethodResponse(request_id=FAKE_RID, status=FAKE_STATUS, payload={})
+        assert m_resp.request_id == FAKE_RID
+
+    @pytest.mark.it("Instantiates with the provided 'status' set as an attribute")
+    def test_status(self):
+        m_resp = MethodResponse(request_id=FAKE_RID, status=FAKE_STATUS, payload={})
+        assert m_resp.status == FAKE_STATUS
+
+    @pytest.mark.it("Instantiates with the optional provided 'payload' set as an attribute")
+    @pytest.mark.parametrize("payload", json_serializable_payload_params)
+    def test_payload(self, payload):
+        m_resp = MethodResponse(request_id=FAKE_RID, status=FAKE_STATUS, payload=payload)
+        assert m_resp.payload == payload
+
+    @pytest.mark.it("Can be instantiated from a MethodResponse via factory API")
+    @pytest.mark.parametrize("payload", json_serializable_payload_params)
+    def test_factory(self, payload):
+        m_req = MethodRequest(request_id=FAKE_RID, name=FAKE_METHOD_NAME, payload={})
+        m_resp = MethodResponse.create_from_method_request(
+            method_request=m_req, status=FAKE_STATUS, payload=payload
+        )
+        assert isinstance(m_resp, MethodResponse)
+        assert m_resp.request_id == m_req.request_id
+        assert m_resp.status == FAKE_STATUS
+        assert m_resp.payload == payload

--- a/v3_async_wip/tests/test_mqtt_topic_iothub.py
+++ b/v3_async_wip/tests/test_mqtt_topic_iothub.py
@@ -26,9 +26,6 @@ logging.basicConfig(level=logging.DEBUG)
 # PLEASE DO THESE TESTS FOR EVEN CASES WHERE THOSE CHARACTERS SHOULD NOT OCCUR, FOR SAFETY.
 
 
-# TODO: are str conversion tests necessary?
-
-
 @pytest.mark.describe(".get_c2d_topic_for_subscribe()")
 class TestGetC2DTopicForSubscribe:
     @pytest.mark.it("Returns the topic for subscribing to C2D messages from IoTHub")

--- a/v3_async_wip/tests/test_mqtt_topic_iothub.py
+++ b/v3_async_wip/tests/test_mqtt_topic_iothub.py
@@ -542,16 +542,6 @@ class TestExtractPropertiesFromMessageTopic:
         properties = mqtt_topic_iothub.extract_properties_from_message_topic(topic)
         assert properties == expected_property_dict
 
-    @pytest.mark.it(
-        "Maps the extracted key to value of None if there is no corresponding value present"
-    )
-    def test_key_only(self, message_topic_base):
-        property_string = "key1&key2&key3=value"
-        expected_property_dict = {"key1": None, "key2": None, "key3": "value"}
-        topic = message_topic_base + property_string
-        properties = mqtt_topic_iothub.extract_properties_from_message_topic(topic)
-        assert properties == expected_property_dict
-
     @pytest.mark.it("Supports empty string in properties")
     @pytest.mark.parametrize(
         "property_string, expected_property_dict",
@@ -561,6 +551,16 @@ class TestExtractPropertiesFromMessageTopic:
         ],
     )
     def test_empty_string(self, message_topic_base, property_string, expected_property_dict):
+        topic = message_topic_base + property_string
+        properties = mqtt_topic_iothub.extract_properties_from_message_topic(topic)
+        assert properties == expected_property_dict
+
+    @pytest.mark.it(
+        "Maps the extracted key to value of empty string if there is a key with no corresponding value present"
+    )
+    def test_key_only(self, message_topic_base):
+        property_string = "key1&key2&key3=value"
+        expected_property_dict = {"key1": "", "key2": "", "key3": "value"}
         topic = message_topic_base + property_string
         properties = mqtt_topic_iothub.extract_properties_from_message_topic(topic)
         assert properties == expected_property_dict
@@ -695,7 +695,8 @@ class TestExtractRequestIdFromMethodRequestTopic:
         "topic",
         [
             pytest.param("$iothub/methods/POST/fake_method/?$mid=1", id="No request id key"),
-            pytest.param("$iothub/methods/POST/fake_method/?$rid=", id="No request id value"),
+            pytest.param("$iothub/methods/POST/fake_method/?$rid", id="No request id value"),
+            pytest.param("$iothub/methods/POST/fake_method/?$rid=", id="Empty request id value"),
         ],
     )
     def test_no_request_id(self, topic):
@@ -803,7 +804,8 @@ class TestExtractRequestIdFromTwinResponseTopic:
         "topic",
         [
             pytest.param("$iothub/twin/res/200/?$mid=1", id="No request id key"),
-            pytest.param("$iothub/twin/res/200/?$rid=", id="No request id value"),
+            pytest.param("$iothub/twin/res/200/?$rid", id="No request id value"),
+            pytest.param("$iothub/twin/res/200/?$rid=", id="Empty request id value"),
         ],
     )
     def test_no_request_id(self, topic):

--- a/v3_async_wip/tests/test_mqtt_topic_iothub.py
+++ b/v3_async_wip/tests/test_mqtt_topic_iothub.py
@@ -1,0 +1,811 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import pytest
+import logging
+from v3_async_wip import mqtt_topic_iothub
+
+logging.basicConfig(level=logging.DEBUG)
+
+# NOTE: All tests (that require it) are parametrized with multiple values for URL encoding.
+# This is to show that the URL encoding is done correctly - not all URL encoding encodes
+# the same way.
+#
+# For URL encoding, we must always test the ' ' and '/' characters specifically, in addition
+# to a generic URL encoding value (e.g. $, #, etc.)
+#
+# For URL decoding, we must always test the '+' character specifically, in addition to
+# a generic URL encoded value (e.g. %24, %23, etc.)
+#
+# Please also always test that provided values are converted to strings in order to ensure
+# that they can be URL encoded without error.
+#
+# PLEASE DO THESE TESTS FOR EVEN CASES WHERE THOSE CHARACTERS SHOULD NOT OCCUR, FOR SAFETY.
+
+
+# TODO: are str conversion tests necessary?
+
+
+@pytest.mark.describe(".get_c2d_topic_for_subscribe()")
+class TestGetC2DTopicForSubscribe:
+    @pytest.mark.it("Returns the topic for subscribing to C2D messages from IoTHub")
+    def test_returns_topic(self):
+        device_id = "my_device"
+        expected_topic = "devices/my_device/messages/devicebound/#"
+        topic = mqtt_topic_iothub.get_c2d_topic_for_subscribe(device_id)
+        assert topic == expected_topic
+
+    # NOTE: It SHOULD do URL encoding, but Hub doesn't currently support URL decoding, so we have
+    # to follow that and not do URL encoding for safety. As a result, some of the values used in
+    # this test would actually be invalid in production due to character restrictions on the Hub
+    # that exist to prevent Hub from breaking due to a lack of URL decoding.
+    # If Hub does begin to support robust URL encoding for safety, this test can easily be switched
+    # to show that URL encoding DOES work.
+    @pytest.mark.it("Does NOT URL encode the device_id when generating the topic")
+    @pytest.mark.parametrize(
+        "device_id, expected_topic",
+        [
+            pytest.param(
+                "my$device", "devices/my$device/messages/devicebound/#", id="id contains '$'"
+            ),
+            pytest.param(
+                "my device", "devices/my device/messages/devicebound/#", id="id contains ' '"
+            ),
+            pytest.param(
+                "my/device", "devices/my/device/messages/devicebound/#", id="id contains '/'"
+            ),
+        ],
+    )
+    def test_url_encoding(self, device_id, expected_topic):
+        topic = mqtt_topic_iothub.get_c2d_topic_for_subscribe(device_id)
+        assert topic == expected_topic
+
+    @pytest.mark.it("Converts the device_id to string when generating the topic")
+    def test_str_conversion(self):
+        device_id = 2000
+        expected_topic = "devices/2000/messages/devicebound/#"
+        topic = mqtt_topic_iothub.get_c2d_topic_for_subscribe(device_id)
+        assert topic == expected_topic
+
+
+@pytest.mark.describe(".get_input_topic_for_subscribe()")
+class TestGetInputTopicForSubscribe:
+    @pytest.mark.it("Returns the topic for subscribing to Input messages from IoTHub")
+    def test_returns_topic(self):
+        device_id = "my_device"
+        module_id = "my_module"
+        expected_topic = "devices/my_device/modules/my_module/inputs/#"
+        topic = mqtt_topic_iothub.get_input_topic_for_subscribe(device_id, module_id)
+        assert topic == expected_topic
+
+    # NOTE: It SHOULD do URL encoding, but Hub doesn't currently support URL decoding, so we have
+    # to follow that and not do URL encoding for safety. As a result, some of the values used in
+    # this test would actually be invalid in production due to character restrictions on the Hub
+    # that exist to prevent Hub from breaking due to a lack of URL decoding.
+    # If Hub does begin to support robust URL encoding for safety, this test can easily be switched
+    # to show that URL encoding DOES work.
+    @pytest.mark.it("URL encodes the device_id and module_id when generating the topic")
+    @pytest.mark.parametrize(
+        "device_id, module_id, expected_topic",
+        [
+            pytest.param(
+                "my$device",
+                "my$module",
+                "devices/my$device/modules/my$module/inputs/#",
+                id="ids contain '$'",
+            ),
+            pytest.param(
+                "my device",
+                "my module",
+                "devices/my device/modules/my module/inputs/#",
+                id="ids contain ' '",
+            ),
+            pytest.param(
+                "my/device",
+                "my/module",
+                "devices/my/device/modules/my/module/inputs/#",
+                id="ids contain '/'",
+            ),
+        ],
+    )
+    def test_url_encoding(self, device_id, module_id, expected_topic):
+        topic = mqtt_topic_iothub.get_input_topic_for_subscribe(device_id, module_id)
+        assert topic == expected_topic
+
+    @pytest.mark.it("Converts the device_id and module_id to string when generating the topic")
+    def test_str_conversion(self):
+        device_id = 2000
+        module_id = 4000
+        expected_topic = "devices/2000/modules/4000/inputs/#"
+        topic = mqtt_topic_iothub.get_input_topic_for_subscribe(device_id, module_id)
+        assert topic == expected_topic
+
+
+@pytest.mark.describe(".get_method_topic_for_subscribe()")
+class TestGetMethodTopicForSubscribe:
+    @pytest.mark.it("Returns the topic for subscribing to methods from IoTHub")
+    def test_returns_topic(self):
+        topic = mqtt_topic_iothub.get_method_topic_for_subscribe()
+        assert topic == "$iothub/methods/POST/#"
+
+
+@pytest.mark.describe("get_twin_response_topic_for_subscribe()")
+class TestGetTwinResponseTopicForSubscribe:
+    @pytest.mark.it("Returns the topic for subscribing to twin response from IoTHub")
+    def test_returns_topic(self):
+        topic = mqtt_topic_iothub.get_twin_response_topic_for_subscribe()
+        assert topic == "$iothub/twin/res/#"
+
+
+@pytest.mark.describe("get_twin_patch_topic_for_subscribe()")
+class TestGetTwinPatchTopicForSubscribe:
+    @pytest.mark.it("Returns the topic for subscribing to twin patches from IoTHub")
+    def test_returns_topic(self):
+        topic = mqtt_topic_iothub.get_twin_patch_topic_for_subscribe()
+        assert topic == "$iothub/twin/PATCH/properties/desired/#"
+
+
+@pytest.mark.describe(".get_telemetry_topic_for_publish()")
+class TestGetTelemetryTopicForPublish:
+    @pytest.mark.it("Returns the topic for sending telemetry to IoTHub")
+    @pytest.mark.parametrize(
+        "device_id, module_id, expected_topic",
+        [
+            pytest.param("my_device", None, "devices/my_device/messages/events/", id="Device"),
+            pytest.param(
+                "my_device",
+                "my_module",
+                "devices/my_device/modules/my_module/messages/events/",
+                id="Module",
+            ),
+        ],
+    )
+    def test_returns_topic(self, device_id, module_id, expected_topic):
+        topic = mqtt_topic_iothub.get_telemetry_topic_for_publish(device_id, module_id)
+        assert topic == expected_topic
+
+    # NOTE: It SHOULD do URL encoding, but Hub doesn't currently support URL decoding, so we have
+    # to follow that and not do URL encoding for safety. As a result, some of the values used in
+    # this test would actually be invalid in production due to character restrictions on the Hub
+    # that exist to prevent Hub from breaking due to a lack of URL decoding.
+    # If Hub does begin to support robust URL encoding for safety, this test can easily be switched
+    # to show that URL encoding DOES work.
+    @pytest.mark.it("URL encodes the device_id and module_id when generating the topic")
+    @pytest.mark.parametrize(
+        "device_id, module_id, expected_topic",
+        [
+            pytest.param(
+                "my$device",
+                None,
+                "devices/my$device/messages/events/",
+                id="Device, id contains '$'",
+            ),
+            pytest.param(
+                "my device",
+                None,
+                "devices/my device/messages/events/",
+                id="Device, id contains ' '",
+            ),
+            pytest.param(
+                "my/device",
+                None,
+                "devices/my/device/messages/events/",
+                id="Device, id contains '/'",
+            ),
+            pytest.param(
+                "my$device",
+                "my$module",
+                "devices/my$device/modules/my$module/messages/events/",
+                id="Module, ids contain '$'",
+            ),
+            pytest.param(
+                "my device",
+                "my module",
+                "devices/my device/modules/my module/messages/events/",
+                id="Module, ids contain ' '",
+            ),
+            pytest.param(
+                "my/device",
+                "my/module",
+                "devices/my/device/modules/my/module/messages/events/",
+                id="Module, ids contain '/'",
+            ),
+        ],
+    )
+    def test_url_encoding(self, device_id, module_id, expected_topic):
+        topic = mqtt_topic_iothub.get_telemetry_topic_for_publish(device_id, module_id)
+        assert topic == expected_topic
+
+    @pytest.mark.it("Converts the device_id and module_id to string when generating the topic")
+    @pytest.mark.parametrize(
+        "device_id, module_id, expected_topic",
+        [
+            pytest.param(2000, None, "devices/2000/messages/events/", id="Device"),
+            pytest.param(2000, 4000, "devices/2000/modules/4000/messages/events/", id="Module"),
+        ],
+    )
+    def test_str_conversion(self, device_id, module_id, expected_topic):
+        topic = mqtt_topic_iothub.get_telemetry_topic_for_publish(device_id, module_id)
+        assert topic == expected_topic
+
+
+@pytest.mark.describe(".get_method_topic_for_publish()")
+class TestGetMethodTopicForPublish:
+    @pytest.mark.it("Returns the topic for sending a method response to IoTHub")
+    @pytest.mark.parametrize(
+        "request_id, status, expected_topic",
+        [
+            pytest.param("1", "200", "$iothub/methods/res/200/?$rid=1", id="Successful result"),
+            pytest.param(
+                "475764", "500", "$iothub/methods/res/500/?$rid=475764", id="Failure result"
+            ),
+        ],
+    )
+    def test_returns_topic(self, request_id, status, expected_topic):
+        topic = mqtt_topic_iothub.get_method_topic_for_publish(request_id, status)
+        assert topic == expected_topic
+
+    @pytest.mark.it("URL encodes provided values when generating the topic")
+    @pytest.mark.parametrize(
+        "request_id, status, expected_topic",
+        [
+            pytest.param(
+                "invalid#request?id",
+                "invalid$status",
+                "$iothub/methods/res/invalid%24status/?$rid=invalid%23request%3Fid",
+                id="Standard URL Encoding",
+            ),
+            pytest.param(
+                "invalid request id",
+                "invalid status",
+                "$iothub/methods/res/invalid%20status/?$rid=invalid%20request%20id",
+                id="URL Encoding of ' ' character",
+            ),
+            pytest.param(
+                "invalid/request/id",
+                "invalid/status",
+                "$iothub/methods/res/invalid%2Fstatus/?$rid=invalid%2Frequest%2Fid",
+                id="URL Encoding of '/' character",
+            ),
+        ],
+    )
+    def test_url_encoding(self, request_id, status, expected_topic):
+        topic = mqtt_topic_iothub.get_method_topic_for_publish(request_id, status)
+        assert topic == expected_topic
+
+    @pytest.mark.it("Converts the provided values to strings when generating the topic")
+    def test_str_conversion(self):
+        request_id = 1
+        status = 200
+        expected_topic = "$iothub/methods/res/200/?$rid=1"
+        topic = mqtt_topic_iothub.get_method_topic_for_publish(request_id, status)
+        assert topic == expected_topic
+
+
+@pytest.mark.describe(".get_twin_request_topic_for_publish()")
+class TestGetTwinRequestTopicForPublish:
+    @pytest.mark.it("Returns topic for sending a get twin request to IoTHub")
+    def test_returns_topic(self):
+        request_id = "3226c2f7-3d30-425c-b83b-0c34335f8220"
+        expected_topic = "$iothub/twin/GET/?$rid=3226c2f7-3d30-425c-b83b-0c34335f8220"
+        topic = mqtt_topic_iothub.get_twin_request_topic_for_publish(request_id)
+        assert topic == expected_topic
+
+    @pytest.mark.it("URL encodes 'request_id' parameter when generating the topic")
+    @pytest.mark.parametrize(
+        "request_id, expected_topic",
+        [
+            pytest.param(
+                "invalid$request?id",
+                "$iothub/twin/GET/?$rid=invalid%24request%3Fid",
+                id="Standard URL Encoding",
+            ),
+            pytest.param(
+                "invalid request id",
+                "$iothub/twin/GET/?$rid=invalid%20request%20id",
+                id="URL Encoding of ' ' character",
+            ),
+            pytest.param(
+                "invalid/request/id",
+                "$iothub/twin/GET/?$rid=invalid%2Frequest%2Fid",
+                id="URL Encoding of '/' character",
+            ),
+        ],
+    )
+    def test_url_encoding(self, request_id, expected_topic):
+        topic = mqtt_topic_iothub.get_twin_request_topic_for_publish(request_id)
+        assert topic == expected_topic
+
+    @pytest.mark.it("Converts 'request_id' parameter to string when generating the topic")
+    def test_str_conversion(self):
+        request_id = 4000
+        expected_topic = "$iothub/twin/GET/?$rid=4000"
+        topic = mqtt_topic_iothub.get_twin_request_topic_for_publish(request_id)
+        assert topic == expected_topic
+
+
+@pytest.mark.describe(".get_twin_patch_topic_for_publish()")
+class TestGetTwinPatchTopicForPublish:
+    @pytest.mark.it("Returns topic for sending a twin patch to IoTHub")
+    def test_returns_topic(self):
+        request_id = "5002b415-af16-47e9-b89c-8680e01b502f"
+        expected_topic = (
+            "$iothub/twin/PATCH/properties/reported/?$rid=5002b415-af16-47e9-b89c-8680e01b502f"
+        )
+        topic = mqtt_topic_iothub.get_twin_patch_topic_for_publish(request_id)
+        assert topic == expected_topic
+
+    @pytest.mark.it("URL encodes 'request_id' parameter when generating the topic")
+    @pytest.mark.parametrize(
+        "request_id, expected_topic",
+        [
+            pytest.param(
+                "invalid$request?id",
+                "$iothub/twin/PATCH/properties/reported/?$rid=invalid%24request%3Fid",
+                id="Standard URL Encoding",
+            ),
+            pytest.param(
+                "invalid request id",
+                "$iothub/twin/PATCH/properties/reported/?$rid=invalid%20request%20id",
+                id="URL Encoding of ' ' character",
+            ),
+            pytest.param(
+                "invalid/request/id",
+                "$iothub/twin/PATCH/properties/reported/?$rid=invalid%2Frequest%2Fid",
+                id="URL Encoding of '/' character",
+            ),
+        ],
+    )
+    def test_url_encoding(self, request_id, expected_topic):
+        topic = mqtt_topic_iothub.get_twin_patch_topic_for_publish(request_id)
+        assert topic == expected_topic
+
+    @pytest.mark.it("Converts 'request_id' parameter to string when generating the topic")
+    def test_str_conversion(self):
+        request_id = 4000
+        expected_topic = "$iothub/twin/PATCH/properties/reported/?$rid=4000"
+        topic = mqtt_topic_iothub.get_twin_patch_topic_for_publish(request_id)
+        assert topic == expected_topic
+
+
+@pytest.mark.describe(".insert_message_properties_in_topic()")
+class TestEncodeMessagePropertiesInTopic:
+    @pytest.fixture(params=["C2D Message", "Input Message"])
+    def message_topic(self, request):
+        if request.param == "C2D Message":
+            return "devices/fake_device/messages/events/"
+        else:
+            return "devices/fake_device/modules/fake_module/messages/events/"
+
+    @pytest.mark.it(
+        "Returns a new version of the given topic string that contains the provided properties as key/value pairs"
+    )
+    @pytest.mark.parametrize(
+        "system_properties, custom_properties, expected_encoding",
+        [
+            pytest.param({}, {}, "", id="No Properties"),
+            pytest.param(
+                {"sys_prop1": "value1", "sys_prop2": "value2"},
+                {},
+                "sys_prop1=value1&sys_prop2=value2",
+                id="System Properties Only",
+            ),
+            pytest.param(
+                {},
+                {"cust_prop1": "value3", "cust_prop2": "value4"},
+                "cust_prop1=value3&cust_prop2=value4",
+                id="Custom Properties Only",
+            ),
+            pytest.param(
+                {"sys_prop1": "value1", "sys_prop2": "value2"},
+                {"cust_prop1": "value3", "cust_prop2": "value4"},
+                "sys_prop1=value1&sys_prop2=value2&cust_prop1=value3&cust_prop2=value4",
+                id="System Properties and Custom Properties",
+            ),
+        ],
+    )
+    def test_adds_properties(
+        self, message_topic, system_properties, custom_properties, expected_encoding
+    ):
+        expected_topic = message_topic + expected_encoding
+        encoded_topic = mqtt_topic_iothub.insert_message_properties_in_topic(
+            message_topic, system_properties, custom_properties
+        )
+        assert encoded_topic == expected_topic
+
+    @pytest.mark.it(
+        "URL encodes keys and values in the provided properties when adding them to the topic string"
+    )
+    @pytest.mark.parametrize(
+        "system_properties, custom_properties, expected_encoding",
+        [
+            pytest.param(
+                {"$.mid": "message#id", "$.ce": "utf-#"},
+                {},
+                "%24.mid=message%23id&%24.ce=utf-%23",
+                id="System Properties Only (Standard URL Encoding)",
+            ),
+            pytest.param(
+                {},
+                {"cu$tom1": "value#3", "cu$tom2": "value#4"},
+                "cu%24tom1=value%233&cu%24tom2=value%234",
+                id="Custom Properties Only (Standard URL Encoding)",
+            ),
+            pytest.param(
+                {"$.mid": "message#id", "$.ce": "utf-#"},
+                {"cu$tom1": "value#3", "cu$tom2": "value#4"},
+                "%24.mid=message%23id&%24.ce=utf-%23&cu%24tom1=value%233&cu%24tom2=value%234",
+                id="System Properties and Custom Properties (Standard URL Encoding)",
+            ),
+            pytest.param(
+                {"m id": "message id", "c e": "utf 8"},
+                {},
+                "m%20id=message%20id&c%20e=utf%208",
+                id="System Properties Only (URL Encoding of ' ' Character)",
+            ),
+            pytest.param(
+                {},
+                {"custom 1": "value 1", "custom 2": "value 2"},
+                "custom%201=value%201&custom%202=value%202",
+                id="Custom Properties Only (URL Encoding of ' ' Character)",
+            ),
+            pytest.param(
+                {"m id": "message id", "c e": "utf 8"},
+                {"custom 1": "value 1", "custom 2": "value 2"},
+                "m%20id=message%20id&c%20e=utf%208&custom%201=value%201&custom%202=value%202",
+                id="System Properties and Custom Properties (URL Encoding of ' ' Character)",
+            ),
+            pytest.param(
+                {"m/id": "message/id", "c/e": "utf/8"},
+                {},
+                "m%2Fid=message%2Fid&c%2Fe=utf%2F8",
+                id="System Properties Only (URL Encoding of '/' Character)",
+            ),
+            pytest.param(
+                {},
+                {"custom/1": "value/1", "custom/2": "value/2"},
+                "custom%2F1=value%2F1&custom%2F2=value%2F2",
+                id="Custom Properties Only (URL Encoding of '/' Character)",
+            ),
+            pytest.param(
+                {"m/id": "message/id", "c/e": "utf/8"},
+                {"custom/1": "value/1", "custom/2": "value/2"},
+                "m%2Fid=message%2Fid&c%2Fe=utf%2F8&custom%2F1=value%2F1&custom%2F2=value%2F2",
+                id="System Properties and Custom Properties (URL Encoding of '/' Character)",
+            ),
+        ],
+    )
+    def test_url_encoding(
+        self, message_topic, system_properties, custom_properties, expected_encoding
+    ):
+        expected_topic = message_topic + expected_encoding
+        encoded_topic = mqtt_topic_iothub.insert_message_properties_in_topic(
+            message_topic, system_properties, custom_properties
+        )
+        assert encoded_topic == expected_topic
+
+
+@pytest.mark.describe(".extract_properties_from_message_topic()")
+class TestExtractPropertiesFromMessageTopic:
+    @pytest.fixture(params=["C2D Message", "Input Message"])
+    def message_topic_base(self, request):
+        if request.param == "C2D Message":
+            return "devices/fake_device/messages/devicebound/"
+        else:
+            return "devices/fake_device/modules/fake_module/inputs/fake_input/"
+
+    @pytest.mark.it(
+        "Returns a dictionary mapping of all key/value pairs contained within the given topic string"
+    )
+    @pytest.mark.parametrize(
+        "property_string, expected_property_dict",
+        [
+            pytest.param("", {}, id="No properties"),
+            pytest.param(
+                "key1=value1&key2=value2&key3=value3",
+                {"key1": "value1", "key2": "value2", "key3": "value3"},
+                id="Some Properties",
+            ),
+        ],
+    )
+    def test_returns_map(self, message_topic_base, property_string, expected_property_dict):
+        topic = message_topic_base + property_string
+        properties = mqtt_topic_iothub.extract_properties_from_message_topic(topic)
+        assert properties == expected_property_dict
+
+    @pytest.mark.it("URL decodes the key/value pairs extracted from the topic")
+    @pytest.mark.parametrize(
+        "property_string, expected_property_dict",
+        [
+            pytest.param(
+                "%24.key1=value%231&%24.key2=value%232",
+                {"$.key1": "value#1", "$.key2": "value#2"},
+                id="Standard URL Decoding",
+            ),
+            pytest.param(
+                "key%201=value%201&key%202=value%202",
+                {"key 1": "value 1", "key 2": "value 2"},
+                id="URL Encoding of ' ' Character",
+            ),
+            pytest.param(
+                "key%2F1=value%2F1&key%2F2=value%2F2",
+                {"key/1": "value/1", "key/2": "value/2"},
+                id="URL Encoding of '/' Character",
+            ),
+        ],
+    )
+    def test_url_decoding(self, message_topic_base, property_string, expected_property_dict):
+        topic = message_topic_base + property_string
+        properties = mqtt_topic_iothub.extract_properties_from_message_topic(topic)
+        assert properties == expected_property_dict
+
+    @pytest.mark.it(
+        "Maps the extracted key to value of None if there is no corresponding value present"
+    )
+    def test_key_only(self, message_topic_base):
+        property_string = "key1&key2&key3=value"
+        expected_property_dict = {"key1": None, "key2": None, "key3": "value"}
+        topic = message_topic_base + property_string
+        properties = mqtt_topic_iothub.extract_properties_from_message_topic(topic)
+        assert properties == expected_property_dict
+
+    @pytest.mark.it("Supports empty string in properties")
+    @pytest.mark.parametrize(
+        "property_string, expected_property_dict",
+        [
+            pytest.param("=value1", {"": "value1"}, id="Empty String Key"),
+            pytest.param("key1=", {"key1": ""}, id="Empty String Value"),
+        ],
+    )
+    def test_empty_string(self, message_topic_base, property_string, expected_property_dict):
+        topic = message_topic_base + property_string
+        properties = mqtt_topic_iothub.extract_properties_from_message_topic(topic)
+        assert properties == expected_property_dict
+
+    @pytest.mark.it(
+        "Raises a ValueError if the provided topic is not a C2D topic or an Input Message topic"
+    )
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            pytest.param("not a topic", id="Not a topic"),
+            pytest.param(
+                "$iothub/twin/res/200/?$rid=d9d7ce4d-3be9-498b-abde-913b81b880e5",
+                id="Topic of wrong type",
+            ),
+            pytest.param(
+                "devices/fake_device/messages/devicebnd/%24.mid=6b822696-f75a-46f5-8b02-0680db65abf5&%24.to=%2Fdevices%2Ffake_device%2Fmessages%2Fdevicebound",
+                id="Malformed C2D topic",
+            ),
+            pytest.param(
+                "devices/fake_device/modules/fake_module/inutps/fake_input/%24.mid=6b822696-f75a-46f5-8b02-0680db65abf5&%24.to=%2Fdevices%2Ffake_device%2Fmodules%2Ffake_module%2Finputs%2Ffake_input",
+                id="Malformed input message topic",
+            ),
+        ],
+    )
+    def test_bad_topic(self, topic):
+        with pytest.raises(ValueError):
+            mqtt_topic_iothub.extract_properties_from_message_topic(topic)
+
+
+@pytest.mark.describe(".extract_name_from_method_request_topic()")
+class TestExtractNameFromMethodRequestTopic:
+    @pytest.mark.it("Returns the method name from a method topic")
+    def test_valid_method_topic(self):
+        topic = "$iothub/methods/POST/fake_method/?$rid=1"
+        expected_method_name = "fake_method"
+
+        assert (
+            mqtt_topic_iothub.extract_name_from_method_request_topic(topic) == expected_method_name
+        )
+
+    @pytest.mark.it("URL decodes the returned method name")
+    @pytest.mark.parametrize(
+        "topic, expected_method_name",
+        [
+            pytest.param(
+                "$iothub/methods/POST/fake%24method/?$rid=1",
+                "fake$method",
+                id="Standard URL Decoding",
+            ),
+            pytest.param(
+                "$iothub/methods/POST/fake+method/?$rid=1",
+                "fake+method",
+                id="Does NOT decode '+' character",
+            ),
+        ],
+    )
+    def test_url_decodes_value(self, topic, expected_method_name):
+        assert (
+            mqtt_topic_iothub.extract_name_from_method_request_topic(topic) == expected_method_name
+        )
+
+    @pytest.mark.it("Raises a ValueError if the provided topic is not a method topic")
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            pytest.param("not a topic", id="Not a topic"),
+            pytest.param(
+                "devices/fake_device/modules/fake_module/inputs/fake_input",
+                id="Topic of wrong type",
+            ),
+            pytest.param("$iothub/methdos/POST/fake_method/?$rid=1", id="Malformed topic"),
+        ],
+    )
+    def test_invalid_method_topic(self, topic):
+        with pytest.raises(ValueError):
+            mqtt_topic_iothub.extract_name_from_method_request_topic(topic)
+
+
+@pytest.mark.describe(".extract_request_id_from_method_request_topic()")
+class TestExtractRequestIdFromMethodRequestTopic:
+    @pytest.mark.it("Returns the request id from a method topic")
+    def test_valid_method_topic(self):
+        topic = "$iothub/methods/POST/fake_method/?$rid=1"
+        expected_request_id = "1"
+
+        assert (
+            mqtt_topic_iothub.extract_request_id_from_method_request_topic(topic)
+            == expected_request_id
+        )
+
+    @pytest.mark.it("URL decodes the returned value")
+    @pytest.mark.parametrize(
+        "topic, expected_request_id",
+        [
+            pytest.param(
+                "$iothub/methods/POST/fake_method/?$rid=fake%24request%2Fid",
+                "fake$request/id",
+                id="Standard URL Decoding",
+            ),
+            pytest.param(
+                "$iothub/methods/POST/fake_method/?$rid=fake+request+id",
+                "fake+request+id",
+                id="Does NOT decode '+' character",
+            ),
+        ],
+    )
+    def test_url_decodes_value(self, topic, expected_request_id):
+        assert (
+            mqtt_topic_iothub.extract_request_id_from_method_request_topic(topic)
+            == expected_request_id
+        )
+
+    @pytest.mark.it("Raises a ValueError if the provided topic is not a method topic")
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            pytest.param("not a topic", id="Not a topic"),
+            pytest.param(
+                "devices/fake_device/modules/fake_module/inputs/fake_input",
+                id="Topic of wrong type",
+            ),
+            pytest.param("$iothub/methdos/POST/fake_method/?$rid=1", id="Malformed topic"),
+        ],
+    )
+    def test_invalid_method_topic(self, topic):
+        with pytest.raises(ValueError):
+            mqtt_topic_iothub.extract_request_id_from_method_request_topic(topic)
+
+    @pytest.mark.it("Raises a ValueError if the provided topic does not contain a request id")
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            pytest.param("$iothub/methods/POST/fake_method/?$mid=1", id="No request id key"),
+            pytest.param("$iothub/methods/POST/fake_method/?$rid=", id="No request id value"),
+        ],
+    )
+    def test_no_request_id(self, topic):
+        with pytest.raises(ValueError):
+            mqtt_topic_iothub.extract_request_id_from_method_request_topic(topic)
+
+
+@pytest.mark.describe(".extract_status_code_from_twin_response_topic()")
+class TestExtractStatusCodeFromTwinResponseTopic:
+    @pytest.mark.it("Returns the status from a twin response topic")
+    def test_valid_twin_response_topic(self):
+        topic = "$iothub/twin/res/200/?rid=1"
+        expected_status = "200"
+
+        assert (
+            mqtt_topic_iothub.extract_status_code_from_twin_response_topic(topic) == expected_status
+        )
+
+    @pytest.mark.it("URL decodes the returned value")
+    @pytest.mark.parametrize(
+        "topic, expected_status",
+        [
+            pytest.param("$iothub/twin/res/%24%24%24/?rid=1", "$$$", id="Standard URL decoding"),
+            pytest.param(
+                "$iothub/twin/res/invalid+status/?rid=1",
+                "invalid+status",
+                id="Does NOT decode '+' character",
+            ),
+        ],
+    )
+    def test_url_decode(self, topic, expected_status):
+        assert (
+            mqtt_topic_iothub.extract_status_code_from_twin_response_topic(topic) == expected_status
+        )
+
+    @pytest.mark.it("Raises a ValueError if the provided topic is not a twin response topic")
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            pytest.param("not a topic", id="Not a topic"),
+            pytest.param(
+                "devices/fake_device/modules/fake_module/inputs/fake_input",
+                id="Topic of wrong type",
+            ),
+            pytest.param("$iothub/twn/res/200?rid=1", id="Malformed topic"),
+        ],
+    )
+    def test_invalid_twin_response_topic(self, topic):
+        with pytest.raises(ValueError):
+            mqtt_topic_iothub.extract_status_code_from_twin_response_topic(topic)
+
+
+@pytest.mark.describe(".extract_request_id_from_twin_response_topic()")
+class TestExtractRequestIdFromTwinResponseTopic:
+    @pytest.mark.it("Returns the request id from a twin response topic")
+    def test_valid_twin_response_topic(self):
+        topic = "$iothub/twin/res/200/?$rid=1"
+        expected_request_id = "1"
+
+        assert (
+            mqtt_topic_iothub.extract_request_id_from_twin_response_topic(topic)
+            == expected_request_id
+        )
+
+    @pytest.mark.it("URL decodes the returned value")
+    @pytest.mark.parametrize(
+        "topic, expected_request_id",
+        [
+            pytest.param(
+                "$iothub/twin/res/200/?$rid=fake%24request%2Fid",
+                "fake$request/id",
+                id="Standard URL Decoding",
+            ),
+            pytest.param(
+                "$iothub/twin/res/200/?$rid=fake+request+id",
+                "fake+request+id",
+                id="Does NOT decode '+' character",
+            ),
+        ],
+    )
+    def test_url_decodes_value(self, topic, expected_request_id):
+        assert (
+            mqtt_topic_iothub.extract_request_id_from_twin_response_topic(topic)
+            == expected_request_id
+        )
+
+    @pytest.mark.it("Raises a ValueError if the provided topic is not a twin response topic")
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            pytest.param("not a topic", id="Not a topic"),
+            pytest.param(
+                "devices/fake_device/modules/fake_module/inputs/fake_input",
+                id="Topic of wrong type",
+            ),
+            pytest.param("$iothub/twn/res/200?$rid=1", id="Malformed topic"),
+        ],
+    )
+    def test_invalid_twin_response_topic(self, topic):
+        with pytest.raises(ValueError):
+            mqtt_topic_iothub.extract_request_id_from_twin_response_topic(topic)
+
+    @pytest.mark.it("Raises a ValueError if the provided topic does not contain a request id")
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            pytest.param("$iothub/twin/res/200/?$mid=1", id="No request id key"),
+            pytest.param("$iothub/twin/res/200/?$rid=", id="No request id value"),
+        ],
+    )
+    def test_no_request_id(self, topic):
+        with pytest.raises(ValueError):
+            mqtt_topic_iothub.extract_request_id_from_twin_response_topic(topic)

--- a/v3_async_wip/tests/test_user_agent.py
+++ b/v3_async_wip/tests/test_user_agent.py
@@ -1,0 +1,65 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import pytest
+from azure.iot.device import user_agent
+import platform
+from azure.iot.device.constant import VERSION, IOTHUB_IDENTIFIER, PROVISIONING_IDENTIFIER
+
+
+check_agent_format = (
+    "{identifier}/{version}({python_runtime};{os_type} {os_release};{architecture})"
+)
+
+
+@pytest.mark.describe(".get_iothub_user_agent()")
+class TestGetIothubUserAgent(object):
+    @pytest.mark.it(
+        "Returns a user agent string formatted for IoTHub, containing python version, operating system and architecture of the system"
+    )
+    def test_get_iothub_user_agent(self):
+        user_agent_str = user_agent.get_iothub_user_agent()
+
+        assert IOTHUB_IDENTIFIER in user_agent_str
+        assert VERSION in user_agent_str
+        assert platform.python_version() in user_agent_str
+        assert platform.system() in user_agent_str
+        assert platform.version() in user_agent_str
+        assert platform.machine() in user_agent_str
+        expected_part_agent = check_agent_format.format(
+            identifier=IOTHUB_IDENTIFIER,
+            version=VERSION,
+            python_runtime=platform.python_version(),
+            os_type=platform.system(),
+            os_release=platform.version(),
+            architecture=platform.machine(),
+        )
+        assert expected_part_agent == user_agent_str
+
+
+@pytest.mark.describe(".get_provisioning_user_agent()")
+class TestGetProvisioningUserAgent(object):
+    @pytest.mark.it(
+        "Returns a user agent string formatted for the Provisioning Service, containing python version, operating system and architecture of the system"
+    )
+    def test_get_provisioning_user_agent_str(self):
+        user_agent_str = user_agent.get_provisioning_user_agent()
+
+        assert PROVISIONING_IDENTIFIER in user_agent_str
+        assert VERSION in user_agent_str
+        assert platform.python_version() in user_agent_str
+        assert platform.system() in user_agent_str
+        assert platform.version() in user_agent_str
+        assert platform.machine() in user_agent_str
+
+        expected_part_agent = check_agent_format.format(
+            identifier=PROVISIONING_IDENTIFIER,
+            version=VERSION,
+            python_runtime=platform.python_version(),
+            os_type=platform.system(),
+            os_release=platform.version(),
+            architecture=platform.machine(),
+        )
+        assert expected_part_agent == user_agent_str

--- a/v3_async_wip/tests/test_user_agent.py
+++ b/v3_async_wip/tests/test_user_agent.py
@@ -4,8 +4,8 @@
 # license information.
 # --------------------------------------------------------------------------
 import pytest
-from v3_async_wip import user_agent
 import platform
+from v3_async_wip import user_agent
 from v3_async_wip.constant import VERSION, IOTHUB_IDENTIFIER, PROVISIONING_IDENTIFIER
 
 

--- a/v3_async_wip/tests/test_user_agent.py
+++ b/v3_async_wip/tests/test_user_agent.py
@@ -4,9 +4,9 @@
 # license information.
 # --------------------------------------------------------------------------
 import pytest
-from azure.iot.device import user_agent
+from v3_async_wip import user_agent
 import platform
-from azure.iot.device.constant import VERSION, IOTHUB_IDENTIFIER, PROVISIONING_IDENTIFIER
+from v3_async_wip.constant import VERSION, IOTHUB_IDENTIFIER, PROVISIONING_IDENTIFIER
 
 
 check_agent_format = (
@@ -15,7 +15,7 @@ check_agent_format = (
 
 
 @pytest.mark.describe(".get_iothub_user_agent()")
-class TestGetIothubUserAgent(object):
+class TestGetIothubUserAgent:
     @pytest.mark.it(
         "Returns a user agent string formatted for IoTHub, containing python version, operating system and architecture of the system"
     )
@@ -40,7 +40,7 @@ class TestGetIothubUserAgent(object):
 
 
 @pytest.mark.describe(".get_provisioning_user_agent()")
-class TestGetProvisioningUserAgent(object):
+class TestGetProvisioningUserAgent:
     @pytest.mark.it(
         "Returns a user agent string formatted for the Provisioning Service, containing python version, operating system and architecture of the system"
     )

--- a/v3_async_wip/v3_async_wip/config.py
+++ b/v3_async_wip/v3_async_wip/config.py
@@ -12,6 +12,7 @@ from azure.iot.device.common.auth import sastoken as st  # type: ignore
 
 # TODO: add typings for imports
 # TODO: update docs to ensure types are correct
+# TODO: can these just be TypeDicts?
 
 
 logger = logging.getLogger(__name__)
@@ -24,7 +25,7 @@ string_to_socks_constant_map = {"HTTP": socks.HTTP, "SOCKS4": socks.SOCKS4, "SOC
 socks_constant_to_string_map = {socks.HTTP: "HTTP", socks.SOCKS4: "SOCKS4", socks.SOCKS5: "SOCKS5"}
 
 
-class ProxyOptions(object):
+class ProxyOptions:
     """
     A class containing various options to send traffic through proxy servers by enabling
     proxying of MQTT connection.

--- a/v3_async_wip/v3_async_wip/config.py
+++ b/v3_async_wip/v3_async_wip/config.py
@@ -34,7 +34,7 @@ class ProxyOptions:
     def __init__(
         self,
         proxy_type: str,
-        proxy_addr: str,
+        proxy_address: str,
         proxy_port: int,
         proxy_username: Optional[str] = None,
         proxy_password: Optional[str] = None,
@@ -48,11 +48,11 @@ class ProxyOptions:
          If it is not provided, authentication will not be used (servers may accept unauthenticated requests).
         :param str proxy_password: (optional) This parameter is valid only for SOCKS5 servers and specifies the respective password for the username provided.
         """
-        (self._proxy_type, self._proxy_type_socks) = _format_proxy_type(proxy_type)
-        self._proxy_addr = proxy_addr
-        self._proxy_port = int(proxy_port)
-        self._proxy_username = proxy_username
-        self._proxy_password = proxy_password
+        (self.proxy_type, self.proxy_type_socks) = _format_proxy_type(proxy_type)
+        self.proxy_address = proxy_address
+        self.proxy_port = int(proxy_port)
+        self.proxy_username = proxy_username
+        self.proxy_password = proxy_password
 
 
 class ClientConfig:

--- a/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
+++ b/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
@@ -73,6 +73,7 @@ class IoTHubMQTTClient:
         self._mqtt_client = _create_mqtt_client(client_config)
 
         # Create incoming IoTHub data generators
+        # TODO: expose these via method to make the device/module split cleaner
         self.incoming_c2d_messages: AsyncGenerator[Message, None] = _create_c2d_message_generator(
             self._device_id, self._mqtt_client
         )
@@ -90,9 +91,6 @@ class IoTHubMQTTClient:
         self._request_ledger = rr.RequestLedger()
         self._twin_responses_enabled = False
         self._twin_response_listener = asyncio.create_task(self._process_twin_responses())
-
-        # TODO: do we need to track what features are enabled?
-        # I don't think so, but check what happens on double subscribe
 
     def _create_token_update_alarm(self) -> alarm.Alarm:
         if not self._sastoken:
@@ -141,7 +139,6 @@ class IoTHubMQTTClient:
 
         async for mqtt_message in twin_responses:
             request_id = mqtt_topic.extract_request_id_from_twin_response_topic(mqtt_message.topic)
-            # TODO: move the int conversion into the topic module?
             status_code = int(
                 mqtt_topic.extract_status_code_from_twin_response_topic(mqtt_message.topic)
             )

--- a/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
+++ b/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
@@ -11,10 +11,9 @@ import urllib.parse
 from typing import Optional, AsyncGenerator
 from .custom_typing import TwinPatch, Twin
 from .models import Message, MethodResponse, MethodRequest
-from . import config, constant
+from . import config, constant, user_agent
 from . import request_response as rr
 from . import mqtt_client as mqtt
-from azure.iot.device import user_agent  # type: ignore
 from azure.iot.device.iothub.pipeline import mqtt_topic_iothub as mqtt_topic  # type: ignore
 from azure.iot.device.common.auth import sastoken as st  # type: ignore
 from azure.iot.device.common import alarm  # type: ignore

--- a/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
+++ b/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
@@ -18,7 +18,6 @@ from . import mqtt_topic_iothub as mqtt_topic
 from azure.iot.device.common.auth import sastoken as st  # type: ignore
 from azure.iot.device.common import alarm  # type: ignore
 
-# TODO: add typings to reused V2 code
 # TODO: update docstrings with correct class paths once repo structured better
 
 logger = logging.getLogger(__name__)

--- a/v3_async_wip/v3_async_wip/models.py
+++ b/v3_async_wip/v3_async_wip/models.py
@@ -3,13 +3,13 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from typing import Optional, Dict, Any
+from typing import Optional, Dict
 from .custom_typing import JSONSerializable
 from . import constant
 
 # TODO: json docs
 
-# TODO: only valid content encodings are utf-7, utf-16, utf-32
+# TODO: only valid content encodings are utf-8, utf-16, utf-32
 
 
 class Message:
@@ -48,9 +48,11 @@ class Message:
         # All Messages
         self.payload = payload
         self.message_id = message_id
-        self.content_encoding = content_encoding  # TODO: default?
-        self.content_type = content_type  # TODO: is this supposed to have a default?
-        self.custom_properties: Dict[str, Any] = {}  # TODO: Make this more accurate
+        self.content_encoding = content_encoding  # TODO: default? YES utf-8?
+        self.content_type = (
+            content_type  # TODO: is this supposed to have a default?      YES application/json
+        )
+        self.custom_properties: Dict[str, str] = {}
 
         # Outgoing Messages (D2C/Output)
         self.output_name = output_name
@@ -111,7 +113,7 @@ class Message:
     @classmethod
     # TODO: should this just replace the __init__?
     def create_from_properties_dict(
-        cls, payload: JSONSerializable, properties: Dict[str, Optional[str]]
+        cls, payload: JSONSerializable, properties: Dict[str, str]
     ) -> "Message":
         message = cls(payload)
 

--- a/v3_async_wip/v3_async_wip/models.py
+++ b/v3_async_wip/v3_async_wip/models.py
@@ -65,8 +65,6 @@ class Message:
         self._iothub_interface_id: Optional[str] = None
 
         # Incoming Messages (C2D/Input)
-        # NOTE: These are not settable via the __init__ since the end user does not create
-        # C2D Messages, they are only created internally
         self.input_name: Optional[str] = None
         self.ack: Optional[str] = None
         self.expiry_time_utc: Optional[str] = None

--- a/v3_async_wip/v3_async_wip/models.py
+++ b/v3_async_wip/v3_async_wip/models.py
@@ -8,8 +8,10 @@ from typing import Optional, Dict
 from .custom_typing import JSONSerializable
 from . import constant
 
+# TODO: json docs
 
-class Message(object):
+
+class Message:
     """Represents a message to or from IoTHub
 
     :ivar payload: The data that constitutes the payload
@@ -32,7 +34,7 @@ class Message(object):
         content_encoding: Optional[str] = None,
         content_type: Optional[str] = None,
         output_name: Optional[str] = None,
-    ):
+    ) -> None:
         """
         Initializer for Message
 
@@ -93,7 +95,7 @@ class Message(object):
         return total
 
 
-class MethodRequest(object):
+class MethodRequest:
     """Represents a request to invoke a direct method.
 
     :ivar str request_id: The request id.
@@ -102,7 +104,7 @@ class MethodRequest(object):
     :type payload: dict, str, int, float, bool, or None (JSON compatible values)
     """
 
-    def __init__(self, request_id: str, name: str, payload: JSONSerializable):
+    def __init__(self, request_id: str, name: str, payload: JSONSerializable) -> None:
         """Initializer for a MethodRequest.
 
         :param str request_id: The request id.
@@ -115,7 +117,7 @@ class MethodRequest(object):
         self.payload = payload
 
 
-class MethodResponse(object):
+class MethodResponse:
     """Represents a response to a direct method.
 
     :ivar str request_id: The request id of the MethodRequest being responded to.
@@ -124,7 +126,7 @@ class MethodResponse(object):
     :type payload: dict, str, int, float, bool, or None (JSON compatible values)
     """
 
-    def __init__(self, request_id: str, status: int, payload: JSONSerializable = None):
+    def __init__(self, request_id: str, status: int, payload: JSONSerializable = None) -> None:
         """Initializer for MethodResponse.
 
         :param str request_id: The request id of the MethodRequest being responded to.

--- a/v3_async_wip/v3_async_wip/models.py
+++ b/v3_async_wip/v3_async_wip/models.py
@@ -7,9 +7,7 @@ from typing import Optional, Dict, Union
 from .custom_typing import JSONSerializable
 from . import constant
 
-# TODO: json docs
-
-# TODO: only valid content encodings are utf-8, utf-16, utf-32
+# TODO: Should Message property dictionaries be TypeDicts?
 
 
 class Message:
@@ -45,6 +43,16 @@ class Message:
             Acceptable values are 'text/plain' and 'application/json'
         :param str output_name: Name of the output that the message is being sent to.
         """
+        # Sanitize
+        if content_encoding not in ["utf-8", "utf-16", "utf-32"]:
+            raise ValueError(
+                "Invalid content encoding. Supported codecs are 'utf-8', 'utf-16' and 'utf-32'"
+            )
+        if content_type not in ["text/plain", "application/json"]:
+            raise ValueError(
+                "Invalid content type. Supported types are 'text/plain' and 'application/json'"
+            )
+
         # All Messages
         self.payload = payload
         self.content_encoding = content_encoding

--- a/v3_async_wip/v3_async_wip/models.py
+++ b/v3_async_wip/v3_async_wip/models.py
@@ -48,9 +48,9 @@ class Message:
         # All Messages
         self.payload = payload
         self.message_id = message_id
-        self.content_encoding = content_encoding
+        self.content_encoding = content_encoding  # TODO: default?
         self.content_type = content_type  # TODO: is this supposed to have a default?
-        self.custom_properties: Dict[str, Any] = {}  # TODO: do tests cover any?
+        self.custom_properties: Dict[str, Any] = {}  # TODO: Make this more accurate
 
         # Outgoing Messages (D2C/Output)
         self.output_name = output_name
@@ -60,7 +60,7 @@ class Message:
         # C2D Messages, they are only created internally
         self.input_name: Optional[str] = None
         self.ack: Optional[str] = None
-        self.expiry_time_utc: Optional[str] = None  # TODO: what is this type?
+        self.expiry_time_utc: Optional[str] = None
         self.user_id: Optional[str] = None
         self.correlation_id: Optional[str] = None
 

--- a/v3_async_wip/v3_async_wip/mqtt_client.py
+++ b/v3_async_wip/v3_async_wip/mqtt_client.py
@@ -11,7 +11,7 @@ import paho.mqtt.client as mqtt  # type: ignore
 from paho.mqtt.client import MQTTMessage  # noqa: F401    (Importing directly to re-export)
 import ssl
 from typing import Any, Dict, AsyncGenerator, Optional, Union
-from azure.iot.device.common import ProxyOptions  # type:ignore
+from v3_async_wip.config import ProxyOptions
 
 
 logger = logging.getLogger(__name__)

--- a/v3_async_wip/v3_async_wip/mqtt_topic_iothub.py
+++ b/v3_async_wip/v3_async_wip/mqtt_topic_iothub.py
@@ -1,0 +1,288 @@
+# --------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import logging
+import urllib.parse
+from typing import Optional, Union, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+# TODO: Can TypeDicts be used for properties?
+
+# NOTE: Whenever using standard URL encoding via the urllib.parse.quote() API
+# make sure to specify that there are NO safe values (e.g. safe=""). By default
+# "/" is skipped in encoding, and that is not desirable.
+#
+# DO NOT use urllib.parse.quote_plus(), as it turns ' ' characters into '+',
+# which is invalid for MQTT publishes.
+#
+# DO NOT use urllib.parse.unquote_plus(), as it turns '+' characters into ' ',
+# which is also invalid.
+
+
+# NOTE (Oct 2020): URL encoding policy is currently inconsistent in this module due to restrictions
+# with the Hub, as Hub does not do URL decoding on most values.
+# (see: https://github.com/Azure/azure-iot-sdk-python/wiki/URL-Encoding-(MQTT)).
+# Currently, as much as possible is URL encoded while keeping in line with the policy outlined
+# in the above linked wiki article. This is to say that Device ID and Module ID are never
+# encoded, however other values are. By convention, it's probably fine to be encoding/decoding most
+# values that are not Device ID or Module ID, since it won't make a difference in production as
+# the narrow range of acceptable values for, say, status code, or request ID don't contain any
+# characters that require URL encoding/decoding in the first place. Thus it doesn't break on Hub,
+# but it's still done here as a client-side best practice - Hub will eventually be doing a new API
+# that does correctly URL encode/decode all values, so it's not good to roll back more than
+# is currently necessary to avoid errors.
+
+
+def _get_topic_base(device_id: str, module_id: Optional[str] = None) -> str:
+    """
+    return the string that is at the beginning of all topics for this
+    device/module
+    """
+
+    # NOTE: Neither Device ID nor Module ID should be URL encoded in a topic string.
+    # See the repo wiki article for details:
+    # https://github.com/Azure/azure-iot-sdk-python/wiki/URL-Encoding-(MQTT)
+    topic = "devices/" + str(device_id)
+    if module_id:
+        topic = topic + "/modules/" + str(module_id)
+    return topic
+
+
+def get_c2d_topic_for_subscribe(device_id: str) -> str:
+    """
+    :return: The topic for cloud to device messages.It is of the format
+    "devices/<deviceid>/messages/devicebound/#"
+    """
+    return _get_topic_base(device_id) + "/messages/devicebound/#"
+
+
+def get_input_topic_for_subscribe(device_id: str, module_id: str) -> str:
+    """
+    :return: The topic for input messages. It is of the format
+    "devices/<deviceId>/modules/<moduleId>/inputs/#"
+    """
+    return _get_topic_base(device_id, module_id) + "/inputs/#"
+
+
+def get_method_topic_for_subscribe() -> str:
+    """
+    :return: The topic for ALL incoming methods. It is of the format
+    "$iothub/methods/POST/#"
+    """
+    return "$iothub/methods/POST/#"
+
+
+def get_twin_response_topic_for_subscribe() -> str:
+    """
+    :return: The topic for ALL incoming twin responses. It is of the format
+    "$iothub/twin/res/#"
+    """
+    return "$iothub/twin/res/#"
+
+
+def get_twin_patch_topic_for_subscribe() -> str:
+    """
+    :return: The topic for ALL incoming twin patches. It is of the format
+    "$iothub/twin/PATCH/properties/desired/#
+    """
+    return "$iothub/twin/PATCH/properties/desired/#"
+
+
+def get_telemetry_topic_for_publish(device_id: str, module_id: Optional[str] = None) -> str:
+    """
+    return the topic string used to publish telemetry
+    """
+    return _get_topic_base(device_id, module_id) + "/messages/events/"
+
+
+def get_method_topic_for_publish(request_id: str, status: Union[str, int]) -> str:
+    """
+    :return: The topic for publishing method responses. It is of the format
+    "$iothub/methods/res/<status>/?$rid=<requestId>"
+    """
+    return "$iothub/methods/res/{status}/?$rid={request_id}".format(
+        status=urllib.parse.quote(str(status), safe=""),
+        request_id=urllib.parse.quote(str(request_id), safe=""),
+    )
+
+
+def get_twin_request_topic_for_publish(request_id: str) -> str:
+    """
+    :return: The topic for publishing a get twin request. It is of the format
+    "$iothub/twin/GET/?$rid=<request_id>"
+    """
+    return "$iothub/twin/GET/?$rid={request_id}".format(
+        request_id=urllib.parse.quote(str(request_id), safe="")
+    )
+
+
+def get_twin_patch_topic_for_publish(request_id: str) -> str:
+    """
+    :return: The topic for publishing a twin patch. It is of the format
+    "$iothub/twin/PATCH/properties/reported?$rid=<request_id>"
+    """
+    return "$iothub/twin/PATCH/properties/reported/?$rid={request_id}".format(
+        request_id=urllib.parse.quote(str(request_id), safe="")
+    )
+
+
+def insert_message_properties_in_topic(
+    topic: str,
+    system_properties: Dict[str, str],
+    custom_properties: Dict[str, Any],
+) -> str:
+    """
+    URI encode system and custom properties into a message topic.
+
+    :param dict system_properties: A dictionary mapping system properties to their values
+    :param dict custom_properties: A dictionary mapping custom properties to their values.
+    :return: The modified topic containing the encoded properties
+    """
+    if system_properties:
+        encoded_system_properties = urllib.parse.urlencode(
+            system_properties, quote_via=urllib.parse.quote
+        )
+        topic += encoded_system_properties
+    if system_properties and custom_properties:
+        topic += "&"
+    if custom_properties:
+        encoded_custom_properties = urllib.parse.urlencode(
+            custom_properties, quote_via=urllib.parse.quote
+        )
+        topic += encoded_custom_properties
+    return topic
+
+
+def extract_properties_from_message_topic(topic: str) -> Dict[str, Optional[str]]:
+    """
+    Extract key=value pairs from an incoming message topic, returning them as a dictionary.
+    If a key has no matching value, the value will be set to None.
+
+    :param str topic: The topic string
+    :returns: dictionary mapping keys to values.
+    """
+    parts = topic.split("/")
+    # Input Message Topic
+    if len(parts) > 4 and parts[4] == "inputs":
+        if len(parts) > 6:
+            properties_string = parts[6]
+        else:
+            properties_string = ""
+    # C2D Message Topic
+    elif len(parts) > 3 and parts[3] == "devicebound":
+        if len(parts) > 4:
+            properties_string = parts[4]
+        else:
+            properties_string = ""
+    else:
+        raise ValueError("topic has incorrect format")
+
+    return _extract_properties(properties_string)
+
+
+def extract_name_from_method_request_topic(topic: str) -> str:
+    """
+    Extract the method name from the method topic.
+    Topics for methods are of the following format:
+    "$iothub/methods/POST/{method name}/?$rid={request id}"
+
+    :param str topic: The topic string
+    :return: method name from topic string
+    """
+    parts = topic.split("/")
+    if topic.startswith("$iothub/methods/POST") and len(parts) >= 4:
+        return urllib.parse.unquote(parts[3])
+    else:
+        raise ValueError("topic has incorrect format")
+
+
+def extract_request_id_from_method_request_topic(topic: str) -> str:
+    """
+    Extract the Request ID (RID) from the method topic.
+    Topics for methods are of the following format:
+    "$iothub/methods/POST/{method name}/?$rid={request id}"
+
+    :param str topic: the topic string
+    :raises: ValueError if topic has incorrect format
+    :returns: request id from topic string
+    """
+    parts = topic.split("/")
+    if topic.startswith("$iothub/methods/POST") and len(parts) >= 4:
+        properties = _extract_properties(topic.split("?")[1])
+        rid = properties.get("$rid")
+        if not rid:
+            raise ValueError("No request id in topic")
+        return rid
+    else:
+        raise ValueError("topic has incorrect format")
+
+
+def extract_status_code_from_twin_response_topic(topic: str) -> str:
+    """
+    Extract the status code from the twin response topic.
+    Topics for twin response are in the following format:
+    "$iothub/twin/res/{status}/?$rid={rid}"
+
+    :param str topic: The topic string
+    :raises: ValueError if the topic has incorrect format
+    :returns status code from topic string
+    """
+    parts = topic.split("/")
+    if topic.startswith("$iothub/twin/res/") and len(parts) >= 4:
+        return urllib.parse.unquote(parts[3])
+    else:
+        raise ValueError("topic has incorrect format")
+
+
+def extract_request_id_from_twin_response_topic(topic: str) -> str:
+    """
+    Extract the Request ID (RID) from the twin response topic.
+    Topics for twin response are in the following format:
+    "$iothub/twin/res/{status}/?$rid={rid}"
+
+    :param str topic: The topic string
+    :raises: ValueError if topic has incorrect format
+    :returns: request id from topic string
+    """
+    parts = topic.split("/")
+    if topic.startswith("$iothub/twin/res/") and len(parts) >= 4:
+        properties = _extract_properties(topic.split("?")[1])
+        rid = properties.get("$rid")
+        if not rid:
+            raise ValueError("No request id in topic")
+        return rid
+    else:
+        raise ValueError("topic has incorrect format")
+
+
+def _extract_properties(properties_str: str) -> Dict[str, Optional[str]]:
+    """Return a dictionary of properties from a string in the format
+    {key1}={value1}&{key2}={value2}...&{keyn}={valuen}
+
+    For extracting values corresponding to keys the following rules are followed:-
+    If there is NO "=", the value is None
+    If there is "=" with no value, the value is an empty string
+    For anything else, the value after "=" and before `&` is considered as the proper value
+    """
+    d: Dict[str, Optional[str]] = {}
+    if len(properties_str) == 0:
+        # There are no properties, return empty
+        return d
+
+    kv_pairs = properties_str.split("&")
+    for entry in kv_pairs:
+        pair = entry.split("=")
+        key = urllib.parse.unquote(pair[0])
+        if len(pair) > 1:
+            # Key/Value Pair
+            value = urllib.parse.unquote(pair[1])
+        else:
+            # Key with no value -> value = None
+            value = None
+        d[key] = value
+
+    return d

--- a/v3_async_wip/v3_async_wip/mqtt_topic_iothub.py
+++ b/v3_async_wip/v3_async_wip/mqtt_topic_iothub.py
@@ -130,9 +130,6 @@ def get_twin_patch_topic_for_publish(request_id: str) -> str:
     )
 
 
-# TODO: ensure valueless key support
-
-
 def insert_message_properties_in_topic(
     topic: str,
     system_properties: Dict[str, str],
@@ -163,7 +160,7 @@ def insert_message_properties_in_topic(
 def extract_properties_from_message_topic(topic: str) -> Dict[str, str]:
     """
     Extract key=value pairs from an incoming message topic, returning them as a dictionary.
-    If a key has no matching value, the value will be set to None.
+    If a key has no matching value, the value will be set to empty string.
 
     :param str topic: The topic string
     :returns: dictionary mapping keys to values.

--- a/v3_async_wip/v3_async_wip/mqtt_topic_iothub.py
+++ b/v3_async_wip/v3_async_wip/mqtt_topic_iothub.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 # values that are not Device ID or Module ID, since it won't make a difference in production as
 # the narrow range of acceptable values for, say, status code, or request ID don't contain any
 # characters that require URL encoding/decoding in the first place. Thus it doesn't break on Hub,
-# but it's still done here as a client-side best practice - Hub will eventually be doing a new API
+# but it's still done here as a client-side best practice - Hub may eventually be doing a new API
 # that does correctly URL encode/decode all values, so it's not good to roll back more than
 # is currently necessary to avoid errors.
 

--- a/v3_async_wip/v3_async_wip/mqtt_topic_iothub.py
+++ b/v3_async_wip/v3_async_wip/mqtt_topic_iothub.py
@@ -6,7 +6,7 @@
 
 import logging
 import urllib.parse
-from typing import Optional, Union, Dict, Any
+from typing import Optional, Union, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -130,10 +130,13 @@ def get_twin_patch_topic_for_publish(request_id: str) -> str:
     )
 
 
+# TODO: ensure valueless key support
+
+
 def insert_message_properties_in_topic(
     topic: str,
     system_properties: Dict[str, str],
-    custom_properties: Dict[str, Any],
+    custom_properties: Dict[str, str],
 ) -> str:
     """
     URI encode system and custom properties into a message topic.
@@ -157,7 +160,7 @@ def insert_message_properties_in_topic(
     return topic
 
 
-def extract_properties_from_message_topic(topic: str) -> Dict[str, Optional[str]]:
+def extract_properties_from_message_topic(topic: str) -> Dict[str, str]:
     """
     Extract key=value pairs from an incoming message topic, returning them as a dictionary.
     If a key has no matching value, the value will be set to None.
@@ -259,16 +262,14 @@ def extract_request_id_from_twin_response_topic(topic: str) -> str:
         raise ValueError("topic has incorrect format")
 
 
-def _extract_properties(properties_str: str) -> Dict[str, Optional[str]]:
+def _extract_properties(properties_str: str) -> Dict[str, str]:
     """Return a dictionary of properties from a string in the format
     {key1}={value1}&{key2}={value2}...&{keyn}={valuen}
 
     For extracting values corresponding to keys the following rules are followed:-
-    If there is NO "=", the value is None
-    If there is "=" with no value, the value is an empty string
-    For anything else, the value after "=" and before `&` is considered as the proper value
+    If there is a just a key with no "=", the value is an empty string
     """
-    d: Dict[str, Optional[str]] = {}
+    d: Dict[str, str] = {}
     if len(properties_str) == 0:
         # There are no properties, return empty
         return d
@@ -282,7 +283,7 @@ def _extract_properties(properties_str: str) -> Dict[str, Optional[str]]:
             value = urllib.parse.unquote(pair[1])
         else:
             # Key with no value -> value = None
-            value = None
+            value = ""
         d[key] = value
 
     return d

--- a/v3_async_wip/v3_async_wip/mqtt_topic_iothub.py
+++ b/v3_async_wip/v3_async_wip/mqtt_topic_iothub.py
@@ -10,8 +10,6 @@ from typing import Optional, Union, Dict
 
 logger = logging.getLogger(__name__)
 
-# TODO: Can TypeDicts be used for properties?
-
 # NOTE: Whenever using standard URL encoding via the urllib.parse.quote() API
 # make sure to specify that there are NO safe values (e.g. safe=""). By default
 # "/" is skipped in encoding, and that is not desirable.

--- a/v3_async_wip/v3_async_wip/user_agent.py
+++ b/v3_async_wip/v3_async_wip/user_agent.py
@@ -1,0 +1,41 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""This module is for creating agent strings for all clients"""
+
+import platform
+from azure.iot.device.constant import VERSION, IOTHUB_IDENTIFIER, PROVISIONING_IDENTIFIER
+
+python_runtime = platform.python_version()
+os_type = platform.system()
+os_release = platform.version()
+architecture = platform.machine()
+
+
+def _get_common_user_agent() -> str:
+    return "({python_runtime};{os_type} {os_release};{architecture})".format(
+        python_runtime=python_runtime,
+        os_type=os_type,
+        os_release=os_release,
+        architecture=architecture,
+    )
+
+
+def get_iothub_user_agent() -> str:
+    """
+    Create the user agent for IotHub
+    """
+    return "{iothub_iden}/{version}{common}".format(
+        iothub_iden=IOTHUB_IDENTIFIER, version=VERSION, common=_get_common_user_agent()
+    )
+
+
+def get_provisioning_user_agent() -> str:
+    """
+    Create the user agent for Provisioning
+    """
+    return "{provisioning_iden}/{version}{common}".format(
+        provisioning_iden=PROVISIONING_IDENTIFIER, version=VERSION, common=_get_common_user_agent()
+    )


### PR DESCRIPTION
* Ported user_agent.py and added typings for V3 
* Ported, added typings and simplified mqtt_topic_iothub.py for V3
* Enhanced Message class to make properties and topics easier to use internally.
* Enhanced Message-related logic to be more rigid about expected typings
* Added full support for JSON payloads when sending/receiving messages
* APIs related to Device/Module-specific features now throw exceptions if not using the correct configuration