### PR TITLE
[V3] Infrastructure to support ProvisioningMQTTClient

### DIFF
--- a/v3_async_wip/tests/test_mqtt_topic_provisioning.py
+++ b/v3_async_wip/tests/test_mqtt_topic_provisioning.py
@@ -1,0 +1,300 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import pytest
+import logging
+from v3_async_wip import mqtt_topic_provisioning
+
+logging.basicConfig(level=logging.DEBUG)
+
+# NOTE: All tests (that require it) are parametrized with multiple values for URL encoding.
+# This is to show that the URL encoding is done correctly - not all URL encoding encodes
+# the same way.
+#
+# For URL encoding, we must always test the ' ' and '/' characters specifically, in addition
+# to a generic URL encoding value (e.g. $, #, etc.)
+#
+# For URL decoding, we must always test the '+' character specifically, in addition to
+# a generic URL encoded value (e.g. %24, %23, etc.)
+#
+# Please also always test that provided values are converted to strings in order to ensure
+# that they can be URL encoded without error.
+#
+# PLEASE DO THESE TESTS FOR EVEN CASES WHERE THOSE CHARACTERS SHOULD NOT OCCUR, FOR SAFETY.
+
+
+@pytest.mark.describe(".get_response_topic_for_subscribe()")
+class TestGetResponseTopicForSubscribe(object):
+    @pytest.mark.it("Returns the topic for subscribing to responses from DPS")
+    def test_returns_topic(self):
+        topic = mqtt_topic_provisioning.get_response_topic_for_subscribe()
+        assert topic == "$dps/registrations/res/#"
+
+
+@pytest.mark.describe(".get_register_topic_for_publish()")
+class TestGetRegisterTopicForPublish(object):
+    @pytest.mark.it("Returns the topic for publishing registration requests to DPS")
+    def test_returns_topic(self):
+        request_id = "3226c2f7-3d30-425c-b83b-0c34335f8220"
+        expected_topic = (
+            "$dps/registrations/PUT/iotdps-register/?$rid=3226c2f7-3d30-425c-b83b-0c34335f8220"
+        )
+        topic = mqtt_topic_provisioning.get_register_topic_for_publish(request_id)
+        assert topic == expected_topic
+
+    @pytest.mark.it("URL encodes the request id when generating the topic")
+    @pytest.mark.parametrize(
+        "request_id, expected_topic",
+        [
+            pytest.param(
+                "invalid$request?id",
+                "$dps/registrations/PUT/iotdps-register/?$rid=invalid%24request%3Fid",
+                id="Standard URL Encoding",
+            ),
+            pytest.param(
+                "invalid request id",
+                "$dps/registrations/PUT/iotdps-register/?$rid=invalid%20request%20id",
+                id="URL Encoding of ' ' character",
+            ),
+            pytest.param(
+                "invalid/request/id",
+                "$dps/registrations/PUT/iotdps-register/?$rid=invalid%2Frequest%2Fid",
+                id="URL Encoding of '/' character",
+            ),
+        ],
+    )
+    def test_url_encoding(self, request_id, expected_topic):
+        topic = mqtt_topic_provisioning.get_register_topic_for_publish(request_id)
+        assert topic == expected_topic
+
+    @pytest.mark.it("Converts the request id to string when generating the topic")
+    def test_string_conversion(self):
+        request_id = 1234
+        expected_topic = "$dps/registrations/PUT/iotdps-register/?$rid=1234"
+        topic = mqtt_topic_provisioning.get_register_topic_for_publish(request_id)
+        assert topic == expected_topic
+
+
+class TestGetStatusQueryTopicForPublish(object):
+    @pytest.mark.it("Returns the topic for publishing status query requests to DPS")
+    def test_returns_topic(self):
+        request_id = "3226c2f7-3d30-425c-b83b-0c34335f8220"
+        operation_id = "4.79f33f69d8eb3870.da2d9251-3097-43e9-b81c-782718485ce7"
+        expected_topic = "$dps/registrations/GET/iotdps-get-operationstatus/?$rid=3226c2f7-3d30-425c-b83b-0c34335f8220&operationId=4.79f33f69d8eb3870.da2d9251-3097-43e9-b81c-782718485ce7"
+        topic = mqtt_topic_provisioning.get_status_query_topic_for_publish(request_id, operation_id)
+        assert topic == expected_topic
+
+    @pytest.mark.it("URL encodes the request id and operation id when generating the topic")
+    @pytest.mark.parametrize(
+        "request_id, operation_id, expected_topic",
+        [
+            pytest.param(
+                "invalid#request?id",
+                "invalid?operation$id",
+                "$dps/registrations/GET/iotdps-get-operationstatus/?$rid=invalid%23request%3Fid&operationId=invalid%3Foperation%24id",
+                id="Standard URL Encoding",
+            ),
+            pytest.param(
+                "invalid request id",
+                "invalid operation id",
+                "$dps/registrations/GET/iotdps-get-operationstatus/?$rid=invalid%20request%20id&operationId=invalid%20operation%20id",
+                id="URL Encoding of ' ' character",
+            ),
+            pytest.param(
+                "invalid/request/id",
+                "invalid/operation/id",
+                "$dps/registrations/GET/iotdps-get-operationstatus/?$rid=invalid%2Frequest%2Fid&operationId=invalid%2Foperation%2Fid",
+                id="URL Encoding of '/' character",
+            ),
+        ],
+    )
+    def test_url_encoding(self, request_id, operation_id, expected_topic):
+        topic = mqtt_topic_provisioning.get_status_query_topic_for_publish(request_id, operation_id)
+        assert topic == expected_topic
+
+    @pytest.mark.it("Converts the request id and operation id to string when generating the topic")
+    def test_string_conversion(self):
+        request_id = 1234
+        operation_id = 4567
+        expected_topic = (
+            "$dps/registrations/GET/iotdps-get-operationstatus/?$rid=1234&operationId=4567"
+        )
+        topic = mqtt_topic_provisioning.get_status_query_topic_for_publish(request_id, operation_id)
+        assert topic == expected_topic
+
+
+@pytest.mark.describe(".extract_properties_from_response_topic()")
+class TestExtractPropertiesFromResponseTopic(object):
+    @pytest.fixture
+    def topic_base(self):
+        return "$dps/registrations/res/200/?"
+
+    @pytest.mark.it(
+        "Returns a dictionary mapping of all key/value pairs contained within the given topic string"
+    )
+    @pytest.mark.parametrize(
+        "property_string, expected_dict",
+        [
+            pytest.param("", {}, id="No properties"),
+            pytest.param(
+                "key1=value1&key2=value2&key3=value3",
+                {"key1": "value1", "key2": "value2", "key3": "value3"},
+                id="Some properties",
+            ),
+        ],
+    )
+    def test_returns_properties(self, topic_base, property_string, expected_dict):
+        topic = topic_base + property_string
+        assert (
+            mqtt_topic_provisioning.extract_properties_from_response_topic(topic) == expected_dict
+        )
+
+    @pytest.mark.it("URL decodes the key/value pairs extracted from the response topic")
+    @pytest.mark.parametrize(
+        "property_string, expected_dict",
+        [
+            pytest.param(
+                "%24.key1=value%231&%24.key2=value%232",
+                {"$.key1": "value#1", "$.key2": "value#2"},
+                id="Standard URL Decoding",
+            ),
+            pytest.param(
+                "key%201=value%201&key%202=value%202",
+                {"key 1": "value 1", "key 2": "value 2"},
+                id="URL Encoding of ' ' Character",
+            ),
+            pytest.param(
+                "key%2F1=value%2F1&key%2F2=value%2F2",
+                {"key/1": "value/1", "key/2": "value/2"},
+                id="URL Encoding of '/' Character",
+            ),
+            pytest.param(
+                "key+1=request+id",
+                {"key+1": "request+id"},
+                id="Does NOT decode '+' character",
+            ),
+        ],
+    )
+    def test_url_decode_properties(self, topic_base, property_string, expected_dict):
+        topic = topic_base + property_string
+        assert (
+            mqtt_topic_provisioning.extract_properties_from_response_topic(topic) == expected_dict
+        )
+
+    @pytest.mark.it("Supports empty string in properties")
+    @pytest.mark.parametrize(
+        "property_string, expected_dict",
+        [
+            pytest.param("=value1", {"": "value1"}, id="Empty String Key"),
+            pytest.param("key1=", {"key1": ""}, id="Empty String Value"),
+        ],
+    )
+    def test_empty_string(self, topic_base, property_string, expected_dict):
+        topic = topic_base + property_string
+        assert (
+            mqtt_topic_provisioning.extract_properties_from_response_topic(topic) == expected_dict
+        )
+
+    @pytest.mark.it(
+        "Maps the extracted key to value of empty string if there is a key with no corresponding value present"
+    )
+    def test_key_only(self, topic_base):
+        property_string = "key1&key2&key3=value"
+        expected_dict = {"key1": "", "key2": "", "key3": "value"}
+        topic = topic_base + property_string
+        assert (
+            mqtt_topic_provisioning.extract_properties_from_response_topic(topic) == expected_dict
+        )
+
+    @pytest.mark.it("Raises a ValueError if the provided topic is not DPS response topic")
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            pytest.param("not a topic", id="Not a topic"),
+            pytest.param(
+                "$iothub/twin/res/200/?$rid=d9d7ce4d-3be9-498b-abde-913b81b880e5",
+                id="Topic of wrong type",
+            ),
+            pytest.param(
+                "$dps/registrtaisons/res/200/?$rid=d9d7ce4d-3be9-498b-abde-913b81b880e5",
+                id="Malformed response topic",
+            ),
+        ],
+    )
+    def test_bad_topic(self, topic):
+        with pytest.raises(ValueError):
+            mqtt_topic_provisioning.extract_properties_from_response_topic(topic)
+
+
+@pytest.mark.describe(".extract_status_code_from_response_topic()")
+class TestExtractStatusCodeFromDpsResponseTopic(object):
+    @pytest.mark.it("Returns the status code from a DPS response topic")
+    @pytest.mark.parametrize(
+        "topic, expected_status",
+        [
+            pytest.param(
+                "$dps/registrations/res/200/?$rid=3226c2f7-3d30-425c-b83b-0c34335f8220",
+                "200",
+                id="Successful (200) response",
+            ),
+            pytest.param(
+                "$dps/registrations/res/202/?$rid=3226c2f7-3d30-425c-b83b-0c34335f8220&retry-after=3",
+                "202",
+                id="Retry-after (202) response",
+            ),
+            pytest.param(
+                "$dps/registrations/res/401/?$rid=3226c2f7-3d30-425c-b83b-0c34335f8220",
+                "401",
+                id="Unauthorized (401) response",
+            ),
+        ],
+    )
+    def test_returns_status(self, topic, expected_status):
+        assert (
+            mqtt_topic_provisioning.extract_status_code_from_response_topic(topic)
+            == expected_status
+        )
+
+    @pytest.mark.it("URL decodes the returned value")
+    @pytest.mark.parametrize(
+        "topic, expected_status",
+        [
+            pytest.param(
+                "$dps/registrations/res/%24%24%24/?$rid=3226c2f7-3d30-425c-b83b-0c34335f8220",
+                "$$$",
+                id="Standard URL decoding",
+            ),
+            pytest.param(
+                "$dps/registrations/res/invalid+status/?$rid=3226c2f7-3d30-425c-b83b-0c34335f8220",
+                "invalid+status",
+                id="Does NOT decode '+' character",
+            ),
+        ],
+    )
+    def test_url_decode(self, topic, expected_status):
+        assert (
+            mqtt_topic_provisioning.extract_status_code_from_response_topic(topic)
+            == expected_status
+        )
+
+    @pytest.mark.it("Raises a ValueError if the provided topic is not a DPS response topic")
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            pytest.param("not a topic", id="Not a topic"),
+            pytest.param(
+                "$iothub/twin/res/200/?$rid=d9d7ce4d-3be9-498b-abde-913b81b880e5",
+                id="Topic of wrong type",
+            ),
+            pytest.param(
+                "$dps/registrtaisons/res/200/?$rid=d9d7ce4d-3be9-498b-abde-913b81b880e5",
+                id="Malformed response topic",
+            ),
+        ],
+    )
+    def test_invalid_response_topic(self, topic):
+        with pytest.raises(ValueError):
+            mqtt_topic_provisioning.extract_properties_from_response_topic(topic)

--- a/v3_async_wip/v3_async_wip/mqtt_topic_iothub.py
+++ b/v3_async_wip/v3_async_wip/mqtt_topic_iothub.py
@@ -257,6 +257,8 @@ def extract_request_id_from_twin_response_topic(topic: str) -> str:
         raise ValueError("topic has incorrect format")
 
 
+# NOTE: This is duplicated from mqtt_topic_provisioning. If changing, change there too.
+# Consider putting this in a separate module at some point.
 def _extract_properties(properties_str: str) -> Dict[str, str]:
     """Return a dictionary of properties from a string in the format
     {key1}={value1}&{key2}={value2}...&{keyn}={valuen}

--- a/v3_async_wip/v3_async_wip/mqtt_topic_provisioning.py
+++ b/v3_async_wip/v3_async_wip/mqtt_topic_provisioning.py
@@ -68,7 +68,7 @@ def extract_properties_from_response_topic(topic: str) -> Dict[str, str]:
         raise ValueError("topic has incorrect format")
 
 
-def extract_status_code_from_response_topic(topic):
+def extract_status_code_from_response_topic(topic: str) -> str:
     """
     Extract the status code from the response topic
 

--- a/v3_async_wip/v3_async_wip/mqtt_topic_provisioning.py
+++ b/v3_async_wip/v3_async_wip/mqtt_topic_provisioning.py
@@ -1,0 +1,114 @@
+# --------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import logging
+import urllib.parse
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+# NOTE: Whenever using standard URL encoding via the urllib.parse.quote() API
+# make sure to specify that there are NO safe values (e.g. safe=""). By default
+# "/" is skipped in encoding, and that is not desirable.
+#
+# DO NOT use urllib.parse.quote_plus(), as it turns ' ' characters into '+',
+# which is invalid for MQTT publishes.
+#
+# DO NOT use urllib.parse.unquote_plus(), as it turns '+' characters into ' ',
+# which is also invalid.
+
+
+def get_response_topic_for_subscribe() -> str:
+    """
+    :return: The topic string used to subscribe for receiving registration responses from DPS.
+    It is of the format "$dps/registrations/res/#"
+    """
+    return "$dps/registrations/res/#"
+
+
+def get_register_topic_for_publish(request_id: str) -> str:
+    """
+    :return: The topic string used to send a registration. It is of the format
+    "$dps/registrations/PUT/iotdps-register/?$rid=<request_id>
+    """
+    return "$dps/registrations/PUT/iotdps-register/?$rid={request_id}".format(
+        request_id=urllib.parse.quote(str(request_id), safe="")
+    )
+
+
+def get_status_query_topic_for_publish(request_id: str, operation_id: str) -> str:
+    """
+    :return: The topic string used to send an operation status query. It is of the format
+    "$dps/registrations/GET/iotdps-get-operationstatus/?$rid=<request_id>&operationId=<operation_id>
+    """
+    return "$dps/registrations/GET/iotdps-get-operationstatus/?$rid={request_id}&operationId={operation_id}".format(
+        request_id=urllib.parse.quote(str(request_id), safe=""),
+        operation_id=urllib.parse.quote(str(operation_id), safe=""),
+    )
+
+
+def extract_properties_from_response_topic(topic: str) -> Dict[str, str]:
+    """Extract key/value pairs from the response topic, returning them as a dictionary.
+    If a key has no matching value, the value will be set to empty string.
+
+    Topics for responses from DPS are of the following format:
+    $dps/registrations/res/<statuscode>/?$<key1>=<value1>&<key2>=<value2>...&<keyN>=<valueN>
+
+    :param topic: The topic string
+    :return: a dictionary of property keys mapped to property values.
+    """
+    parts = topic.split("/")
+    if topic.startswith("$dps/registrations/res/") and len(parts) == 5:
+        properties_string = parts[4].split("?")[1]
+        return _extract_properties(properties_string)
+    else:
+        raise ValueError("topic has incorrect format")
+
+
+def extract_status_code_from_response_topic(topic):
+    """
+    Extract the status code from the response topic
+
+    Topics for responses from DPS are of the following format:
+    $dps/registrations/res/<statuscode>/?$<key1>=<value1>&<key2>=<value2>...&<keyN>=<valueN>
+    Extract the status code part from the topic.
+    :param topic: The topic string
+    :return: The status code from the DPS response topic, as a string
+    """
+    parts = topic.split("/")
+    if topic.startswith("$dps/registrations/res/") and len(parts) >= 4:
+        return urllib.parse.unquote(parts[3])
+    else:
+        raise ValueError("topic has incorrect format")
+
+
+# NOTE: This is duplicated from mqtt_topic_iothub. If changing, change there too.
+# Consider putting this in a separate module at some point.
+def _extract_properties(properties_str: str) -> Dict[str, str]:
+    """Return a dictionary of properties from a string in the format
+    {key1}={value1}&{key2}={value2}...&{keyn}={valuen}
+
+    For extracting values corresponding to keys the following rules are followed:-
+    If there is a just a key with no "=", the value is an empty string
+    """
+    d: Dict[str, str] = {}
+    if len(properties_str) == 0:
+        # There are no properties, return empty
+        return d
+
+    kv_pairs = properties_str.split("&")
+    for entry in kv_pairs:
+        pair = entry.split("=")
+        key = urllib.parse.unquote(pair[0])
+        if len(pair) > 1:
+            # Key/Value Pair
+            value = urllib.parse.unquote(pair[1])
+        else:
+            # Key with no value -> value = None
+            value = ""
+        d[key] = value
+
+    return d


### PR DESCRIPTION
* Ported `mqtt_topic_provisioning` and associated tests
* Added support for custom `request_id` in `request_response` module to support DPS query functionality