### PR TITLE
[V3] Allow connection loss to propagate through APIs and generators

### DIFF
--- a/v3_async_wip/tests/test_iothub_mqtt_client.py
+++ b/v3_async_wip/tests/test_iothub_mqtt_client.py
@@ -797,6 +797,7 @@ class TestIoTHubMQTTClientStop:
             # Unset the mock so that tests can clean up
             client.disconnect = original_disconnect
 
+    # TODO: when run by itself, this test leaves a task unresolved. Not sure why. Not too important.
     @pytest.mark.it(
         "Does not alter any background tasks if already stopped, but does disconnect again"
     )

--- a/v3_async_wip/tests/test_iothub_session.py
+++ b/v3_async_wip/tests/test_iothub_session.py
@@ -1,0 +1,1650 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import asyncio
+import pytest
+import ssl
+import time
+from dev_utils import custom_mock
+from pytest_lazyfixture import lazy_fixture
+from v3_async_wip.iothub_session import IoTHubSession
+from v3_async_wip import config, models, iot_exceptions
+from v3_async_wip import connection_string as cs
+from v3_async_wip import iothub_mqtt_client as mqtt
+from v3_async_wip import sastoken as st
+from v3_async_wip import signing_mechanism as sm
+
+FAKE_DEVICE_ID = "fake_device_id"
+FAKE_MODULE_ID = "fake_module_id"
+FAKE_HOSTNAME = "fake.hostname"
+FAKE_GATEWAY_HOSTNAME = "fake.gateway.hostname"
+FAKE_URI = "fake/resource/location"
+FAKE_SHARED_ACCESS_KEY = "Zm9vYmFy"
+FAKE_SIGNATURE = "ajsc8nLKacIjGsYyB4iYDFCZaRMmmDrUuY5lncYDYPI="
+
+# TODO: aenter/aexit tests
+
+# ~~~~~ Helpers ~~~~~~
+
+
+def sastoken_generator_fn():
+    return "SharedAccessSignature sr={resource}&sig={signature}&se={expiry}".format(
+        resource=FAKE_URI, signature=FAKE_SIGNATURE, expiry=str(int(time.time()) + 3600)
+    )
+
+
+def get_expected_uri(hostname, device_id, module_id):
+    if module_id:
+        return "{hostname}/devices/{device_id}/modules/{module_id}".format(
+            hostname=hostname, device_id=device_id, module_id=module_id
+        )
+    else:
+        return "{hostname}/devices/{device_id}".format(hostname=hostname, device_id=device_id)
+
+
+# ~~~~~ Fixtures ~~~~~~
+
+# Mock out the underlying client in order to not do network operations
+@pytest.fixture(autouse=True)
+def mock_mqtt_iothub_client(mocker):
+    return mocker.patch.object(mqtt, "IoTHubMQTTClient", spec=mqtt.IoTHubMQTTClient).return_value
+
+
+@pytest.fixture(autouse=True)
+def mock_sastoken_provider(mocker):
+    return mocker.patch.object(st, "SasTokenProvider", spec=st.SasTokenProvider).return_value
+
+
+@pytest.fixture
+def custom_ssl_context():
+    # NOTE: It doesn't matter how the SSLContext is configured for the tests that use this fixture,
+    # so it isn't configured at all.
+    return ssl.SSLContext()
+
+
+@pytest.fixture(params=["Default SSLContext", "Custom SSLContext"])
+def optional_ssl_context(request, custom_ssl_context):
+    """Sometimes tests need to show something works with or without an SSLContext"""
+    if request.param == "Custom SSLContext":
+        return custom_ssl_context
+    else:
+        return None
+
+
+@pytest.fixture
+def session(custom_ssl_context):
+    """Use a device configuration and custom SSL auth for simplicity"""
+    return IoTHubSession(
+        hostname=FAKE_HOSTNAME, device_id=FAKE_DEVICE_ID, ssl_context=custom_ssl_context
+    )
+
+
+# ~~~~~ Parametrizations ~~~~~
+# Define parametrizations that will be used across multiple test suites, and that may eventually
+# need to be changed everywhere, e.g. new auth scheme added.
+# Note that some parametrizations are also defined within the scope of a single test suite if that
+# is the only unit they are relevant to.
+
+
+# Parameters for arguments to the __init__ or factory methods. Represent different types of
+# authentication. Use this parametrization whenever possible on .create() tests.
+# NOTE: Do NOT combine this with the SSL fixtures above. This parametrization contains
+# ssl contexts where necessary
+create_auth_params = [
+    # Provide args in form 'shared_access_key, sastoken_fn, ssl_context'
+    pytest.param(
+        FAKE_SHARED_ACCESS_KEY, None, None, id="Shared Access Key SAS Auth + Default SSLContext"
+    ),
+    pytest.param(
+        FAKE_SHARED_ACCESS_KEY,
+        None,
+        lazy_fixture("custom_ssl_context"),
+        id="Shared Access Key SAS Auth + Custom SSLContext",
+    ),
+    pytest.param(
+        None,
+        sastoken_generator_fn,
+        None,
+        id="User-Provided SAS Token Auth + Default SSLContext",
+    ),
+    pytest.param(
+        None,
+        sastoken_generator_fn,
+        lazy_fixture("custom_ssl_context"),
+        id="User-Provided SAS Token Auth + Custom SSLContext",
+    ),
+    pytest.param(None, None, lazy_fixture("custom_ssl_context"), id="Custom SSLContext Auth"),
+]
+# Just the parameters where SAS auth is used
+create_auth_params_sas = [param for param in create_auth_params if "SAS" in param.id]
+# Just the parameters where a Shared Access Key auth is used
+create_auth_params_sak = [param for param in create_auth_params if param.values[0] is not None]
+# Just the parameters where SAS callback auth is used
+create_auth_params_token_cb = [param for param in create_auth_params if param.values[1] is not None]
+# Just the parameters where a custom SSLContext is provided
+create_auth_params_custom_ssl = [
+    param for param in create_auth_params if param.values[2] is not None
+]
+# Just the parameters where a custom SSLContext is NOT provided
+create_auth_params_default_ssl = [param for param in create_auth_params if param.values[2] is None]
+
+
+# Covers all option kwargs shared across client factory methods
+factory_kwargs = [
+    # pytest.param("auto_reconnect", False, id="auto_reconnect"),
+    pytest.param("keep_alive", 34, id="keep_alive"),
+    pytest.param("product_info", "fake-product-info", id="product_info"),
+    pytest.param(
+        "proxy_options", config.ProxyOptions("HTTP", "fake.address", 1080), id="proxy_options"
+    ),
+    pytest.param("websockets", True, id="websockets"),
+]
+
+sk_sm_create_exceptions = [
+    pytest.param(ValueError(), id="ValueError"),
+    pytest.param(lazy_fixture("arbitrary_exception"), id="Unexpected Exception"),
+]
+
+
+@pytest.mark.describe("IoTHubSession -- Instantiation")
+class TestIoTHubSessionInstantiation:
+    create_id_params = [
+        # Provide args in the form 'device_id, module_id'
+        pytest.param(FAKE_DEVICE_ID, None, id="Device"),
+        pytest.param(FAKE_DEVICE_ID, FAKE_MODULE_ID, id="Module"),
+    ]
+
+    @pytest.mark.it(
+        "Instantiates and stores a SasTokenProvider that uses symmetric key-based token generation, if `shared_access_key` is provided"
+    )
+    @pytest.mark.parametrize("shared_access_key, sastoken_fn, ssl_context", create_auth_params_sak)
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_sak_auth(
+        self, mocker, device_id, module_id, shared_access_key, sastoken_fn, ssl_context
+    ):
+        assert sastoken_fn is None
+        spy_sk_sm_cls = mocker.spy(sm, "SymmetricKeySigningMechanism")
+        spy_st_generator_cls = mocker.spy(st, "InternalSasTokenGenerator")
+        spy_st_provider_cls = mocker.spy(st, "SasTokenProvider")
+        expected_uri = get_expected_uri(FAKE_HOSTNAME, device_id, module_id)
+
+        session = IoTHubSession(
+            hostname=FAKE_HOSTNAME,
+            device_id=device_id,
+            module_id=module_id,
+            shared_access_key=shared_access_key,
+            ssl_context=ssl_context,
+        )
+
+        # SymmetricKeySigningMechanism was created from the shared access key
+        assert spy_sk_sm_cls.call_count == 1
+        assert spy_sk_sm_cls.call_args == mocker.call(shared_access_key)
+        # InternalSasTokenGenerator was created from the SymmetricKeySigningMechanism
+        assert spy_st_generator_cls.call_count == 1
+        assert spy_st_generator_cls.call_args == mocker.call(
+            signing_mechanism=spy_sk_sm_cls.spy_return, uri=expected_uri
+        )
+        # SasTokenProvider was created from the InternalSasTokenGenerator
+        assert spy_st_provider_cls.call_count == 1
+        assert spy_st_provider_cls.call_args == mocker.call(spy_st_generator_cls.spy_return)
+        # SasTokenProvider was set on the Session
+        assert session._sastoken_provider is spy_st_provider_cls.spy_return
+
+    @pytest.mark.it(
+        "Instantiates and stores a SasTokenProvider that uses callback-based token generation, if `sastoken_fn` is provided"
+    )
+    @pytest.mark.parametrize(
+        "shared_access_key, sastoken_fn, ssl_context", create_auth_params_token_cb
+    )
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_token_callback_auth(
+        self, mocker, device_id, module_id, shared_access_key, sastoken_fn, ssl_context
+    ):
+        assert shared_access_key is None
+        spy_st_generator_cls = mocker.spy(st, "ExternalSasTokenGenerator")
+        spy_st_provider_cls = mocker.spy(st, "SasTokenProvider")
+
+        session = IoTHubSession(
+            hostname=FAKE_HOSTNAME,
+            device_id=device_id,
+            module_id=module_id,
+            sastoken_fn=sastoken_fn,
+            ssl_context=ssl_context,
+        )
+
+        # ExternalSasTokenGenerator was created from the sastoken_fn
+        assert spy_st_generator_cls.call_count == 1
+        assert spy_st_generator_cls.call_args == mocker.call(sastoken_fn)
+        # SasTokenProvider was created from the ExternalSasTokenGenerator
+        assert spy_st_provider_cls.call_count == 1
+        assert spy_st_provider_cls.call_args == mocker.call(spy_st_generator_cls.spy_return)
+        # SasTokenProvider was set on the Session
+        assert session._sastoken_provider is spy_st_provider_cls.spy_return
+
+    @pytest.mark.it(
+        "Does not instantiate or store any SasTokenProvider if neither `shared_access_key` nor `sastoken_fn` are provided"
+    )
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_non_sas_auth(self, mocker, device_id, module_id, custom_ssl_context):
+        spy_st_provider_cls = mocker.spy(st, "SasTokenProvider")
+
+        session = IoTHubSession(
+            hostname=FAKE_HOSTNAME,
+            device_id=device_id,
+            module_id=module_id,
+            ssl_context=custom_ssl_context,
+        )
+
+        # No SasTokenProvider
+        assert session._sastoken_provider is None
+        assert spy_st_provider_cls.call_count == 0
+
+    @pytest.mark.it(
+        "Instantiates and stores an IoTHubMQTTClient, using a new IoTHubClientConfig object"
+    )
+    @pytest.mark.parametrize("shared_access_key, sastoken_fn, ssl_context", create_auth_params)
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_mqtt_client(
+        self, mocker, device_id, module_id, shared_access_key, sastoken_fn, ssl_context
+    ):
+        spy_config_cls = mocker.spy(config, "IoTHubClientConfig")
+        spy_mqtt_cls = mocker.spy(mqtt, "IoTHubMQTTClient")
+        assert spy_config_cls.call_count == 0
+        assert spy_mqtt_cls.call_count == 0
+
+        session = IoTHubSession(
+            hostname=FAKE_HOSTNAME,
+            device_id=device_id,
+            module_id=module_id,
+            shared_access_key=shared_access_key,
+            sastoken_fn=sastoken_fn,
+            ssl_context=ssl_context,
+        )
+
+        assert spy_config_cls.call_count == 1
+        assert spy_mqtt_cls.call_count == 1
+        assert spy_mqtt_cls.call_args == mocker.call(spy_config_cls.spy_return)
+        assert session._mqtt_client is spy_mqtt_cls.spy_return
+
+    @pytest.mark.it(
+        "Sets the provided `hostname` on the IoTHubClientConfig used to create the IoTHubMQTTClient"
+    )
+    @pytest.mark.parametrize("shared_access_key, sastoken_fn, ssl_context", create_auth_params)
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_hostname(
+        self, mocker, device_id, module_id, shared_access_key, sastoken_fn, ssl_context
+    ):
+        spy_mqtt_cls = mocker.spy(mqtt, "IoTHubMQTTClient")
+
+        IoTHubSession(
+            hostname=FAKE_HOSTNAME,
+            device_id=device_id,
+            module_id=module_id,
+            shared_access_key=shared_access_key,
+            sastoken_fn=sastoken_fn,
+            ssl_context=ssl_context,
+        )
+
+        cfg = spy_mqtt_cls.call_args[0][0]
+        assert cfg.hostname == FAKE_HOSTNAME
+
+    @pytest.mark.it(
+        "Sets the provided `device_id` and `module_id` values on the IoTHubClientConfig used to create the IoTHubMQTTClient"
+    )
+    @pytest.mark.parametrize("shared_access_key, sastoken_fn, ssl_context", create_auth_params)
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_ids(
+        self, mocker, device_id, module_id, shared_access_key, sastoken_fn, ssl_context
+    ):
+        spy_mqtt_cls = mocker.spy(mqtt, "IoTHubMQTTClient")
+
+        IoTHubSession(
+            hostname=FAKE_HOSTNAME,
+            device_id=device_id,
+            module_id=module_id,
+            shared_access_key=shared_access_key,
+            sastoken_fn=sastoken_fn,
+            ssl_context=ssl_context,
+        )
+
+        cfg = spy_mqtt_cls.call_args[0][0]
+        assert cfg.device_id == device_id
+        assert cfg.module_id == module_id
+
+    @pytest.mark.it(
+        "Sets the provided `ssl_context` on the IoTHubClientConfig used to create the IoTHubMQTTClient, if provided"
+    )
+    @pytest.mark.parametrize(
+        "shared_access_key, sastoken_fn, ssl_context", create_auth_params_custom_ssl
+    )
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_custom_ssl_context(
+        self, mocker, device_id, module_id, shared_access_key, sastoken_fn, ssl_context
+    ):
+        spy_mqtt_cls = mocker.spy(mqtt, "IoTHubMQTTClient")
+
+        IoTHubSession(
+            hostname=FAKE_HOSTNAME,
+            device_id=device_id,
+            module_id=module_id,
+            shared_access_key=shared_access_key,
+            sastoken_fn=sastoken_fn,
+            ssl_context=ssl_context,
+        )
+
+        cfg = spy_mqtt_cls.call_args[0][0]
+        assert cfg.ssl_context is ssl_context
+
+    @pytest.mark.it(
+        "Sets a default SSLContext on the IoTHubClientConfig used to create the IoTHubMQTTClient, if `ssl_context` is not provided"
+    )
+    @pytest.mark.parametrize(
+        "shared_access_key, sastoken_fn, ssl_context", create_auth_params_default_ssl
+    )
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_default_ssl_context(
+        self, mocker, device_id, module_id, shared_access_key, sastoken_fn, ssl_context
+    ):
+        assert ssl_context is None
+        spy_mqtt_cls = mocker.spy(mqtt, "IoTHubMQTTClient")
+        my_ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
+        original_ssl_ctx_cls = ssl.SSLContext
+
+        # NOTE: SSLContext is difficult to mock as an entire class, due to how it implements
+        # instantiation. Essentially, if you mock the entire class, it will not be able to
+        # instantiate due to an internal reference to the class type, which of course has now been
+        # changed to MagicMock. To get around this, we mock the class with a side effect that can
+        # check the arguments passed to the constructor, return a pre-existing SSLContext, and then
+        # unset the mock to prevent future issues.
+        def return_and_reset(*args, **kwargs):
+            ssl.SSLContext = original_ssl_ctx_cls
+            assert kwargs["protocol"] is ssl.PROTOCOL_TLS_CLIENT
+            return my_ssl_context
+
+        mocker.patch.object(ssl, "SSLContext", side_effect=return_and_reset)
+        mocker.spy(my_ssl_context, "load_default_certs")
+
+        IoTHubSession(
+            hostname=FAKE_HOSTNAME,
+            device_id=device_id,
+            module_id=module_id,
+            shared_access_key=shared_access_key,
+            sastoken_fn=sastoken_fn,
+        )
+
+        cfg = spy_mqtt_cls.call_args[0][0]
+        ctx = cfg.ssl_context
+        assert ctx is my_ssl_context
+        # NOTE: ctx protocol is checked in the `return_and_reset` side effect above
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+        assert ctx.check_hostname is True
+        assert ctx.load_default_certs.call_count == 1
+        assert ctx.load_default_certs.call_args == mocker.call()
+        assert ctx.minimum_version == ssl.TLSVersion.TLSv1_2
+
+    @pytest.mark.it(
+        "Sets the stored SasTokenProvider (if any) on the IoTHubClientConfig used to create the IoTHubMQTTClient"
+    )
+    @pytest.mark.parametrize("shared_access_key, sastoken_fn, ssl_context", create_auth_params)
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_sastoken_provider_cfg(
+        self, mocker, device_id, module_id, shared_access_key, sastoken_fn, ssl_context
+    ):
+        spy_mqtt_cls = mocker.spy(mqtt, "IoTHubMQTTClient")
+
+        session = IoTHubSession(
+            hostname=FAKE_HOSTNAME,
+            device_id=device_id,
+            module_id=module_id,
+            shared_access_key=shared_access_key,
+            sastoken_fn=sastoken_fn,
+            ssl_context=ssl_context,
+        )
+
+        cfg = spy_mqtt_cls.call_args[0][0]
+        assert cfg.sastoken_provider is session._sastoken_provider
+
+    @pytest.mark.it(
+        "Sets `auto_reconnect` to False on the IoTHubClientConfig used to create the IoTHubMQTTClient"
+    )
+    @pytest.mark.parametrize("shared_access_key, sastoken_fn, ssl_context", create_auth_params)
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_auto_reconnect_cfg(
+        self, mocker, device_id, module_id, shared_access_key, sastoken_fn, ssl_context
+    ):
+        spy_mqtt_cls = mocker.spy(mqtt, "IoTHubMQTTClient")
+
+        IoTHubSession(
+            hostname=FAKE_HOSTNAME,
+            device_id=device_id,
+            module_id=module_id,
+            shared_access_key=shared_access_key,
+            sastoken_fn=sastoken_fn,
+            ssl_context=ssl_context,
+        )
+
+        cfg = spy_mqtt_cls.call_args[0][0]
+        assert cfg.auto_reconnect is False
+
+    @pytest.mark.it(
+        "Sets any provided optional keyword arguments on the IoTHubClientConfig used to create the IoTHubMQTTClient"
+    )
+    @pytest.mark.parametrize("shared_access_key, sastoken_fn, ssl_context", create_auth_params)
+    @pytest.mark.parametrize("kwarg_name, kwarg_value", factory_kwargs)
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_kwargs(
+        self,
+        mocker,
+        device_id,
+        module_id,
+        shared_access_key,
+        sastoken_fn,
+        ssl_context,
+        kwarg_name,
+        kwarg_value,
+    ):
+        spy_mqtt_cls = mocker.spy(mqtt, "IoTHubMQTTClient")
+        kwargs = {kwarg_name: kwarg_value}
+
+        IoTHubSession(
+            hostname=FAKE_HOSTNAME,
+            device_id=device_id,
+            module_id=module_id,
+            shared_access_key=shared_access_key,
+            sastoken_fn=sastoken_fn,
+            ssl_context=ssl_context,
+            **kwargs
+        )
+
+        cfg = spy_mqtt_cls.call_args[0][0]
+        assert getattr(cfg, kwarg_name) == kwarg_value
+
+    @pytest.mark.it(
+        "Raises ValueError if neither `shared_access_key`, `sastoken_fn` nor `ssl_context` are provided as parameters"
+    )
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_no_auth(self, device_id, module_id):
+        with pytest.raises(ValueError):
+            IoTHubSession(
+                device_id=device_id,
+                module_id=module_id,
+                hostname=FAKE_HOSTNAME,
+            )
+
+    @pytest.mark.it(
+        "Raises ValueError if both `shared_access_key` and `sastoken_fn` are provided as parameters"
+    )
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_conflicting_auth(self, device_id, module_id, optional_ssl_context):
+        with pytest.raises(ValueError):
+            IoTHubSession(
+                hostname=FAKE_HOSTNAME,
+                device_id=device_id,
+                module_id=module_id,
+                shared_access_key=FAKE_SHARED_ACCESS_KEY,
+                sastoken_fn=sastoken_generator_fn,
+                ssl_context=optional_ssl_context,
+            )
+
+    @pytest.mark.it("Raises TypeError if an invalid keyword argument is provided")
+    @pytest.mark.parametrize("shared_access_key, sastoken_fn, ssl_context", create_auth_params)
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_bad_kwarg(
+        self, device_id, module_id, shared_access_key, sastoken_fn, ssl_context
+    ):
+        with pytest.raises(TypeError):
+            IoTHubSession(
+                hostname=FAKE_HOSTNAME,
+                device_id=device_id,
+                module_id=module_id,
+                shared_access_key=shared_access_key,
+                sastoken_fn=sastoken_fn,
+                ssl_context=ssl_context,
+                invalid_argument="some value",
+            )
+
+    @pytest.mark.it(
+        "Allows any exceptions raised when creating a SymmetricKeySigningMechanism to propagate"
+    )
+    @pytest.mark.parametrize("exception", sk_sm_create_exceptions)
+    @pytest.mark.parametrize("shared_access_key, sastoken_fn, ssl_context", create_auth_params_sak)
+    @pytest.mark.parametrize("device_id, module_id", create_id_params)
+    async def test_sksm_raises(
+        self, mocker, device_id, module_id, shared_access_key, sastoken_fn, ssl_context, exception
+    ):
+        mocker.patch.object(sm, "SymmetricKeySigningMechanism", side_effect=exception)
+        assert sastoken_fn is None
+
+        with pytest.raises(type(exception)) as e_info:
+            IoTHubSession(
+                hostname=FAKE_HOSTNAME,
+                device_id=device_id,
+                module_id=module_id,
+                shared_access_key=shared_access_key,
+                sastoken_fn=sastoken_fn,
+                ssl_context=ssl_context,
+            )
+        assert e_info.value is exception
+
+
+@pytest.mark.describe("IoTHubSession - .from_connection_string")
+class TestIoTHubSessionFromConnectionString:
+    factory_params = [
+        # TODO: once Edge support is decided upon, either re-enable, or remove the commented Edge parameters
+        # TODO: Do we want gateway hostname tests that are non-Edge? probably?
+        pytest.param(
+            "HostName={hostname};DeviceId={device_id};SharedAccessKey={shared_access_key}".format(
+                hostname=FAKE_HOSTNAME,
+                device_id=FAKE_DEVICE_ID,
+                shared_access_key=FAKE_SHARED_ACCESS_KEY,
+            ),
+            None,
+            id="Standard Device Connection String w/ SharedAccessKey + Default SSLContext",
+        ),
+        pytest.param(
+            "HostName={hostname};DeviceId={device_id};SharedAccessKey={shared_access_key}".format(
+                hostname=FAKE_HOSTNAME,
+                device_id=FAKE_DEVICE_ID,
+                shared_access_key=FAKE_SHARED_ACCESS_KEY,
+            ),
+            lazy_fixture("custom_ssl_context"),
+            id="Standard Device Connection String w/ SharedAccessKey + Custom SSLContext",
+        ),
+        # pytest.param(
+        #     "HostName={hostname};DeviceId={device_id};SharedAccessKey={shared_access_key};GatewayHostName={gateway_hostname}".format(
+        #         hostname=FAKE_HOSTNAME,
+        #         device_id=FAKE_DEVICE_ID,
+        #         shared_access_key=FAKE_SHARED_ACCESS_KEY,
+        #         gateway_hostname=FAKE_GATEWAY_HOSTNAME,
+        #     ),
+        #     None,
+        #     id="Edge Device Connection String w/ SharedAccessKey + Default SSLContext",
+        # ),
+        # pytest.param(
+        #     "HostName={hostname};DeviceId={device_id};SharedAccessKey={shared_access_key};GatewayHostName={gateway_hostname}".format(
+        #         hostname=FAKE_HOSTNAME,
+        #         device_id=FAKE_DEVICE_ID,
+        #         shared_access_key=FAKE_SHARED_ACCESS_KEY,
+        #         gateway_hostname=FAKE_GATEWAY_HOSTNAME,
+        #     ),
+        #     lazy_fixture("custom_ssl_context"),
+        #     id="Edge Device Connection String w/ SharedAccessKey + Custom SSLContext",
+        # ),
+        # NOTE: X509 certs imply use of custom SSLContext
+        pytest.param(
+            "HostName={hostname};DeviceId={device_id};x509=true".format(
+                hostname=FAKE_HOSTNAME,
+                device_id=FAKE_DEVICE_ID,
+            ),
+            lazy_fixture("custom_ssl_context"),
+            id="Standard Device Connection String w/ X509",
+        ),
+        # pytest.param(
+        #     "HostName={hostname};DeviceId={device_id};GatewayHostName={gateway_hostname};x509=true".format(
+        #         hostname=FAKE_HOSTNAME,
+        #         device_id=FAKE_DEVICE_ID,
+        #         gateway_hostname=FAKE_GATEWAY_HOSTNAME,
+        #     ),
+        #     lazy_fixture("custom_ssl_context"),
+        #     id="Edge Device Connection String w/ X509",
+        # ),
+        pytest.param(
+            "HostName={hostname};DeviceId={device_id};ModuleId={module_id};SharedAccessKey={shared_access_key}".format(
+                hostname=FAKE_HOSTNAME,
+                device_id=FAKE_DEVICE_ID,
+                module_id=FAKE_MODULE_ID,
+                shared_access_key=FAKE_SHARED_ACCESS_KEY,
+            ),
+            None,
+            id="Standard Module Connection String w/ SharedAccessKey + Default SSLContext",
+        ),
+        pytest.param(
+            "HostName={hostname};DeviceId={device_id};ModuleId={module_id};SharedAccessKey={shared_access_key}".format(
+                hostname=FAKE_HOSTNAME,
+                device_id=FAKE_DEVICE_ID,
+                module_id=FAKE_MODULE_ID,
+                shared_access_key=FAKE_SHARED_ACCESS_KEY,
+            ),
+            lazy_fixture("custom_ssl_context"),
+            id="Standard Module Connection String w/ SharedAccessKey + Custom SSLContext",
+        ),
+        # pytest.param(
+        #     "HostName={hostname};DeviceId={device_id};ModuleId={module_id};SharedAccessKey={shared_access_key};GatewayHostName={gateway_hostname}".format(
+        #         hostname=FAKE_HOSTNAME,
+        #         device_id=FAKE_DEVICE_ID,
+        #         module_id=FAKE_MODULE_ID,
+        #         shared_access_key=FAKE_SHARED_ACCESS_KEY,
+        #         gateway_hostname=FAKE_GATEWAY_HOSTNAME,
+        #     ),
+        #     None,
+        #     id="Edge Module Connection String w/ SharedAccessKey + Default SSLContext",
+        # ),
+        # pytest.param(
+        #     "HostName={hostname};DeviceId={device_id};ModuleId={module_id};SharedAccessKey={shared_access_key};GatewayHostName={gateway_hostname}".format(
+        #         hostname=FAKE_HOSTNAME,
+        #         device_id=FAKE_DEVICE_ID,
+        #         module_id=FAKE_MODULE_ID,
+        #         shared_access_key=FAKE_SHARED_ACCESS_KEY,
+        #         gateway_hostname=FAKE_GATEWAY_HOSTNAME,
+        #     ),
+        #     lazy_fixture("custom_ssl_context"),
+        #     id="Edge Module Connection String w/ SharedAccessKey + Custom SSLContext",
+        # ),
+        # NOTE: X509 certs imply use of custom SSLContext
+        pytest.param(
+            "HostName={hostname};DeviceId={device_id};ModuleId={module_id};x509=true".format(
+                hostname=FAKE_HOSTNAME,
+                device_id=FAKE_DEVICE_ID,
+                module_id=FAKE_MODULE_ID,
+            ),
+            lazy_fixture("custom_ssl_context"),
+            id="Standard Module Connection String w/ X509",
+        ),
+        # pytest.param(
+        #     "HostName={hostname};DeviceId={device_id};ModuleId={module_id};GatewayHostName={gateway_hostname};x509=true".format(
+        #         hostname=FAKE_HOSTNAME,
+        #         device_id=FAKE_DEVICE_ID,
+        #         module_id=FAKE_MODULE_ID,
+        #         gateway_hostname=FAKE_GATEWAY_HOSTNAME,
+        #     ),
+        #     lazy_fixture("custom_ssl_context"),
+        #     id="Edge Module Connection String w/ X509",
+        # ),
+    ]
+    # Just the parameters for using standard connection strings
+    factory_params_no_gateway = [
+        param for param in factory_params if cs.GATEWAY_HOST_NAME not in param.values[0]
+    ]
+    # Just the parameters for using connection strings with a GatewayHostName
+    factory_params_gateway = [
+        param for param in factory_params if cs.GATEWAY_HOST_NAME in param.values[0]
+    ]
+    # # Just the parameters where a custom SSLContext is provided
+    # factory_params_custom_ssl = [param for param in factory_params if param.values[1] is not None]
+    # # Just the parameters where a custom SSLContext is NOT provided
+    # factory_params_default_ssl = [param for param in factory_params if param.values[1] is None]
+    # # Just the parameters for using SharedAccessKeys
+    # factory_params_sak = [
+    #     param for param in factory_params if cs.SHARED_ACCESS_KEY in param.values[0]
+    # ]
+    # Just the parameters for NOT using SharedAccessKeys
+    factory_params_no_sak = [
+        param for param in factory_params if cs.SHARED_ACCESS_KEY not in param.values[0]
+    ]
+
+    @pytest.mark.it("Returns a new IoTHubSession instance")
+    @pytest.mark.parametrize("connection_string, ssl_context", factory_params)
+    async def test_instantiation(self, connection_string, ssl_context):
+        session = IoTHubSession.from_connection_string(connection_string, ssl_context)
+        assert isinstance(session, IoTHubSession)
+
+    @pytest.mark.it(
+        "Extracts the `DeviceId`, `ModuleId` and `SharedAccessKey` values from the connection string (if present), passing them to the IoTHubSession initializer"
+    )
+    @pytest.mark.parametrize("connection_string, ssl_context", factory_params)
+    async def test_extracts_values(self, mocker, connection_string, ssl_context):
+        spy_session_init = mocker.spy(IoTHubSession, "__init__")
+        cs_obj = cs.ConnectionString(connection_string)
+
+        IoTHubSession.from_connection_string(connection_string, ssl_context)
+
+        assert spy_session_init.call_count == 1
+        assert spy_session_init.call_args[1]["device_id"] == cs_obj[cs.DEVICE_ID]
+        assert spy_session_init.call_args[1]["module_id"] == cs_obj.get(cs.MODULE_ID)
+        assert spy_session_init.call_args[1]["shared_access_key"] == cs_obj.get(
+            cs.SHARED_ACCESS_KEY
+        )
+
+    @pytest.mark.it(
+        "Extracts the `HostName` value from the connection string and passes it to the IoTHubSession initializer as the `hostname`, if no `GatewayHostName` value is present in the connection string"
+    )
+    @pytest.mark.parametrize("connection_string, ssl_context", factory_params_no_gateway)
+    async def test_hostname(self, mocker, connection_string, ssl_context):
+        spy_session_init = mocker.spy(IoTHubSession, "__init__")
+        cs_obj = cs.ConnectionString(connection_string)
+
+        IoTHubSession.from_connection_string(connection_string, ssl_context)
+
+        assert spy_session_init.call_count == 1
+        assert spy_session_init.call_args[1]["hostname"] == cs_obj[cs.HOST_NAME]
+
+    # TODO: This test is currently being skipped because test data does not include such values
+    # Get clarity on how we want to handle Edge, and then clear this up.
+    @pytest.mark.it(
+        "Extracts the `GatewayHostName` value from the connection string and passes it to the IoTHubSession initializer as the `hostname`, if present in the connection string"
+    )
+    @pytest.mark.parametrize("connection_string, ssl_context", factory_params_gateway)
+    async def test_gateway_hostname(self, mocker, connection_string, ssl_context):
+        spy_session_init = mocker.spy(IoTHubSession, "__init__")
+        cs_obj = cs.ConnectionString(connection_string)
+        assert cs_obj[cs.GATEWAY_HOST_NAME] != cs_obj[cs.HOST_NAME]
+
+        IoTHubSession.from_connection_string(connection_string, ssl_context)
+
+        assert spy_session_init.call_count == 1
+        assert spy_session_init.call_args[1]["hostname"] == cs_obj[cs.GATEWAY_HOST_NAME]
+
+    @pytest.mark.it("Passes any provided `ssl_context` to the IoTHubSession initializer")
+    @pytest.mark.parametrize("connection_string, ssl_context", factory_params)
+    async def test_ssl_context(self, mocker, connection_string, ssl_context):
+        spy_session_init = mocker.spy(IoTHubSession, "__init__")
+
+        IoTHubSession.from_connection_string(connection_string, ssl_context)
+
+        assert spy_session_init.call_count == 1
+        assert spy_session_init.call_args[1]["ssl_context"] is ssl_context
+
+    @pytest.mark.it(
+        "Passes any provided optional keyword arguments to the IoTHubSession initializer"
+    )
+    @pytest.mark.parametrize("connection_string, ssl_context", factory_params)
+    @pytest.mark.parametrize("kwarg_name, kwarg_value", factory_kwargs)
+    async def test_kwargs(self, mocker, connection_string, ssl_context, kwarg_name, kwarg_value):
+        spy_session_init = mocker.spy(IoTHubSession, "__init__")
+        kwargs = {kwarg_name: kwarg_value}
+
+        IoTHubSession.from_connection_string(connection_string, ssl_context, **kwargs)
+
+        assert spy_session_init.call_count == 1
+        assert spy_session_init.call_args[1][kwarg_name] == kwarg_value
+
+    @pytest.mark.it(
+        "Raises ValueError if `x509=true` is present in the connection string, but no `ssl_context` is provided"
+    )
+    @pytest.mark.parametrize("connection_string, ssl_context", factory_params_no_sak)
+    async def test_x509_true_no_ssl(self, connection_string, ssl_context):
+        # Ignore the ssl_context provided by the parametrization
+        with pytest.raises(ValueError):
+            IoTHubSession.from_connection_string(connection_string)
+
+    @pytest.mark.it(
+        "Does not raise a ValueError if `x509=false` is present in the connection string and no `ssl_context` is provided"
+    )
+    async def test_x509_equals_false(self):
+        # NOTE: This is a weird test in that if you aren't using X509 certs, there shouldn't be
+        # an `x509` field in your connection string in the first place. But, semantically, it feels
+        # as though this test ought to exist to validate that we are checking the value of the
+        # field, not just the key name.
+        # NOTE: Because we're in the land of undefined behavior here, on account of this scenario
+        # not being supposed to happen, I'm arbitrarily deciding we're testing this with a string
+        # containing a SharedAccessKey and no GatewayHostName for simplicity.
+        connection_string = "HostName={hostname};DeviceId={device_id};ModuleId={module_id};SharedAccessKey={shared_access_key};x509=false".format(
+            hostname=FAKE_HOSTNAME,
+            device_id=FAKE_DEVICE_ID,
+            module_id=FAKE_MODULE_ID,
+            shared_access_key=FAKE_SHARED_ACCESS_KEY,
+        )
+        IoTHubSession.from_connection_string(connection_string)
+        # If the above invocation didn't raise, the test passed, no assertions required
+
+    @pytest.mark.it("Raises TypeError if an invalid keyword argument is provided")
+    @pytest.mark.parametrize("connection_string, ssl_context", factory_params)
+    async def test_bad_kwarg(self, connection_string, ssl_context):
+        with pytest.raises(TypeError):
+            IoTHubSession.from_connection_string(
+                connection_string, ssl_context, invalid_argument="some_value"
+            )
+
+    @pytest.mark.it("Allows any exceptions raised while parsing the connection string to propagate")
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(ValueError(), id="ValueError"),
+            pytest.param(lazy_fixture("arbitrary_exception"), id="Unexpected Exception"),
+        ],
+    )
+    async def test_cs_parsing_raises(self, mocker, optional_ssl_context, exception):
+        # NOTE: This test covers all invalid connection string scenarios. For more detail, see the
+        # dedicated connection string parsing tests for the `connection_string.py` module - there's
+        # no reason to replicate them all here.
+        # NOTE: For the purposes of this test, it does not matter what this connection string is.
+        # The one provided here is valid, but the mock will cause the parsing to raise anyway.
+        connection_string = "HostName={hostname};DeviceId={device_id};ModuleId={module_id};SharedAccessKey={shared_access_key}".format(
+            hostname=FAKE_HOSTNAME,
+            device_id=FAKE_DEVICE_ID,
+            module_id=FAKE_MODULE_ID,
+            shared_access_key=FAKE_SHARED_ACCESS_KEY,
+        )
+        # Mock cs parsing
+        mocker.patch.object(cs, "ConnectionString", side_effect=exception)
+
+        with pytest.raises(type(exception)) as e_info:
+            IoTHubSession.from_connection_string(
+                connection_string, ssl_context=optional_ssl_context
+            )
+        assert e_info.value is exception
+
+    @pytest.mark.it("Allows any exceptions raised by the initializer to propagate")
+    @pytest.mark.parametrize("connection_string, ssl_context", factory_params)
+    async def test_init_raises(self, mocker, connection_string, ssl_context, arbitrary_exception):
+        # NOTE: for an in-depth look at what possible exceptions could be raised,
+        # see the TestIoTHubSessionInstantiation suite. To prevent duplication,
+        # we will simply use an arbitrary exception here
+        mocker.patch.object(IoTHubSession, "__init__", side_effect=arbitrary_exception)
+
+        with pytest.raises(type(arbitrary_exception)) as e_info:
+            IoTHubSession.from_connection_string(connection_string, ssl_context)
+        assert e_info.value is arbitrary_exception
+
+
+@pytest.mark.describe("IoTHubSession -- Context Manager Usage")
+class TestIoTHubSessionContextManager:
+    @pytest.mark.it(
+        "Starts the IoTHubMQTTClient upon entry into the context manager, and stops it upon exit"
+    )
+    async def test_mqtt_client_start_stop(self, session):
+        assert session._mqtt_client.start.await_count == 0
+        assert session._mqtt_client.stop.await_count == 0
+
+        async with session as session:
+            assert session._mqtt_client.start.await_count == 1
+            assert session._mqtt_client.stop.await_count == 0
+
+        assert session._mqtt_client.start.await_count == 1
+        assert session._mqtt_client.stop.await_count == 1
+
+    @pytest.mark.it(
+        "Stops the IoTHubMQTTClient upon exit, even if an error was raised within the block inside the context manager"
+    )
+    async def test_mqtt_client_start_stop_with_failure(self, session, arbitrary_exception):
+        assert session._mqtt_client.start.await_count == 0
+        assert session._mqtt_client.stop.await_count == 0
+
+        try:
+            async with session as session:
+                assert session._mqtt_client.start.await_count == 1
+                assert session._mqtt_client.stop.await_count == 0
+                raise arbitrary_exception
+        except type(arbitrary_exception):
+            pass
+
+        assert session._mqtt_client.start.await_count == 1
+        assert session._mqtt_client.stop.await_count == 1
+
+    @pytest.mark.it(
+        "Connect the IoTHubMQTTClient upon entry into the context manager, and disconnect it upon exit"
+    )
+    async def test_mqtt_client_connection(self, session):
+        assert session._mqtt_client.connect.await_count == 0
+        assert session._mqtt_client.disconnect.await_count == 0
+
+        async with session as session:
+            assert session._mqtt_client.connect.await_count == 1
+            assert session._mqtt_client.disconnect.await_count == 0
+
+        assert session._mqtt_client.connect.await_count == 1
+        assert session._mqtt_client.disconnect.await_count == 1
+
+    @pytest.mark.it(
+        "Disconnect the IoTHubMQTTClient upon exit, even if an error was raised within the block inside the context manager"
+    )
+    async def test_mqtt_client_connection_with_failure(self, session, arbitrary_exception):
+        assert session._mqtt_client.connect.await_count == 0
+        assert session._mqtt_client.disconnect.await_count == 0
+
+        try:
+            async with session as session:
+                assert session._mqtt_client.connect.await_count == 1
+                assert session._mqtt_client.disconnect.await_count == 0
+                raise arbitrary_exception
+        except type(arbitrary_exception):
+            pass
+
+        assert session._mqtt_client.connect.await_count == 1
+        assert session._mqtt_client.disconnect.await_count == 1
+
+    @pytest.mark.it(
+        "Starts the SasTokenProvider upon entry into the context manager, and stops it upon exit, if one exists"
+    )
+    async def test_sastoken_provider_start_stop(self, session, mock_sastoken_provider):
+        session._sastoken_provider = mock_sastoken_provider
+        assert session._sastoken_provider.start.await_count == 0
+        assert session._sastoken_provider.stop.await_count == 0
+
+        async with session as session:
+            assert session._sastoken_provider.start.await_count == 1
+            assert session._sastoken_provider.stop.await_count == 0
+
+        assert session._sastoken_provider.start.await_count == 1
+        assert session._sastoken_provider.stop.await_count == 1
+
+    @pytest.mark.it(
+        "Stops the SasTokenProvider upon exit, even if an error was raised within the block inside the context manager"
+    )
+    async def test_sastoken_provider_start_stop_with_failure(
+        self, session, mock_sastoken_provider, arbitrary_exception
+    ):
+        session._sastoken_provider = mock_sastoken_provider
+        assert session._sastoken_provider.start.await_count == 0
+        assert session._sastoken_provider.stop.await_count == 0
+
+        try:
+            async with session as session:
+                assert session._sastoken_provider.start.await_count == 1
+                assert session._sastoken_provider.stop.await_count == 0
+                raise arbitrary_exception
+        except type(arbitrary_exception):
+            pass
+
+        assert session._sastoken_provider.start.await_count == 1
+        assert session._sastoken_provider.stop.await_count == 1
+
+    @pytest.mark.it("Can handle the case where SasTokenProvider does not exist")
+    async def test_no_sastoken_provider(self, session):
+        assert session._sastoken_provider is None
+
+        async with session as session:
+            pass
+
+        # If nothing raises here, the test passes
+
+    @pytest.mark.it(
+        "Allows any errors raised within the block inside the context manager to propagate"
+    )
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(lazy_fixture("arbitrary_exception"), id="Unexpected Exception"),
+            # NOTE: it is important to test the CancelledError since it is a regular Exception in 3.7,
+            # but a BaseException from 3.8+
+            pytest.param(asyncio.CancelledError(), id="CancelledError"),
+        ],
+    )
+    async def test_error_propagation(self, session, exception):
+        with pytest.raises(type(exception)) as e_info:
+            async with session as session:
+                raise exception
+        assert e_info.value is exception
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Allows any errors raised while starting the SasTokenProvider during context manager entry to propagate"
+    )
+    async def test_enter_sastoken_provider_start_raises(
+        self, session, mock_sastoken_provider, arbitrary_exception
+    ):
+        session._sastoken_provider = mock_sastoken_provider
+        session._sastoken_provider.start.side_effect = arbitrary_exception
+
+        with pytest.raises(type(arbitrary_exception)) as e_info:
+            async with session as session:
+                pass
+        assert e_info.value is arbitrary_exception
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Does not start or connect the IoTHubMQTTClient if an error is raised while starting the SasTokenProvider during context manager entry"
+    )
+    async def test_enter_sastoken_provider_start_raises_cleanup(
+        self, session, mock_sastoken_provider, arbitrary_exception
+    ):
+        session._sastoken_provider = mock_sastoken_provider
+        session._sastoken_provider.start.side_effect = arbitrary_exception
+        assert session._sastoken_provider.start.await_count == 0
+        assert session._mqtt_client.start.await_count == 0
+        assert session._mqtt_client.connect.await_count == 0
+
+        with pytest.raises(type(arbitrary_exception)) as e_info:
+            async with session as session:
+                pass
+        assert e_info.value is arbitrary_exception
+
+        assert session._sastoken_provider.start.await_count == 1
+        assert session._mqtt_client.start.await_count == 0
+        assert session._mqtt_client.connect.await_count == 0
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Allows any errors raised while starting the IoTHubMQTTClient during context manager entry to propagate"
+    )
+    async def test_enter_mqtt_client_start_raises(self, session, arbitrary_exception):
+        session._mqtt_client.start.side_effect = arbitrary_exception
+
+        with pytest.raises(type(arbitrary_exception)) as e_info:
+            async with session as session:
+                pass
+        assert e_info.value is arbitrary_exception
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Stops the IoTHubMQTTClient and SasTokenProvider (if present) that were previously started, if an error is raised while starting the IoTHubMQTTClient during context manager entry"
+    )
+    @pytest.mark.parametrize(
+        "sastoken_provider",
+        [
+            pytest.param(lazy_fixture("mock_sastoken_provider"), id="SasTokenProvider present"),
+            pytest.param(None, id="SasTokenProvider not present"),
+        ],
+    )
+    async def test_enter_mqtt_client_start_raises_cleanup(
+        self, session, sastoken_provider, arbitrary_exception
+    ):
+        session._sastoken_provider = sastoken_provider
+        session._mqtt_client.start.side_effect = arbitrary_exception
+        assert session._mqtt_client.stop.await_count == 0
+        if session._sastoken_provider:
+            assert session._sastoken_provider.stop.await_count == 0
+
+        with pytest.raises(type(arbitrary_exception)):
+            async with session as session:
+                pass
+
+        assert session._mqtt_client.stop.await_count == 1
+        if session._sastoken_provider:
+            assert session._sastoken_provider.stop.await_count == 1
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Stops the SasTokenProvider (if present) even if an error was raised while stopping the IoTHubMQTTClient in response to an error raised while starting the IoTHubMQTTClient during context manager entry"
+    )
+    @pytest.mark.parametrize(
+        "sastoken_provider",
+        [
+            pytest.param(lazy_fixture("mock_sastoken_provider"), id="SasTokenProvider present"),
+            pytest.param(None, id="SasTokenProvider not present"),
+        ],
+    )
+    async def test_enter_mqtt_client_start_raises_then_mqtt_client_stop_raises(
+        self, session, sastoken_provider, arbitrary_exception
+    ):
+        session._sastoken_provider = sastoken_provider
+        session._mqtt_client.start.side_effect = arbitrary_exception
+        session._mqtt_client.stop.side_effect = arbitrary_exception
+        assert session._mqtt_client.stop.await_count == 0
+        if session._sastoken_provider:
+            assert session._sastoken_provider.stop.await_count == 0
+
+        with pytest.raises(type(arbitrary_exception)):
+            async with session as session:
+                pass
+
+        assert session._mqtt_client.stop.await_count == 1
+        if session._sastoken_provider:
+            assert session._sastoken_provider.stop.await_count == 1
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Stops the IoTHubMQTTClient even if an error was raised while stopping the SasTokenProvider in response to an error raised while starting the IoTHubMQTTClient during context manager entry"
+    )
+    async def test_enter_mqtt_client_start_raises_then_sastoken_provider_stop_raises(
+        self, session, mock_sastoken_provider, arbitrary_exception
+    ):
+        session._sastoken_provider = mock_sastoken_provider
+        session._mqtt_client.start.side_effect = arbitrary_exception
+        session._sastoken_provider.stop.side_effect = arbitrary_exception
+        assert session._mqtt_client.stop.await_count == 0
+        assert session._sastoken_provider.stop.await_count == 0
+
+        with pytest.raises(type(arbitrary_exception)):
+            async with session as session:
+                pass
+
+        assert session._mqtt_client.stop.await_count == 1
+        assert session._sastoken_provider.stop.await_count == 1
+
+    @pytest.mark.it(
+        "Allows any errors raised while connecting with the IoTHubMQTTClient during context manager entry to propagate"
+    )
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(mqtt.MQTTConnectionFailedError(), id="MQTTConnectionFailedError"),
+            pytest.param(lazy_fixture("arbitrary_exception"), id="Unexpected Exception"),
+        ],
+    )
+    async def test_enter_mqtt_client_connect_raises(self, session, exception):
+        session._mqtt_client.connect.side_effect = exception
+
+        with pytest.raises(type(exception)) as e_info:
+            async with session as session:
+                pass
+        assert e_info.value is exception
+
+    @pytest.mark.it(
+        "Stops the IoTHubMQTTClient and SasTokenProvider (if present) that were previously started, if an error is raised while connecting during context manager entry"
+    )
+    @pytest.mark.parametrize(
+        "sastoken_provider",
+        [
+            pytest.param(lazy_fixture("mock_sastoken_provider"), id="SasTokenProvider present"),
+            pytest.param(None, id="SasTokenProvider not present"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(mqtt.MQTTConnectionFailedError(), id="MQTTConnectionFailedError"),
+            pytest.param(lazy_fixture("arbitrary_exception"), id="Unexpected Exception"),
+        ],
+    )
+    async def test_enter_mqtt_client_connect_raises_cleanup(
+        self, session, sastoken_provider, exception
+    ):
+        session._sastoken_provider = sastoken_provider
+        session._mqtt_client.connect.side_effect = exception
+        assert session._mqtt_client.stop.await_count == 0
+        if session._sastoken_provider:
+            assert session._sastoken_provider.stop.await_count == 0
+
+        with pytest.raises(type(exception)):
+            async with session as session:
+                pass
+
+        assert session._mqtt_client.stop.await_count == 1
+        if session._sastoken_provider:
+            assert session._sastoken_provider.stop.await_count == 1
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Stops the SasTokenProvider (if present) even if an error was raised while stopping the IoTHubMQTTClient in response to an error raised while connecting the IoTHubMQTTClient during context manager entry"
+    )
+    @pytest.mark.parametrize(
+        "sastoken_provider",
+        [
+            pytest.param(lazy_fixture("mock_sastoken_provider"), id="SasTokenProvider present"),
+            pytest.param(None, id="SasTokenProvider not present"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(mqtt.MQTTConnectionFailedError(), id="MQTTConnectionFailedError"),
+            pytest.param(lazy_fixture("arbitrary_exception"), id="Unexpected Exception"),
+        ],
+    )
+    async def test_enter_mqtt_client_connect_raises_then_mqtt_client_stop_raises(
+        self, session, sastoken_provider, exception, arbitrary_exception
+    ):
+        session._sastoken_provider = sastoken_provider
+        session._mqtt_client.connect.side_effect = exception  # Realistic failure
+        session._mqtt_client.stop.side_effect = arbitrary_exception  # Shouldn't happen
+        assert session._mqtt_client.stop.await_count == 0
+        if session._sastoken_provider:
+            assert session._sastoken_provider.stop.await_count == 0
+
+        # NOTE: arbitrary_exception is raised here instead of exception - this is because it
+        # happened second, during resolution of exception, thus taking precedence
+        with pytest.raises(type(arbitrary_exception)):
+            async with session as session:
+                pass
+
+        assert session._mqtt_client.stop.await_count == 1
+        if session._sastoken_provider:
+            assert session._sastoken_provider.stop.await_count == 1
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Stops the IoTHubMQTTClient even if an error was raised while stopping the SasTokenProvider in response to an error raised while connecting the IoTHubMQTTClient during context manager entry"
+    )
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(mqtt.MQTTConnectionFailedError(), id="MQTTConnectionFailedError"),
+            pytest.param(lazy_fixture("arbitrary_exception"), id="Unexpected Exception"),
+        ],
+    )
+    async def test_enter_mqtt_client_connect_raises_then_sastoken_provider_stop_raises(
+        self, session, mock_sastoken_provider, exception, arbitrary_exception
+    ):
+        session._sastoken_provider = mock_sastoken_provider
+        session._mqtt_client.connect.side_effect = exception  # Realistic failure
+        session._sastoken_provider.stop.side_effect = arbitrary_exception  # Shouldn't happen
+        assert session._mqtt_client.stop.await_count == 0
+        assert session._sastoken_provider.stop.await_count == 0
+
+        # NOTE: arbitrary_exception is raised here instead of exception - this is because it
+        # happened second, during resolution of exception, thus taking precedence
+        with pytest.raises(type(arbitrary_exception)):
+            async with session as session:
+                pass
+
+        assert session._mqtt_client.stop.await_count == 1
+        assert session._sastoken_provider.stop.await_count == 1
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Allows any errors raised while disconnecting the IoTHubMQTTClient during context manager exit to propagate"
+    )
+    async def test_exit_disconnect_raises(self, session, arbitrary_exception):
+        session._mqtt_client.disconnect.side_effect = arbitrary_exception
+
+        with pytest.raises(type(arbitrary_exception)) as e_info:
+            async with session as session:
+                pass
+        assert e_info.value is arbitrary_exception
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Stops the IoTHubMQTTClient and SasTokenProvider (if present), even if an error was raised while disconnecting the IoTHubMQTTClient during context manager exit"
+    )
+    @pytest.mark.parametrize(
+        "sastoken_provider",
+        [
+            pytest.param(lazy_fixture("mock_sastoken_provider"), id="SasTokenProvider present"),
+            pytest.param(None, id="SasTokenProvider not present"),
+        ],
+    )
+    async def test_exit_disconnect_raises_cleanup(
+        self, session, sastoken_provider, arbitrary_exception
+    ):
+        session._sastoken_provider = sastoken_provider
+        session._mqtt_client.disconnect.side_effect = arbitrary_exception
+        assert session._mqtt_client.stop.await_count == 0
+        if session._sastoken_provider:
+            assert session._sastoken_provider.stop.await_count == 0
+
+        with pytest.raises(type(arbitrary_exception)):
+            async with session as session:
+                pass
+
+        assert session._mqtt_client.stop.await_count == 1
+        if session._sastoken_provider:
+            assert session._sastoken_provider.stop.await_count == 1
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Allows any errors raised while stopping the IoTHubMQTTClient during context manager exit to propagate"
+    )
+    async def test_exit_mqtt_client_stop_raises(self, session, arbitrary_exception):
+        session._mqtt_client.stop.side_effect = arbitrary_exception
+
+        with pytest.raises(type(arbitrary_exception)) as e_info:
+            async with session as session:
+                pass
+        assert e_info.value is arbitrary_exception
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Disconnects the IoTHubMQTTClient and stops the SasTokenProvider (if present), even if an error was raised while stopping the IoTHubMQTTClient during context manager exit"
+    )
+    @pytest.mark.parametrize(
+        "sastoken_provider",
+        [
+            pytest.param(lazy_fixture("mock_sastoken_provider"), id="SasTokenProvider present"),
+            pytest.param(None, id="SasTokenProvider not present"),
+        ],
+    )
+    async def test_exit_mqtt_client_stop_raises_cleanup(
+        self, session, sastoken_provider, arbitrary_exception
+    ):
+        session._sastoken_provider = sastoken_provider
+        session._mqtt_client.stop.side_effect = arbitrary_exception
+        assert session._mqtt_client.disconnect.await_count == 0
+        if session._sastoken_provider:
+            assert session._sastoken_provider.stop.await_count == 0
+
+        with pytest.raises(type(arbitrary_exception)):
+            async with session as session:
+                pass
+
+        assert session._mqtt_client.disconnect.await_count == 1
+        if session._sastoken_provider:
+            assert session._sastoken_provider.stop.await_count == 1
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Allows any errors raised while stopping the SasTokenProvider during context manager exit to propagate"
+    )
+    async def test_exit_sastoken_provider_stop_raises(
+        self, session, mock_sastoken_provider, arbitrary_exception
+    ):
+        session._sastoken_provider = mock_sastoken_provider
+        session._sastoken_provider.stop.side_effect = arbitrary_exception
+
+        with pytest.raises(type(arbitrary_exception)):
+            async with session as session:
+                pass
+
+    # NOTE: This shouldn't happen, but we test it anyway
+    @pytest.mark.it(
+        "Disconnects and stops the IoTHubMQTTClient, even if an error was raised while stopping the SasTokenProvider during context manager exit"
+    )
+    async def test_exit_sastoken_provider_stop_raises_cleanup(
+        self, session, mock_sastoken_provider, arbitrary_exception
+    ):
+        session._sastoken_provider = mock_sastoken_provider
+        session._sastoken_provider.stop.side_effect = arbitrary_exception
+        assert session._mqtt_client.disconnect.await_count == 0
+        assert session._mqtt_client.stop.await_count == 0
+
+        with pytest.raises(type(arbitrary_exception)):
+            async with session as session:
+                pass
+
+        assert session._mqtt_client.disconnect.await_count == 1
+        assert session._mqtt_client.stop.await_count == 1
+
+    # TODO: consider adding detailed cancellation tests
+    # Not sure how cancellation would work in a context manager situation, needs more investigation
+
+
+@pytest.mark.describe("IoTHubSession - .send_message()")
+class TestIoTHubSessionSendMessage:
+    @pytest.mark.it(
+        "Invokes .send_message() on the IoTHubMQTTClient, passing the provided `message`, if `message` is a Message object"
+    )
+    async def test_message_object(self, mocker, session):
+        assert session._mqtt_client.send_message.await_count == 0
+
+        m = models.Message("hi")
+        await session.send_message(m)
+
+        assert session._mqtt_client.send_message.await_count == 1
+        assert session._mqtt_client.send_message.await_args == mocker.call(m)
+
+    @pytest.mark.it(
+        "Invokes .send_message() on the IoTHubMQTTClient, passing a new Message object with `message` as the payload, if `message` is a string"
+    )
+    async def test_message_string(self, session):
+        assert session._mqtt_client.send_message.await_count == 0
+
+        m_str = "hi"
+        await session.send_message(m_str)
+
+        assert session._mqtt_client.send_message.await_count == 1
+        m_obj = session._mqtt_client.send_message.await_args[0][0]
+        assert isinstance(m_obj, models.Message)
+        assert m_obj.payload == m_str
+
+    @pytest.mark.it("Allows any exceptions raised by the IoTHubMQTTClient to propagate")
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(mqtt.MQTTError(5), id="MQTTError"),
+            pytest.param(ValueError(), id="ValueError"),
+            pytest.param(lazy_fixture("arbitrary_exception"), id="Unexpected Error"),
+        ],
+    )
+    async def test_mqtt_client_raises(self, session, exception):
+        session._mqtt_client.send_message.side_effect = exception
+
+        with pytest.raises(type(exception)) as e_info:
+            await session.send_message("hi")
+        assert e_info.value is exception
+
+    @pytest.mark.it("Can be cancelled while waiting for the IoTHubMQTTClient operation to complete")
+    async def test_cancel_during_send(self, session):
+        session._mqtt_client.send_message = custom_mock.HangingAsyncMock()
+
+        t = asyncio.create_task(session.send_message("hi"))
+
+        # Hanging, waiting for send to finish
+        await session._mqtt_client.send_message.wait_for_hang()
+        assert not t.done()
+
+        # Cancel
+        t.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await t
+
+
+@pytest.mark.describe("IoTHubSession - .send_direct_method_response()")
+class TestIoTHubSessionSendDirectMethodResponse:
+    @pytest.fixture
+    def direct_method_response(self):
+        return models.DirectMethodResponse(request_id="id", status=200, payload={"some": "value"})
+
+    @pytest.mark.it(
+        "Invokes .send_direct_method_response() on the IoTHubMQTTClient, passing the provided `method_response`"
+    )
+    async def test_invoke(self, mocker, session, direct_method_response):
+        assert session._mqtt_client.send_direct_method_response.await_count == 0
+
+        await session.send_direct_method_response(direct_method_response)
+
+        assert session._mqtt_client.send_direct_method_response.await_count == 1
+        assert session._mqtt_client.send_direct_method_response.await_args == mocker.call(
+            direct_method_response
+        )
+
+    @pytest.mark.it("Allows any exceptions raised by the IoTHubMQTTClient to propagate")
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(mqtt.MQTTError(5), id="MQTTError"),
+            pytest.param(ValueError(), id="ValueError"),
+            pytest.param(lazy_fixture("arbitrary_exception"), id="Unexpected Error"),
+        ],
+    )
+    async def test_mqtt_client_raises(self, session, direct_method_response, exception):
+        session._mqtt_client.send_direct_method_response.side_effect = exception
+
+        with pytest.raises(type(exception)) as e_info:
+            await session.send_direct_method_response(direct_method_response)
+        assert e_info.value is exception
+
+    @pytest.mark.it("Can be cancelled while waiting for the IoTHubMQTTClient operation to complete")
+    async def test_cancel_during_send(self, session, direct_method_response):
+        session._mqtt_client.send_direct_method_response = custom_mock.HangingAsyncMock()
+
+        t = asyncio.create_task(session.send_direct_method_response(direct_method_response))
+
+        # Hanging, waiting for send to finish
+        await session._mqtt_client.send_direct_method_response.wait_for_hang()
+        assert not t.done()
+
+        # Cancel
+        t.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await t
+
+
+@pytest.mark.describe("IoTHubSession - .update_reported_properties()")
+class TestIoTHubSessionUpdateReportedProperties:
+    @pytest.fixture
+    def patch(self):
+        return {"key1": "value1", "key2": "value2"}
+
+    @pytest.mark.it(
+        "Invokes .send_twin_patch() on the IoTHubMQTTClient, passing the provided `patch`"
+    )
+    async def test_invoke(self, mocker, session, patch):
+        assert session._mqtt_client.send_twin_patch.await_count == 0
+
+        await session.update_reported_properties(patch)
+
+        assert session._mqtt_client.send_twin_patch.await_count == 1
+        assert session._mqtt_client.send_twin_patch.await_args == mocker.call(patch)
+
+    @pytest.mark.it("Allows any exceptions raised by the IoTHubMQTTClient to propagate")
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(iot_exceptions.IoTHubError(), id="IoTHubError"),
+            pytest.param(mqtt.MQTTError(5), id="MQTTError"),
+            pytest.param(ValueError(), id="ValueError"),
+            pytest.param(asyncio.CancelledError(), id="CancelledError"),
+            pytest.param(lazy_fixture("arbitrary_exception"), id="Unexpected Error"),
+        ],
+    )
+    async def test_mqtt_client_raises(self, session, patch, exception):
+        session._mqtt_client.send_twin_patch.side_effect = exception
+
+        with pytest.raises(type(exception)) as e_info:
+            await session.update_reported_properties(patch)
+        assert e_info.value is exception
+
+    @pytest.mark.it("Can be cancelled while waiting for the IoTHubMQTTClient operation to complete")
+    async def test_cancel_during_send(self, session, patch):
+        session._mqtt_client.send_twin_patch = custom_mock.HangingAsyncMock()
+
+        t = asyncio.create_task(session.update_reported_properties(patch))
+
+        # Hanging, waiting for send to finish
+        await session._mqtt_client.send_twin_patch.wait_for_hang()
+        assert not t.done()
+
+        # Cancel
+        t.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await t
+
+
+@pytest.mark.describe("IoTHubSession - .get_twin()")
+class TestIoTHubSessionGetTwin:
+    @pytest.mark.it("Invokes .get_twin() on the IoTHubMQTTClient")
+    async def test_invoke(self, mocker, session):
+        assert session._mqtt_client.get_twin.await_count == 0
+
+        await session.get_twin()
+
+        assert session._mqtt_client.get_twin.await_count == 1
+        assert session._mqtt_client.get_twin.await_args == mocker.call()
+
+    @pytest.mark.it("Allows any exceptions raised by the IoTHubMQTTClient to propagate")
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(iot_exceptions.IoTHubError(), id="IoTHubError"),
+            pytest.param(mqtt.MQTTError(5), id="MQTTError"),
+            pytest.param(asyncio.CancelledError(), id="CancelledError"),
+            pytest.param(lazy_fixture("arbitrary_exception"), id="Unexpected Error"),
+        ],
+    )
+    async def test_mqtt_client_raises(self, session, exception):
+        session._mqtt_client.get_twin.side_effect = exception
+
+        with pytest.raises(type(exception)) as e_info:
+            await session.get_twin()
+        assert e_info.value is exception
+
+    @pytest.mark.it("Can be cancelled while waiting for the IoTHubMQTTClient operation to complete")
+    async def test_cancel_during_send(self, session):
+        session._mqtt_client.get_twin = custom_mock.HangingAsyncMock()
+
+        t = asyncio.create_task(session.get_twin())
+
+        # Hanging, waiting for send to finish
+        await session._mqtt_client.get_twin.wait_for_hang()
+        assert not t.done()
+
+        # Cancel
+        t.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await t
+
+
+@pytest.mark.describe("IoTHubSession - .messages()")
+class TestIoTHubSessionMessages:
+    @pytest.mark.it(
+        "Enables C2D message receive with the IoTHubMQTTClient upon entry into the context manager and disables C2D message receive upon exit"
+    )
+    async def test_context_manager(self, session):
+        assert session._mqtt_client.enable_c2d_message_receive.await_count == 0
+        assert session._mqtt_client.disable_c2d_message_receive.await_count == 0
+
+        async with session.messages():
+            assert session._mqtt_client.enable_c2d_message_receive.await_count == 1
+            assert session._mqtt_client.disable_c2d_message_receive.await_count == 0
+
+        assert session._mqtt_client.enable_c2d_message_receive.await_count == 1
+        assert session._mqtt_client.disable_c2d_message_receive.await_count == 1
+
+    @pytest.mark.it(
+        "Disables C2D message receive upon exit, even if an error is raised inside the context manager block"
+    )
+    async def test_context_manager_failure(self, session, arbitrary_exception):
+        assert session._mqtt_client.enable_c2d_message_receive.await_count == 0
+        assert session._mqtt_client.disable_c2d_message_receive.await_count == 0
+
+        try:
+            async with session.messages():
+                assert session._mqtt_client.enable_c2d_message_receive.await_count == 1
+                assert session._mqtt_client.disable_c2d_message_receive.await_count == 0
+                raise arbitrary_exception
+        except type(arbitrary_exception):
+            pass
+
+        assert session._mqtt_client.enable_c2d_message_receive.await_count == 1
+        assert session._mqtt_client.disable_c2d_message_receive.await_count == 1
+
+    @pytest.mark.it("Yields the IoTHubMQTTClient's incoming C2D message generator")
+    async def test_generator(self, session):
+        # NOTE: This generator is thoroughly tested in test_iothub_mqtt_client.py
+        async with session.messages() as messages:
+            assert messages is session._mqtt_client.incoming_c2d_messages
+
+
+@pytest.mark.describe("IoTHubSession - .direct_method_requests()")
+class TestIoTHubSessionDirectMethodRequests:
+    @pytest.mark.it(
+        "Enables direct method request receive with the IoTHubMQTTClient upon entry into the context manager and disables direct method request receive upon exit"
+    )
+    async def test_context_manager(self, session):
+        assert session._mqtt_client.enable_direct_method_request_receive.await_count == 0
+        assert session._mqtt_client.disable_direct_method_request_receive.await_count == 0
+
+        async with session.direct_method_requests():
+            assert session._mqtt_client.enable_direct_method_request_receive.await_count == 1
+            assert session._mqtt_client.disable_direct_method_request_receive.await_count == 0
+
+        assert session._mqtt_client.enable_direct_method_request_receive.await_count == 1
+        assert session._mqtt_client.disable_direct_method_request_receive.await_count == 1
+
+    @pytest.mark.it(
+        "Disables direct method request receive upon exit, even if an error is raised inside the context manager block"
+    )
+    async def test_context_manager_failure(self, session, arbitrary_exception):
+        assert session._mqtt_client.enable_direct_method_request_receive.await_count == 0
+        assert session._mqtt_client.disable_direct_method_request_receive.await_count == 0
+
+        try:
+            async with session.direct_method_requests():
+                assert session._mqtt_client.enable_direct_method_request_receive.await_count == 1
+                assert session._mqtt_client.disable_direct_method_request_receive.await_count == 0
+                raise arbitrary_exception
+        except type(arbitrary_exception):
+            pass
+
+        assert session._mqtt_client.enable_direct_method_request_receive.await_count == 1
+        assert session._mqtt_client.disable_direct_method_request_receive.await_count == 1
+
+    @pytest.mark.it("Yields the IoTHubMQTTClient's incoming direct method request generator")
+    async def test_generator(self, session):
+        # NOTE: This generator is thoroughly tested in test_iothub_mqtt_client.py
+        async with session.direct_method_requests() as method_requests:
+            assert method_requests is session._mqtt_client.incoming_direct_method_requests
+
+
+@pytest.mark.describe("IoTHubSession - .desired_property_updates()")
+class TestIoTHubSessionDesiredPropertyUpdates:
+    @pytest.mark.it(
+        "Enables twin patch receive with the IoTHubMQTTClient upon entry into the context manager and disables twin patch receive upon exit"
+    )
+    async def test_context_manager(self, session):
+        assert session._mqtt_client.enable_twin_patch_receive.await_count == 0
+        assert session._mqtt_client.disable_twin_patch_receive.await_count == 0
+
+        async with session.desired_property_updates():
+            assert session._mqtt_client.enable_twin_patch_receive.await_count == 1
+            assert session._mqtt_client.disable_twin_patch_receive.await_count == 0
+
+        assert session._mqtt_client.enable_twin_patch_receive.await_count == 1
+        assert session._mqtt_client.disable_twin_patch_receive.await_count == 1
+
+    @pytest.mark.it(
+        "Disables twin patch receive upon exit, even if an error is raised inside the context manager block"
+    )
+    async def test_context_manager_failure(self, session, arbitrary_exception):
+        assert session._mqtt_client.enable_twin_patch_receive.await_count == 0
+        assert session._mqtt_client.disable_twin_patch_receive.await_count == 0
+
+        try:
+            async with session.desired_property_updates():
+                assert session._mqtt_client.enable_twin_patch_receive.await_count == 1
+                assert session._mqtt_client.disable_twin_patch_receive.await_count == 0
+                raise arbitrary_exception
+        except type(arbitrary_exception):
+            pass
+
+        assert session._mqtt_client.enable_twin_patch_receive.await_count == 1
+        assert session._mqtt_client.disable_twin_patch_receive.await_count == 1
+
+    @pytest.mark.it("Yields the IoTHubMQTTClient's incoming twin patch generator")
+    async def test_generator(self, session):
+        # NOTE: This generator is thoroughly tested in test_iothub_mqtt_client.py
+        async with session.desired_property_updates() as updates:
+            assert updates is session._mqtt_client.incoming_twin_patches

--- a/v3_async_wip/tests/test_iothub_session.py
+++ b/v3_async_wip/tests/test_iothub_session.py
@@ -197,7 +197,7 @@ class TestIoTHubSessionInstantiation:
         # InternalSasTokenGenerator was created from the SymmetricKeySigningMechanism
         assert spy_st_generator_cls.call_count == 1
         assert spy_st_generator_cls.call_args == mocker.call(
-            signing_mechanism=spy_sk_sm_cls.spy_return, uri=expected_uri
+            signing_mechanism=spy_sk_sm_cls.spy_return, uri=expected_uri, ttl=3600
         )
         # SasTokenProvider was created from the InternalSasTokenGenerator
         assert spy_st_provider_cls.call_count == 1

--- a/v3_async_wip/tests/test_iothub_session.py
+++ b/v3_async_wip/tests/test_iothub_session.py
@@ -1489,7 +1489,7 @@ class TestIoTHubSessionSendMessage:
         assert session._mqtt_client.send_message.call_count == 0
 
     @pytest.mark.it(
-        "Raises MQTTError (rc=4) if an expected disconnect occurs in the IoTHubMQTTClient while waiting for the operation to complete"
+        "Raises CancelledError if an expected disconnect occurs in the IoTHubMQTTClient while waiting for the operation to complete"
     )
     async def test_expected_disconnect_during_send(self, session):
         session._mqtt_client.send_message = custom_mock.HangingAsyncMock()
@@ -1509,9 +1509,8 @@ class TestIoTHubSessionSendMessage:
         session._mqtt_client.wait_for_disconnect.return_value = None
         session._mqtt_client.wait_for_disconnect.stop_hanging()
 
-        with pytest.raises(mqtt.MQTTError) as e_info:
+        with pytest.raises(asyncio.CancelledError):
             await t
-        assert e_info.value.rc == 4
 
     @pytest.mark.it(
         "Raises the MQTTError that caused the unexpected disconnect, if an unexpected disconnect occurs in the IoTHubMQTTClient while waiting for the operation to complete"
@@ -1603,7 +1602,7 @@ class TestIoTHubSessionSendDirectMethodResponse:
         assert session._mqtt_client.send_message.call_count == 0
 
     @pytest.mark.it(
-        "Raises MQTTError (rc=4) if an expected disconnect occurs in the IoTHubMQTTClient while waiting for the operation to complete"
+        "Raises CancelledError if an expected disconnect occurs in the IoTHubMQTTClient while waiting for the operation to complete"
     )
     async def test_expected_disconnect_during_send(self, session, direct_method_response):
         session._mqtt_client.send_direct_method_response = custom_mock.HangingAsyncMock()
@@ -1623,9 +1622,8 @@ class TestIoTHubSessionSendDirectMethodResponse:
         session._mqtt_client.wait_for_disconnect.return_value = None
         session._mqtt_client.wait_for_disconnect.stop_hanging()
 
-        with pytest.raises(mqtt.MQTTError) as e_info:
+        with pytest.raises(asyncio.CancelledError):
             await t
-        assert e_info.value.rc == 4
 
     @pytest.mark.it(
         "Raises the MQTTError that caused the unexpected disconnect, if an unexpected disconnect occurs in the IoTHubMQTTClient while waiting for the operation to complete"
@@ -1720,7 +1718,7 @@ class TestIoTHubSessionUpdateReportedProperties:
         assert session._mqtt_client.send_twin_patch.call_count == 0
 
     @pytest.mark.it(
-        "Raises MQTTError (rc=4) if an expected disconnect occurs in the IoTHubMQTTClient while waiting for the operation to complete"
+        "Raises CancelledError if an expected disconnect occurs in the IoTHubMQTTClient while waiting for the operation to complete"
     )
     async def test_expected_disconnect_during_send(self, session, patch):
         session._mqtt_client.send_twin_patch = custom_mock.HangingAsyncMock()
@@ -1740,9 +1738,8 @@ class TestIoTHubSessionUpdateReportedProperties:
         session._mqtt_client.wait_for_disconnect.return_value = None
         session._mqtt_client.wait_for_disconnect.stop_hanging()
 
-        with pytest.raises(mqtt.MQTTError) as e_info:
+        with pytest.raises(asyncio.CancelledError):
             await t
-        assert e_info.value.rc == 4
 
     @pytest.mark.it(
         "Raises the MQTTError that caused the unexpected disconnect, if an unexpected disconnect occurs in the IoTHubMQTTClient while waiting for the operation to complete"
@@ -1830,7 +1827,7 @@ class TestIoTHubSessionGetTwin:
         assert session._mqtt_client.get_twin.call_count == 0
 
     @pytest.mark.it(
-        "Raises MQTTError (rc=4) if an expected disconnect occurs in the IoTHubMQTTClient while waiting for the operation to complete"
+        "Raises CancelledError if an expected disconnect occurs in the IoTHubMQTTClient while waiting for the operation to complete"
     )
     async def test_expected_disconnect_during_send(self, session):
         session._mqtt_client.get_twin = custom_mock.HangingAsyncMock()
@@ -1850,9 +1847,8 @@ class TestIoTHubSessionGetTwin:
         session._mqtt_client.wait_for_disconnect.return_value = None
         session._mqtt_client.wait_for_disconnect.stop_hanging()
 
-        with pytest.raises(mqtt.MQTTError) as e_info:
+        with pytest.raises(asyncio.CancelledError):
             await t
-        assert e_info.value.rc == 4
 
     @pytest.mark.it(
         "Raises the MQTTError that caused the unexpected disconnect, if an unexpected disconnect occurs in the IoTHubMQTTClient while waiting for the operation to complete"

--- a/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
+++ b/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
@@ -239,7 +239,7 @@ class IoTHubMQTTClient:
         await self._mqtt_client.disconnect()
         logger.debug("Disconnect succeeded")
 
-    async def wait_for_connection_drop(self) -> MQTTError:
+    async def report_connection_drop(self) -> MQTTError:
         """Block until the connection is dropped and return the cause"""
         async with self._mqtt_client.disconnected_cond:
             await self._mqtt_client.disconnected_cond.wait_for(

--- a/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
+++ b/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
@@ -362,7 +362,7 @@ class IoTHubMQTTClient:
                 )
             )
             # TODO: should body be logged? Is there useful info there?
-            if response.status != 200:
+            if response.status >= 300:
                 raise IoTHubError(
                     "IoTHub responded to twin patch with a failed status - {}".format(
                         response.status
@@ -430,7 +430,7 @@ class IoTHubMQTTClient:
                 await self._request_ledger.delete_request(request.request_id)
 
         # Interpret response
-        if response.status != 200:
+        if response.status >= 300:
             raise IoTHubError(
                 "IoTHub responded to get twin request with a failed status - {}".format(
                     response.status

--- a/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
+++ b/v3_async_wip/v3_async_wip/iothub_mqtt_client.py
@@ -11,6 +11,10 @@ import urllib.parse
 from typing import Callable, Optional, AsyncGenerator, TypeVar
 from .custom_typing import TwinPatch, Twin
 from .iot_exceptions import IoTHubError, IoTHubClientError
+from .mqtt_client import (  # noqa: F401 (Importing directly to re-export)
+    MQTTError,
+    MQTTConnectionFailedError,
+)
 from . import config, constant, user_agent, models
 from . import request_response as rr
 from . import mqtt_client as mqtt
@@ -331,6 +335,7 @@ class IoTHubMQTTClient:
         :param patch: The JSON patch to send
         :type patch: dict, list, tuple, str, int, float, bool, None
 
+        :raises: IoTHubError if an error response is received from IoT Hub
         :raises: MQTTError if there is an error sending the twin patch
         :raises: ValueError if the size of the the twin patch is too large
         :raises: CancelledError if enabling twin responses is cancelled by network failure
@@ -400,6 +405,7 @@ class IoTHubMQTTClient:
         :returns: The full twin as a JSON object
         :rtype: dict
 
+        :raises: IoTHubError if an error response is received from IoT Hub
         :raises: MQTTError if there is an error sending the twin request
         :raises: CancelledError if enabling twin responses is cancelled by network failure
         """

--- a/v3_async_wip/v3_async_wip/iothub_session.py
+++ b/v3_async_wip/v3_async_wip/iothub_session.py
@@ -289,6 +289,7 @@ class IoTHubSession:
                 await self._mqtt_client.disable_c2d_message_receive()
             except mqtt.MQTTError:
                 # i.e. not connected
+                # This error would be expected if a disconnection has ocurred
                 pass
 
     @contextlib.asynccontextmanager
@@ -306,6 +307,7 @@ class IoTHubSession:
                 await self._mqtt_client.disable_direct_method_request_receive()
             except mqtt.MQTTError:
                 # i.e. not connected
+                # This error would be expected if a disconnection has ocurred
                 pass
 
     @contextlib.asynccontextmanager
@@ -323,6 +325,7 @@ class IoTHubSession:
                 await self._mqtt_client.disable_twin_patch_receive()
             except mqtt.MQTTError:
                 # i.e. not connected
+                # This error would be expected if a disconnection has ocurred
                 pass
 
     def _add_disconnect_interrupt_to_generator(

--- a/v3_async_wip/v3_async_wip/iothub_session.py
+++ b/v3_async_wip/v3_async_wip/iothub_session.py
@@ -1,0 +1,288 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import asyncio
+import contextlib
+import ssl
+from typing import Optional, Union, AsyncGenerator, Type
+from types import TracebackType
+
+from v3_async_wip import signing_mechanism as sm
+from v3_async_wip import connection_string as cs
+from v3_async_wip import sastoken as st
+from v3_async_wip import config, models, custom_typing
+from v3_async_wip import iothub_mqtt_client as mqtt
+
+
+class IoTHubSession:
+    def __init__(
+        self,
+        *,
+        hostname: str,  # iothub_hostname?
+        device_id: str,
+        module_id: Optional[str] = None,
+        ssl_context: Optional[ssl.SSLContext] = None,
+        shared_access_key: Optional[str] = None,
+        sastoken_fn: Optional[custom_typing.FunctionOrCoroutine] = None,
+        **kwargs,
+    ) -> None:
+        """
+        :param str device_id: The device identity for the IoT Hub device containing the
+            IoT Hub module
+        :param str module_id: The module identity for the IoT Hub module
+        :param str hostname: Hostname of the IoT Hub or IoT Edge the device should connect to
+        :param ssl_context: Custom SSL context to be used by the client
+            If not provided, a default one will be used
+        :type ssl_context: :class:`ssl.SSLContext`
+        :param str shared_access_key: A key that can be used to generate SAS Tokens
+        :param sastoken_fn: A function or coroutine function that takes no arguments and returns
+            a SAS token string when invoked
+
+        :raises: ValueError if none of 'ssl_context', 'symmetric_key' or 'sastoken_fn' are provided
+        :raises: ValueError if both 'symmetric_key' and 'sastoken_fn' are provided
+        :raises: ValueError if an invalid 'symmetric_key' is provided
+        :raises: TypeError if an invalid keyword argument is provided
+        """
+        # Validate parameters
+        _validate_kwargs(**kwargs)
+        if shared_access_key and sastoken_fn:
+            raise ValueError(
+                "Incompatible authentication - cannot provide both 'shared_access_key' and 'sastoken_fn'"
+            )
+        if not shared_access_key and not sastoken_fn and not ssl_context:
+            raise ValueError(
+                "Missing authentication - must provide one of 'shared_access_key', 'sastoken_fn' or 'ssl_context'"
+            )
+
+        # Set up SAS auth (if using)
+        generator: Optional[st.SasTokenGenerator]
+        # NOTE: Need to keep a reference to the SasTokenProvider so we can stop it during cleanup
+        self._sastoken_provider: Optional[st.SasTokenProvider]
+        if shared_access_key:
+            uri = _format_sas_uri(hostname=hostname, device_id=device_id, module_id=module_id)
+            signing_mechanism = sm.SymmetricKeySigningMechanism(shared_access_key)
+            generator = st.InternalSasTokenGenerator(signing_mechanism=signing_mechanism, uri=uri)
+            self._sastoken_provider = st.SasTokenProvider(generator)
+        elif sastoken_fn:
+            generator = st.ExternalSasTokenGenerator(sastoken_fn)
+            self._sastoken_provider = st.SasTokenProvider(generator)
+        else:
+            self._sastoken_provider = None
+
+        # Create a default SSLContext if not provided
+        if not ssl_context:
+            ssl_context = _default_ssl_context()
+
+        # Instantiate the MQTTClient
+        client_config = config.IoTHubClientConfig(
+            hostname=hostname,
+            device_id=device_id,
+            module_id=module_id,
+            sastoken_provider=self._sastoken_provider,
+            ssl_context=ssl_context,
+            auto_reconnect=False,  # No reconnect for now
+            **kwargs,
+        )
+        self._mqtt_client = mqtt.IoTHubMQTTClient(client_config)
+
+    async def __aenter__(self) -> "IoTHubSession":
+        # First, if using SAS auth, start up the provider
+        if self._sastoken_provider:
+            # NOTE: No try/except block is needed here because in the case of failure there is not
+            # yet anything that we would need to clean up.
+            await self._sastoken_provider.start()
+
+        # Start/connect
+        try:
+            await self._mqtt_client.start()
+            await self._mqtt_client.connect()
+        except (Exception, asyncio.CancelledError):
+            # Stop/cleanup if something goes wrong
+            await self._stop_all()
+            raise
+
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        traceback: TracebackType,
+    ) -> None:
+        try:
+            await self._mqtt_client.disconnect()
+        finally:
+            await self._stop_all()
+
+    async def _stop_all(self) -> None:
+        try:
+            await self._mqtt_client.stop()
+        finally:
+            if self._sastoken_provider:
+                await self._sastoken_provider.stop()
+
+    @classmethod
+    def from_connection_string(
+        cls, connection_string: str, ssl_context: Optional[ssl.SSLContext] = None, **kwargs
+    ) -> "IoTHubSession":
+        """Instantiate an IoTHubSession using an IoT Hub device or module connection string
+
+        :param str connection_string: The IoT Hub device connection string
+        :param ssl_context: Custom SSL context to be used by the client
+            If not provided, a default one will be used
+        :type ssl_context: :class:`ssl.SSLContext`
+
+        :keyword int keep_alive: Maximum period in seconds between MQTT communications. If no
+            communications are exchanged for this period, a ping exchange will occur.
+            Default is 60 seconds
+        :keyword str product_info: Arbitrary product information which will be included in the
+            User-Agent string
+        :keyword proxy_options: Configuration structure for sending traffic through a proxy server
+        :type: proxy_options: :class:`ProxyOptions`
+        :keyword bool websockets: Set to 'True' to use WebSockets over MQTT. Default is 'False'
+
+        :raises: ValueError if the provided connection string is invalid
+        :raises: TypeError if an invalid keyword argument is provided
+        """
+        cs_obj = cs.ConnectionString(connection_string)
+        if cs_obj.get(cs.X509, "").lower() == "true" and ssl_context is None:
+            raise ValueError(
+                "Connection string indicates X509 certificate authentication, but no ssl_context provided"
+            )
+        if cs.GATEWAY_HOST_NAME in cs_obj:
+            hostname = cs_obj[cs.GATEWAY_HOST_NAME]
+        else:
+            hostname = cs_obj[cs.HOST_NAME]
+        return cls(
+            hostname=hostname,
+            device_id=cs_obj[cs.DEVICE_ID],
+            module_id=cs_obj.get(cs.MODULE_ID),
+            shared_access_key=cs_obj.get(cs.SHARED_ACCESS_KEY),
+            ssl_context=ssl_context,
+            **kwargs,
+        )
+
+    # TODO: should "output" be an optional argument here?
+    async def send_message(self, message: Union[str, models.Message]) -> None:
+        """Send a telemetry or input message to its destination
+
+        :param message: Message to send. If not a Message object, will be used as the payload of
+            a new Message object.
+        :type message: str or :class:`Message`
+
+        :raises: MQTTError if there is an error sending the Message
+        :raises: ValueError if the size of the Message payload is too large
+        """
+        if not isinstance(message, models.Message):
+            message = models.Message(message)
+        await self._mqtt_client.send_message(message)
+
+    async def send_direct_method_response(
+        self, method_response: models.DirectMethodResponse
+    ) -> None:
+        """Send a response to a direct method request
+
+        :param method_response: The response object containing information regarding the result of
+            the direct method invocation
+        :type method_response: :class:`DirectMethodResponse`
+
+        :raises: MQTTError if there is an error sending the DirectMethodResponse
+        :raises: ValueError if the size of the DirectMethodResponse payload is too large
+        """
+        await self._mqtt_client.send_direct_method_response(method_response)
+
+    async def update_reported_properties(self, patch: custom_typing.TwinPatch) -> None:
+        """Update the reported properties of the Twin
+
+        :param dict patch: JSON object containing the updates to the Twin reported properties
+
+        :raises: IoTHubError if an error response is received from IoT Hub
+        :raises: MQTTError if there is an error sending the updated reported properties
+        :raises: ValueError if the size of the the reported properties patch too large
+        :raises: CancelledError if enabling responses from IoT Hub is cancelled by network failure      # TODO: what should the behavior be here?
+        """
+        await self._mqtt_client.send_twin_patch(patch)
+
+    async def get_twin(self) -> custom_typing.Twin:
+        """Retrieve the full Twin data
+
+        :returns: Twin as a JSON object
+        :rtype: dict
+
+        :raises: IoTHubError if a error response is received from IoTHub
+        :raises: MQTTError if there is an error sending the request
+        :raises: CancelledError if enabling responses from IoT Hub is cancelled by network failure
+        """
+        return await self._mqtt_client.get_twin()
+
+    # TODO: does this need to support input messages? Pending discussion re: Edge
+    @contextlib.asynccontextmanager
+    async def messages(self) -> AsyncGenerator[AsyncGenerator[models.Message, None], None]:
+        """Returns an async generator of incoming C2D messages"""
+        await self._mqtt_client.enable_c2d_message_receive()
+        try:
+            yield self._mqtt_client.incoming_c2d_messages
+        finally:
+            await self._mqtt_client.disable_c2d_message_receive()
+
+    @contextlib.asynccontextmanager
+    async def direct_method_requests(
+        self,
+    ) -> AsyncGenerator[AsyncGenerator[models.DirectMethodRequest, None], None]:
+        """Returns an async generator of incoming direct method requests"""
+        await self._mqtt_client.enable_direct_method_request_receive()
+        try:
+            yield self._mqtt_client.incoming_direct_method_requests
+        finally:
+            await self._mqtt_client.disable_direct_method_request_receive()
+
+    @contextlib.asynccontextmanager
+    async def desired_property_updates(
+        self,
+    ) -> AsyncGenerator[AsyncGenerator[custom_typing.TwinPatch, None], None]:
+        """Returns an async generator of incoming twin desired property patches"""
+        await self._mqtt_client.enable_twin_patch_receive()
+        try:
+            yield self._mqtt_client.incoming_twin_patches
+        finally:
+            await self._mqtt_client.disable_twin_patch_receive()
+
+
+def _validate_kwargs(exclude=[], **kwargs) -> None:
+    """Helper function to validate user provided kwargs.
+    Raises TypeError if an invalid option has been provided"""
+    valid_kwargs = [
+        # "auto_reconnect",
+        "keep_alive",
+        "product_info",
+        "proxy_options",
+        "websockets",
+    ]
+
+    for kwarg in kwargs:
+        if (kwarg not in valid_kwargs) or (kwarg in exclude):
+            # NOTE: TypeError is the conventional error that is returned when an invalid kwarg is
+            # supplied. It feels like it should be a ValueError, but it's not.
+            raise TypeError("Unsupported keyword argument: '{}'".format(kwarg))
+
+
+def _format_sas_uri(hostname: str, device_id: str, module_id: Optional[str]) -> str:
+    """Format the SAS URI for using IoT Hub"""
+    if module_id:
+        return "{hostname}/devices/{device_id}/modules/{module_id}".format(
+            hostname=hostname, device_id=device_id, module_id=module_id
+        )
+    else:
+        return "{hostname}/devices/{device_id}".format(hostname=hostname, device_id=device_id)
+
+
+def _default_ssl_context() -> ssl.SSLContext:
+    """Return a default SSLContext"""
+    ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
+    ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+    ssl_context.verify_mode = ssl.CERT_REQUIRED
+    ssl_context.check_hostname = True
+    ssl_context.load_default_certs()
+    return ssl_context

--- a/v3_async_wip/v3_async_wip/iothub_session.py
+++ b/v3_async_wip/v3_async_wip/iothub_session.py
@@ -201,7 +201,7 @@ class IoTHubSession:
         :raises: IoTHubError if an error response is received from IoT Hub
         :raises: MQTTError if there is an error sending the updated reported properties
         :raises: ValueError if the size of the the reported properties patch too large
-        :raises: CancelledError if enabling responses from IoT Hub is cancelled by network failure      # TODO: what should the behavior be here?
+        :raises: CancelledError if enabling responses from IoT Hub is cancelled by network failure
         """
         await self._mqtt_client.send_twin_patch(patch)
 

--- a/v3_async_wip/v3_async_wip/iothub_session.py
+++ b/v3_async_wip/v3_async_wip/iothub_session.py
@@ -94,7 +94,7 @@ class IoTHubSession:
         # NOTE: If we wanted to design lower levels of the stack to be specific to our
         # Session design pattern, this could happen lower (and it would be simpler), but it's
         # up here so we can be more implementation-generic down the stack.
-        self._wait_for_conn_drop_bg_task: Optional[asyncio.Task[mqtt.MQTTError]] = None
+        self._report_conn_drop_bg_task: Optional[asyncio.Task[mqtt.MQTTError]] = None
 
     async def __aenter__(self) -> "IoTHubSession":
         # First, if using SAS auth, start up the provider
@@ -107,8 +107,8 @@ class IoTHubSession:
         try:
             await self._mqtt_client.start()
             await self._mqtt_client.connect()
-            self._wait_for_conn_drop_bg_task = asyncio.create_task(
-                self._mqtt_client.wait_for_connection_drop()
+            self._report_conn_drop_bg_task = asyncio.create_task(
+                self._mqtt_client.report_connection_drop()
             )
         except (Exception, asyncio.CancelledError):
             # Stop/cleanup if something goes wrong
@@ -126,9 +126,9 @@ class IoTHubSession:
         try:
             await self._mqtt_client.disconnect()
         finally:
-            if self._wait_for_conn_drop_bg_task:
-                self._wait_for_conn_drop_bg_task.cancel()
-                self._wait_for_conn_drop_bg_task = None
+            if self._report_conn_drop_bg_task:
+                self._report_conn_drop_bg_task.cancel()
+                self._report_conn_drop_bg_task = None
             await self._stop_all()
 
     async def _stop_all(self) -> None:
@@ -291,12 +291,12 @@ class IoTHubSession:
             while True:
                 new_item_t = asyncio.create_task(generator.__anext__())
                 done, _ = await asyncio.wait(
-                    [new_item_t, self._wait_for_conn_drop_bg_task],
+                    [new_item_t, self._report_conn_drop_bg_task],
                     return_when=asyncio.FIRST_COMPLETED,
                 )
-                if self._wait_for_conn_drop_bg_task in done:
+                if self._report_conn_drop_bg_task in done:
                     new_item_t.cancel()
-                    raise self._wait_for_conn_drop_bg_task.result()
+                    raise self._report_conn_drop_bg_task.result()
                 else:
                     yield new_item_t.result()
 

--- a/v3_async_wip/v3_async_wip/iothub_session.py
+++ b/v3_async_wip/v3_async_wip/iothub_session.py
@@ -341,7 +341,8 @@ class IoTHubSession:
                 if cause is not None:
                     raise cause
                 else:
-                    raise mqtt.MQTTError(rc=4)
+                    # TODO: should this raise MQTTError(rc=4) instead?
+                    raise asyncio.CancelledError("Cancelled by disconnect")
             else:
                 return await original_task
 


### PR DESCRIPTION
* Removed SAS renewal logic in the IoTHubMQTTClient.
* Added support for reporting connection drop errors in MQTTClient and IoTHubMQTTClient
* Modified IoTHubSession receiver generators to raise error in the case of connection drop / disconnection
* Modified outgoing data IoTHubSession APIs to raise error in the case of connection drop / disconnection
* Added basic `sastoken_ttl` argument support

NOTE: Auth API adjustments to reflect the lack of SAS renewal will be part of a separate PR