### PR TITLE
Fix: empty payload

### DIFF
--- a/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub_http.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub_http.py
@@ -77,7 +77,7 @@ class IoTHubHTTPTranslationStage(PipelineStage):
                 )
                 error = map_http_error(error=error, http_op=op)
                 if not error:
-                    op_waiting_for_response.method_response = json.loads(op.response_body)
+                    op_waiting_for_response.method_response = json.loads(op.response_body or 'null')
                 op_waiting_for_response.complete(error=error)
 
             self.send_op_down(
@@ -122,7 +122,7 @@ class IoTHubHTTPTranslationStage(PipelineStage):
                 )
                 error = map_http_error(error=error, http_op=op)
                 if not error:
-                    op_waiting_for_response.storage_info = json.loads(op.response_body)
+                    op_waiting_for_response.storage_info = json.loads(op.response_body or 'null')
                 op_waiting_for_response.complete(error=error)
 
             self.send_op_down(

--- a/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub_mqtt.py
+++ b/azure-iot-device/azure/iot/device/iothub/pipeline/pipeline_stages_iothub_mqtt.py
@@ -203,7 +203,7 @@ class IoTHubMQTTTranslationStage(PipelineStage):
                 method_received = MethodRequest(
                     request_id=request_id,
                     name=method_name,
-                    payload=json.loads(event.payload.decode("utf-8")),
+                    payload=json.loads(event.payload.decode("utf-8") or 'null'),
                 )
                 self.send_event_up(pipeline_events_iothub.MethodRequestEvent(method_received))
 
@@ -219,7 +219,7 @@ class IoTHubMQTTTranslationStage(PipelineStage):
             elif mqtt_topic_iothub.is_twin_desired_property_patch_topic(topic):
                 self.send_event_up(
                     pipeline_events_iothub.TwinDesiredPropertiesPatchEvent(
-                        patch=json.loads(event.payload.decode("utf-8"))
+                        patch=json.loads(event.payload.decode("utf-8") or 'null')
                     )
                 )
 

--- a/tests/unit/iothub/pipeline/test_pipeline_stages_iothub_mqtt.py
+++ b/tests/unit/iothub/pipeline/test_pipeline_stages_iothub_mqtt.py
@@ -892,7 +892,7 @@ class TestIoTHubMQTTTranslationStageHandlePipelineEventWithIncomingMQTTMessageEv
         assert new_event.method_request.name == method_name
         assert new_event.method_request.request_id == rid
         # This is expanded on in in the next test
-        assert new_event.method_request.payload == json.loads(event.payload.decode("utf-8"))
+        assert new_event.method_request.payload == json.loads(event.payload.decode("utf-8") or 'null')
 
     @pytest.mark.it(
         "Derives the MethodRequestEvent's payload by converting the original event's payload from bytes into a JSON object"
@@ -904,6 +904,7 @@ class TestIoTHubMQTTTranslationStageHandlePipelineEventWithIncomingMQTTMessageEv
             pytest.param(b'"payload"', "payload", id="String JSON"),
             pytest.param(b"1234", 1234, id="Int JSON"),
             pytest.param(b"null", None, id="None JSON"),
+            pytest.param(b"", None, id="Empty JSON"),
         ],
     )
     def test_json_payload(self, event, stage, original_payload, derived_payload):
@@ -975,6 +976,7 @@ class TestIoTHubMQTTTranslationStageHandlePipelineEventWithIncomingMQTTMessageEv
             pytest.param(b'"payload"', "payload", id="String JSON"),
             pytest.param(b"1234", 1234, id="Int JSON"),
             pytest.param(b"null", None, id="None JSON"),
+            pytest.param(b"", None, id="Empty JSON"),
         ],
     )
     def test_twin_patch_event(self, event, stage, original_payload, derived_payload):


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-python/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
-  (n/a) If this is a modification that impacts the behavior of a public API
   - [x] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

## Reference/Link to the issue solved with this PR (if any)

#1081 

## Description of the problem

Method request with no payload were raising a json decode issue like mentioned in #1081.

## Description of the solution

Added a oneliner to manage empty payloads.
MQTT tests updated too.
HTTP tests: I did not find the way to test this specific change.
