### PR TITLE
fix: re-enable eventhub routing in CI

### DIFF
--- a/tests/e2e/iothub_e2e/aio/test_twin.py
+++ b/tests/e2e/iothub_e2e/aio/test_twin.py
@@ -18,7 +18,6 @@ reset_reported_props = {const.TEST_CONTENT: None}
 
 
 @pytest.mark.describe("Client Reported Properties")
-@pytest.mark.skip(reason="Disabling as tests are failing. Needs investigation.")
 class TestReportedProperties(object):
     @pytest.mark.it("Can set a simple reported property")
     @pytest.mark.quicktest_suite
@@ -116,7 +115,6 @@ class TestReportedProperties(object):
 @pytest.mark.dropped_connection
 @pytest.mark.describe("Client Reported Properties with dropped connection")
 @pytest.mark.keep_alive(5)
-@pytest.mark.skip(reason="Disabling as tests are failing. Needs investigation.")
 class TestReportedPropertiesDroppedConnection(object):
 
     # TODO: split drop tests between first and second patches

--- a/tests/e2e/iothub_e2e/sync/test_sync_twin.py
+++ b/tests/e2e/iothub_e2e/sync/test_sync_twin.py
@@ -22,7 +22,7 @@ reset_reported_props = {const.TEST_CONTENT: None}
 class TestReportedProperties(object):
     @pytest.mark.it("Can set a simple reported property")
     @pytest.mark.quicktest_suite
-    @pytest.mark.skip(reason="Disabling as tests are failing. Needs investigation.")
+    # @pytest.mark.skip(reason="Disabling as tests are failing. Needs investigation.")
     def test_sync_sends_simple_reported_patch(
         self, client, random_reported_props, service_helper, leak_tracker
     ):
@@ -56,7 +56,7 @@ class TestReportedProperties(object):
 
     @pytest.mark.it("Can clear a reported property")
     @pytest.mark.quicktest_suite
-    @pytest.mark.skip(reason="Disabling as tests are failing. Needs investigation.")
+    # @pytest.mark.skip(reason="Disabling as tests are failing. Needs investigation.")
     def test_sync_clear_property(self, client, random_reported_props, service_helper, leak_tracker):
         leak_tracker.set_initial_object_list()
 
@@ -82,7 +82,7 @@ class TestReportedProperties(object):
 
     @pytest.mark.it("Connects the transport if necessary")
     @pytest.mark.quicktest_suite
-    @pytest.mark.skip(reason="Disabling as tests are failing. Needs investigation.")
+    # @pytest.mark.skip(reason="Disabling as tests are failing. Needs investigation.")
     def test_sync_patch_reported_connect_if_necessary(
         self, client, random_reported_props, service_helper, leak_tracker
     ):

--- a/tests/e2e/iothub_e2e/sync/test_sync_twin.py
+++ b/tests/e2e/iothub_e2e/sync/test_sync_twin.py
@@ -22,7 +22,6 @@ reset_reported_props = {const.TEST_CONTENT: None}
 class TestReportedProperties(object):
     @pytest.mark.it("Can set a simple reported property")
     @pytest.mark.quicktest_suite
-    # @pytest.mark.skip(reason="Disabling as tests are failing. Needs investigation.")
     def test_sync_sends_simple_reported_patch(
         self, client, random_reported_props, service_helper, leak_tracker
     ):
@@ -56,7 +55,6 @@ class TestReportedProperties(object):
 
     @pytest.mark.it("Can clear a reported property")
     @pytest.mark.quicktest_suite
-    # @pytest.mark.skip(reason="Disabling as tests are failing. Needs investigation.")
     def test_sync_clear_property(self, client, random_reported_props, service_helper, leak_tracker):
         leak_tracker.set_initial_object_list()
 
@@ -82,7 +80,6 @@ class TestReportedProperties(object):
 
     @pytest.mark.it("Connects the transport if necessary")
     @pytest.mark.quicktest_suite
-    # @pytest.mark.skip(reason="Disabling as tests are failing. Needs investigation.")
     def test_sync_patch_reported_connect_if_necessary(
         self, client, random_reported_props, service_helper, leak_tracker
     ):
@@ -109,7 +106,6 @@ class TestReportedProperties(object):
 @pytest.mark.dropped_connection
 @pytest.mark.describe("Client Reported Properties with dropped connection")
 @pytest.mark.keep_alive(5)
-@pytest.mark.skip(reason="Disabling as tests are failing. Needs investigation.")
 class TestReportedPropertiesDroppedConnection(object):
 
     # TODO: split drop tests between first and second patches
@@ -176,7 +172,6 @@ class TestReportedPropertiesDroppedConnection(object):
 
 
 @pytest.mark.describe("Client Desired Properties")
-@pytest.mark.skip(reason="Disabling as tests are failing. Needs investigation.")
 class TestDesiredProperties(object):
     @pytest.mark.it("Receives a patch for a simple desired property")
     @pytest.mark.quicktest_suite

--- a/vsts/python-e2e.yaml
+++ b/vsts/python-e2e.yaml
@@ -40,6 +40,20 @@ stages:
               az iot hub consumer-group create -g "$AZURE_RESOURCE_GROUP" --hub-name "$AZURE_IOTHUB_NAME" --name "$cg_name"
           done
 
+          # Route twin change events to the built-in Event Hubs-compatible endpoint
+          # so reported-properties E2E tests can observe service-side patch arrivals.
+          az iot hub route create \
+            -g "$AZURE_RESOURCE_GROUP" \
+            --hub-name "$AZURE_IOTHUB_NAME" \
+            --route-name "twin-change-events" \
+            --endpoint-name "events" \
+            --source-type "twinchangeevents"
+
+          az iot hub route show \
+            -g "$AZURE_RESOURCE_GROUP" \
+            --hub-name "$AZURE_IOTHUB_NAME" \
+            --route-name "twin-change-events"
+
           # Export variables to other stages/jobs/steps.
           echo "##vso[task.setvariable variable=IOTHUB_CONNECTION_STRING;isOutput=true]$IOTHUB_CONNECTION_STRING"
           echo "##vso[task.setvariable variable=EVENTHUB_CONNECTION_STRING;isOutput=true]$EVENTHUB_CONNECTION_STRING"

--- a/vsts/python-nightly.yaml
+++ b/vsts/python-nightly.yaml
@@ -40,6 +40,20 @@ stages:
               az iot hub consumer-group create -g "$AZURE_RESOURCE_GROUP" --hub-name "$AZURE_IOTHUB_NAME" --name "$cg_name"
           done
 
+          # Route twin change events to the built-in Event Hubs-compatible endpoint
+          # so reported-properties E2E tests can observe service-side patch arrivals.
+          az iot hub route create \
+            -g "$AZURE_RESOURCE_GROUP" \
+            --hub-name "$AZURE_IOTHUB_NAME" \
+            --route-name "twin-change-events" \
+            --endpoint-name "events" \
+            --source-type "twinchangeevents"
+
+          az iot hub route show \
+            -g "$AZURE_RESOURCE_GROUP" \
+            --hub-name "$AZURE_IOTHUB_NAME" \
+            --route-name "twin-change-events"
+
           # Export variables to other stages/jobs/steps.
           echo "##vso[task.setvariable variable=IOTHUB_CONNECTION_STRING;isOutput=true]$IOTHUB_CONNECTION_STRING"
           echo "##vso[task.setvariable variable=EVENTHUB_CONNECTION_STRING;isOutput=true]$EVENTHUB_CONNECTION_STRING"


### PR DESCRIPTION
Added routing to the EventHubs used in CI.
This allows us to re-enable the failing twin tests which relied upon EventHub.