### PR TITLE
chore: Update test dependencies and remove use of deprecated concepts

### DIFF
--- a/azure-iot-device/azure/iot/device/common/http_transport.py
+++ b/azure-iot-device/azure/iot/device/common/http_transport.py
@@ -69,7 +69,8 @@ class HTTPTransport(object):
         This method creates the SSLContext object used to authenticate the connection. The generated context is used by the http_client and is necessary when authenticating using a self-signed X509 cert or trusted X509 cert
         """
         logger.debug("creating a SSL context")
-        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLSv1_2)
+        # Note that PROTOCOL_TLS_CLIENT implies ssl.CERT_REQUIRED and check_hostname == true
+        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
 
         if self._server_verification_cert:
             ssl_context.load_verify_locations(cadata=self._server_verification_cert)
@@ -90,9 +91,6 @@ class HTTPTransport(object):
                 self._x509_cert.key_file,
                 self._x509_cert.pass_phrase,
             )
-
-        ssl_context.verify_mode = ssl.CERT_REQUIRED
-        ssl_context.check_hostname = True
 
         return ssl_context
 

--- a/azure-iot-device/azure/iot/device/common/mqtt_transport.py
+++ b/azure-iot-device/azure/iot/device/common/mqtt_transport.py
@@ -321,7 +321,8 @@ class MQTTTransport(object):
         This method creates the SSLContext object used by Paho to authenticate the connection.
         """
         logger.debug("creating a SSL context")
-        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLSv1_2)
+        # Note that PROTOCOL_TLS_CLIENT implies ssl.CERT_REQUIRED and check_hostname == true
+        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
 
         if self._server_verification_cert:
             logger.debug("configuring SSL context with custom server verification cert")
@@ -345,9 +346,6 @@ class MQTTTransport(object):
                 self._x509_cert.key_file,
                 self._x509_cert.pass_phrase,
             )
-
-        ssl_context.verify_mode = ssl.CERT_REQUIRED
-        ssl_context.check_hostname = True
 
         return ssl_context
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+asyncio_mode=auto
 testdox_format = plaintext
 addopts = --testdox --timeout 20 --ignore e2e --ignore tests/e2e
 norecursedirs=__pycache__, *.egg-info

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
-pytest < 8.0.0
-pytest-asyncio <= 0.16
+pytest < 9.0.0
+pytest-asyncio
 pytest-mock
 pytest-testdox>=1.1.1
 pytest-cov

--- a/tests/e2e/iothub_e2e/aio/test_c2d.py
+++ b/tests/e2e/iothub_e2e/aio/test_c2d.py
@@ -10,7 +10,6 @@ from dev_utils import get_random_dict
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
 
-pytestmark = pytest.mark.asyncio
 
 # TODO: add tests for various application properties
 # TODO: is there a way to call send_c2d so it arrives as an object rather than a JSON string?

--- a/tests/e2e/iothub_e2e/aio/test_connect_disconnect.py
+++ b/tests/e2e/iothub_e2e/aio/test_connect_disconnect.py
@@ -9,8 +9,6 @@ import parametrize
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.mark.describe("Client object")
 class TestConnectDisconnect(object):

--- a/tests/e2e/iothub_e2e/aio/test_connect_disconnect_stress.py
+++ b/tests/e2e/iothub_e2e/aio/test_connect_disconnect_stress.py
@@ -10,8 +10,6 @@ import random
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.mark.stress
 @pytest.mark.describe("Client object connect/disconnect stress")

--- a/tests/e2e/iothub_e2e/aio/test_infrastructure.py
+++ b/tests/e2e/iothub_e2e/aio/test_infrastructure.py
@@ -4,8 +4,6 @@
 import pytest
 import uuid
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.mark.describe("ServiceHelper object")
 class TestServiceHelper(object):

--- a/tests/e2e/iothub_e2e/aio/test_methods.py
+++ b/tests/e2e/iothub_e2e/aio/test_methods.py
@@ -11,8 +11,6 @@ from azure.iot.device.iothub import MethodResponse
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture
 def method_name():

--- a/tests/e2e/iothub_e2e/aio/test_sas_renewal.py
+++ b/tests/e2e/iothub_e2e/aio/test_sas_renewal.py
@@ -11,8 +11,6 @@ import parametrize
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.mark.skipif(
     test_config.config.auth not in test_config.AUTH_WITH_RENEWING_TOKEN,

--- a/tests/e2e/iothub_e2e/aio/test_send_message.py
+++ b/tests/e2e/iothub_e2e/aio/test_send_message.py
@@ -11,8 +11,6 @@ from azure.iot.device.exceptions import OperationCancelled, ClientError
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.mark.describe("Client send_message method")
 class TestSendMessage(object):

--- a/tests/e2e/iothub_e2e/aio/test_send_message_stress.py
+++ b/tests/e2e/iothub_e2e/aio/test_send_message_stress.py
@@ -15,7 +15,6 @@ from retry_async import retry_exponential_backoff_with_jitter
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
 
-pytestmark = pytest.mark.asyncio
 
 # Settings that apply to all tests in this module
 TELEMETRY_PAYLOAD_SIZE = 16 * 1024

--- a/tests/e2e/iothub_e2e/aio/test_twin.py
+++ b/tests/e2e/iothub_e2e/aio/test_twin.py
@@ -11,8 +11,6 @@ from azure.iot.device.exceptions import ClientError
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
 
-pytestmark = pytest.mark.asyncio
-
 
 # TODO: tests with drop_incoming and reject_incoming
 

--- a/tests/e2e/iothub_e2e/aio/test_twin_stress.py
+++ b/tests/e2e/iothub_e2e/aio/test_twin_stress.py
@@ -12,8 +12,6 @@ from retry_async import retry_exponential_backoff_with_jitter
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture
 def toxic():

--- a/tests/e2e/iothub_e2e/sync/conftest.py
+++ b/tests/e2e/iothub_e2e/sync/conftest.py
@@ -20,7 +20,7 @@ def brand_new_client(device_identity, client_kwargs, service_helper, device_id, 
     # Keep this here.  It is useful to see this info inside the inside devops pipeline test failures.
     logger.info(
         "Connecting device_id={}, module_id={}, to hub={} at {} (UTC)".format(
-            device_id, module_id, test_env.IOTHUB_HOSTNAME, datetime.datetime.utcnow()
+            device_id, module_id, test_env.IOTHUB_HOSTNAME, datetime.datetime.now(datetime.UTC)
         )
     )
 

--- a/tests/e2e/provisioning_e2e/tests/test_async_certificate_enrollments.py
+++ b/tests/e2e/provisioning_e2e/tests/test_async_certificate_enrollments.py
@@ -29,7 +29,6 @@ from create_x509_chain_crypto import (
 )
 
 
-pytestmark = pytest.mark.asyncio
 logging.basicConfig(level=logging.DEBUG)
 
 

--- a/tests/e2e/provisioning_e2e/tests/test_async_symmetric_enrollments.py
+++ b/tests/e2e/provisioning_e2e/tests/test_async_symmetric_enrollments.py
@@ -13,7 +13,7 @@ import logging
 import os
 import uuid
 
-pytestmark = pytest.mark.asyncio
+
 logging.basicConfig(level=logging.DEBUG)
 
 

--- a/tests/unit/common/test_async_adapter.py
+++ b/tests/unit/common/test_async_adapter.py
@@ -11,7 +11,6 @@ import logging
 import azure.iot.device.common.async_adapter as async_adapter
 
 logging.basicConfig(level=logging.DEBUG)
-pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture

--- a/tests/unit/common/test_http_transport.py
+++ b/tests/unit/common/test_http_transport.py
@@ -100,14 +100,13 @@ class TestInstantiation(object):
     )
     def test_configures_tls_context(self, mocker):
         mock_ssl_context_constructor = mocker.patch.object(ssl, "SSLContext")
-        mock_ssl_context = mock_ssl_context_constructor.return_value
 
         HTTPTransport(hostname=fake_hostname)
         # Verify correctness of TLS/SSL Context
         assert mock_ssl_context_constructor.call_count == 1
-        assert mock_ssl_context_constructor.call_args == mocker.call(protocol=ssl.PROTOCOL_TLSv1_2)
-        assert mock_ssl_context.check_hostname is True
-        assert mock_ssl_context.verify_mode == ssl.CERT_REQUIRED
+        assert mock_ssl_context_constructor.call_args == mocker.call(
+            protocol=ssl.PROTOCOL_TLS_CLIENT
+        )
 
     @pytest.mark.it(
         "Configures TLS/SSL context using default certificates if protocol wrapper not instantiated with a server verification certificate"

--- a/tests/unit/common/test_mqtt_transport.py
+++ b/tests/unit/common/test_mqtt_transport.py
@@ -267,9 +267,9 @@ class TestInstantiation(object):
 
         # Verify correctness of TLS/SSL Context
         assert mock_ssl_context_constructor.call_count == 1
-        assert mock_ssl_context_constructor.call_args == mocker.call(protocol=ssl.PROTOCOL_TLSv1_2)
-        assert mock_ssl_context.check_hostname is True
-        assert mock_ssl_context.verify_mode == ssl.CERT_REQUIRED
+        assert mock_ssl_context_constructor.call_args == mocker.call(
+            protocol=ssl.PROTOCOL_TLS_CLIENT
+        )
 
         # Verify context has been set
         assert mock_mqtt_client.tls_set_context.call_count == 1

--- a/tests/unit/iothub/aio/test_async_clients.py
+++ b/tests/unit/iothub/aio/test_async_clients.py
@@ -44,7 +44,6 @@ from ..shared_client_tests import (
     SharedIoTHubModuleClientCreateFromEdgeEnvironmentWithDebugEnvTests,
 )
 
-pytestmark = pytest.mark.asyncio
 logging.basicConfig(level=logging.DEBUG)
 
 

--- a/tests/unit/iothub/aio/test_async_handler_manager.py
+++ b/tests/unit/iothub/aio/test_async_handler_manager.py
@@ -16,7 +16,6 @@ from azure.iot.device.iothub.sync_handler_manager import MESSAGE, METHOD, TWIN_D
 from azure.iot.device.iothub.inbox_manager import InboxManager
 from azure.iot.device.iothub.aio.async_inbox import AsyncClientInbox
 
-pytestmark = pytest.mark.asyncio
 logging.basicConfig(level=logging.DEBUG)
 
 # NOTE ON TEST IMPLEMENTATION:

--- a/tests/unit/provisioning/aio/test_async_provisioning_device_client.py
+++ b/tests/unit/provisioning/aio/test_async_provisioning_device_client.py
@@ -20,7 +20,6 @@ from ..shared_client_tests import (
 
 
 logging.basicConfig(level=logging.DEBUG)
-pytestmark = pytest.mark.asyncio
 
 
 async def create_completed_future(result=None):


### PR DESCRIPTION
* Updated to modern versions of `pytest` and `pytest-asyncio`
* Removed the use of deprecated TLS specification in favor of negotiated
* Removed the use of deprecated UTC APIs in test infrastructure