### PR TITLE
Restricted requests version for unixsocket compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         # Actual project dependencies
         "deprecation>=2.1.0,<3.0.0",
         "paho-mqtt>=1.6.1,<2.0.0",
-        "requests>=2.20.0,<3.0.0",
+        "requests>=2.20.0,<2.32.0",  # 2.32.0 breaks requests-unixsocket
         "requests-unixsocket>=0.1.5,<1.0.0",
         "janus",
         "PySocks",


### PR DESCRIPTION
`requests` 2.32.0 broke `requests-unixsocket`. This breaks IoT Edge functionality.

Until we can find a long-term solution, we are restricting the version of `requests`.