### PR TITLE
[DO NOT MERGE] Gateway Hostname Experiment

### DIFF
--- a/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
@@ -699,7 +699,8 @@ class AbstractIoTHubModuleClient(AbstractIoTHubClient):
             try:
                 device_id = connection_string[cs.DEVICE_ID]
                 module_id = connection_string[cs.MODULE_ID]
-                hostname = connection_string[cs.HOST_NAME]
+                # hostname = connection_string[cs.HOST_NAME]
+                hostname = connection_string[cs.GATEWAY_HOST_NAME]
                 gateway_hostname = connection_string[cs.GATEWAY_HOST_NAME]
             except KeyError:
                 raise ValueError("Invalid Connection String")

--- a/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
+++ b/azure-iot-device/azure/iot/device/iothub/abstract_clients.py
@@ -664,7 +664,8 @@ class AbstractIoTHubModuleClient(AbstractIoTHubClient):
 
         # First try the regular Edge container variables
         try:
-            hostname = os.environ["IOTEDGE_IOTHUBHOSTNAME"]
+            # hostname = os.environ["IOTEDGE_IOTHUBHOSTNAME"]
+            hostname = os.environ["IOTEDGE_GATEWAYHOSTNAME"]
             device_id = os.environ["IOTEDGE_DEVICEID"]
             module_id = os.environ["IOTEDGE_MODULEID"]
             gateway_hostname = os.environ["IOTEDGE_GATEWAYHOSTNAME"]


### PR DESCRIPTION
* Horton Edge tests pass, even though we use the Gateway Hostname only.
* Unit tests fail because they weren't updated

Thus, in Edge scenarios, the Gateway Hostname is the only endpoint necessary.