### PR TITLE
bugfix: sample: disconnect when all the messages are sent

### DIFF
--- a/samples/sync-samples/provision_symmetric_key.py
+++ b/samples/sync-samples/provision_symmetric_key.py
@@ -55,7 +55,7 @@ if registration_result.status == "assigned":
         device_client.send_message(msg)
         time.sleep(1)
 
-        # finally, disconnect
-        device_client.disconnect()
+    # finally, disconnect
+    device_client.disconnect()
 else:
     print("Can not send telemetry from the provisioned device")


### PR DESCRIPTION
## Description of the problem

Current implementation of the sync version of `provision_symmetric_key.py` calls disconnect API repeatedly, it seems weird.

## Description of the solution

I think it would be correct just as the async version [samples/async-hub-scenarios/provision_symmetric_key.py](https://github.com/Azure/azure-iot-sdk-python/blob/main/samples/async-hub-scenarios/provision_symmetric_key.py#L56) does.
