### PR TITLE
Fix importlib_metadata.entry_points attribute error by updating flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,8 @@ repos:
     - id: black
       language_version: python3
 -   repo: https://github.com/pycqa/flake8
-    rev: 3.9.1  # Use the ref you want to point at
+    rev: 7.0.0  # Use the ref you want to point at
     hooks:
     -   id: flake8
         args: ['--config=.flake8']
+        additional_dependencies: ['importlib_metadata==4.3']


### PR DESCRIPTION
## Description of the problem

```
 _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'EntryPoints' object has no attribute 'get'
```

## Description of the solution

Bump flake8 pre-commit hook version from 3.9.1 to 7.0.0.