### PR TITLE
[V3] Simplified shutdown

### DIFF
--- a/v3_async_wip/v3_async_wip/iothub_client.py
+++ b/v3_async_wip/v3_async_wip/iothub_client.py
@@ -4,10 +4,11 @@
 # license information.
 # --------------------------------------------------------------------------
 import abc
+import asyncio
 import logging
 import os
 import ssl
-from typing import Optional, Union, cast
+from typing import Optional, cast
 from .custom_typing import FunctionOrCoroutine
 from .iot_exceptions import IoTEdgeEnvironmentError
 from . import config, edge_hsm
@@ -50,46 +51,15 @@ class IoTHubClient(abc.ABC):
         Cannot be cancelled - if you try, the client will still fully shut down as much as
         possible (although the CancelledError will still be raised)
         """
-        cached_exception: Optional[Union[Exception, BaseException]] = None
-        logger.debug("Beginning IoTHubClient shutdown procedure")
-        try:
-            logger.debug("Shutting down IoTHubMQTTClient...")
-            await self._mqtt_client.shutdown()
-            logger.debug("IoTHubMQTTClient shutdown complete")
-        except (Exception, BaseException) as e:
-            logger.warning(
-                "Unexpected error during shutdown of IoTHubMQTTClient suppressed - still completing the rest of shutdown procedure"
-            )
-            cached_exception = e
-
-        try:
-            logger.debug("Shutting down IoTHubHTTPClient...")
-            await self._http_client.shutdown()
-            logger.debug("IoTHubHTTPClient shutdown complete")
-        except (Exception, BaseException) as e:
-            logger.warning(
-                "Unexpected error during shutdown of IoTHubHTTPClient suppressed - still completing the rest of shutdown procedure"
-            )
-            cached_exception = e
+        operations = []
+        operations.append(asyncio.shield(self._mqtt_client.shutdown()))
+        operations.append(asyncio.shield(self._http_client.shutdown()))
         if self._sastoken_provider:
-            try:
-                logger.debug("Shutting down SasTokenProvider...")
-                await self._sastoken_provider.shutdown()
-                logger.debug("SasTokenProvider shutdown complete")
-            except (Exception, BaseException) as e:
-                logger.warning(
-                    "Unexpected error during shutdown of SasTokenProvider suppressed - still completing the rest of shutdown procedure"
-                )
-                cached_exception = e
-
-        logger.debug("IoTHubClient shutdown procedure complete")
-        if cached_exception:
-            # NOTE: In the case of multiple failures, only the last one gets raised.
-            # Not much way around it, and besides, this is all an extreme edge case anyway.
-            logger.warning(
-                "Raising previously suppressed error now that shutdown procedure is complete"
-            )
-            raise cached_exception
+            operations.append(asyncio.shield(self._sastoken_provider.shutdown()))
+        results = await asyncio.gather(*operations, return_exceptions=True)
+        for result in results:
+            if isinstance(result, Exception):
+                raise result
 
     # ~~~~~ Abstract declarations ~~~~~
     # NOTE: rigid typechecking doesn't like when the signature changes in the child class

--- a/v3_async_wip/v3_async_wip/iothub_client.py
+++ b/v3_async_wip/v3_async_wip/iothub_client.py
@@ -58,7 +58,9 @@ class IoTHubClient(abc.ABC):
             operations.append(asyncio.shield(self._sastoken_provider.shutdown()))
         results = await asyncio.gather(*operations, return_exceptions=True)
         for result in results:
-            if isinstance(result, Exception):
+            # NOTE: Need to specifically exclude asyncio.CancelledError because it is not a
+            # BaseException in Python 3.7
+            if isinstance(result, Exception) and not isinstance(result, asyncio.CancelledError):
                 raise result
 
     # ~~~~~ Abstract declarations ~~~~~

--- a/v3_async_wip/v3_async_wip/iothub_http_client.py
+++ b/v3_async_wip/v3_async_wip/iothub_http_client.py
@@ -86,7 +86,7 @@ class IoTHubHTTPClient:
 
         Invoke only when complete finished with the client for graceful exit.
         """
-        await self._session.close()
+        await asyncio.shield(self._session.close())
         # Wait 250ms for the underlying SSL connections to close
         # See: https://docs.aiohttp.org/en/stable/client_advanced.html#graceful-shutdown
         await asyncio.sleep(0.25)

--- a/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
+++ b/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
@@ -164,7 +164,9 @@ class IoTHubMQTTClient:
             *cancelled_tasks, asyncio.shield(self.disconnect()), return_exceptions=True
         )
         for result in results:
-            if isinstance(result, Exception):
+            # NOTE: Need to specifically exclude asyncio.CancelledError because it is not a
+            # BaseException in Python 3.7
+            if isinstance(result, Exception) and not isinstance(result, asyncio.CancelledError):
                 raise result
 
     async def connect(self) -> None:

--- a/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
+++ b/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
@@ -8,7 +8,7 @@ import asyncio
 import json
 import logging
 import urllib.parse
-from typing import Optional, Union, AsyncGenerator
+from typing import Optional, AsyncGenerator
 from .custom_typing import TwinPatch, Twin
 from .iot_exceptions import IoTHubError, IoTHubClientError
 from .models import Message, DirectMethodResponse, DirectMethodRequest
@@ -149,19 +149,6 @@ class IoTHubMQTTClient:
         Cannot be cancelled - if you try, the client will still fully shut down as much as
         possible.
         """
-        # NOTE: .disconnect() really shouldn't fail, but if it does, we temporarily suppress
-        # the exception so we can still do as much cleanup as possible.
-        cached_exception: Optional[Union[Exception, asyncio.CancelledError]] = None
-        logger.debug("Attempting disconnect in shutdown")
-        try:
-            await self.disconnect()
-        except asyncio.CancelledError as e:
-            logger.warning("Cancellation during shutdown. Still attempting to clean up.")
-            cached_exception = e
-        except Exception as e:
-            logger.warning("Unexpected error disconnecting. Continuing shutdown procedure")
-            cached_exception = e
-
         cancelled_tasks = []
 
         logger.debug("Cancelling 'process_twin_responses' background task")
@@ -173,14 +160,12 @@ class IoTHubMQTTClient:
             self._keep_credentials_fresh_bg_task.cancel()
             cancelled_tasks.append(self._keep_credentials_fresh_bg_task)
 
-        # Wait for the cancellation to complete before returning
-        # NOTE: If cancelled while awaiting here, all tasks in gather will still be cancelled
-        # because the cancellations have already been issued.
-        # NOTE: Also, cancelling a gather implicitly cancels all the tasks that are gathered anyway
-        await asyncio.gather(*cancelled_tasks, return_exceptions=True)
-
-        if cached_exception:
-            raise cached_exception
+        results = await asyncio.gather(
+            *cancelled_tasks, asyncio.shield(self.disconnect()), return_exceptions=True
+        )
+        for result in results:
+            if isinstance(result, Exception):
+                raise result
 
     async def connect(self) -> None:
         """Connect to IoTHub


### PR DESCRIPTION
* Simplified `.shutdown()` implementations with use of `asyncio.shield()`
* Marked tests where some more complex mocking is required to truly demonstrate the accuracy of shutdown (low priority for now)
* Added try/finally blocks to tests that could hang upon assertion failure due to the mocking of methods that are required for teardown