### PR TITLE
Add a dedicated CodeQL job for python and javascript

### DIFF
--- a/vsts/build.yaml
+++ b/vsts/build.yaml
@@ -1,7 +1,40 @@
 resources:
 - repo: self
+
+variables:
+  # CodeQL is auto-injected into every job by the 1ES policy decorator. Off by
+  # default so the python test matrix (5 parallel jobs) does not each build and
+  # upload a competing database -- S360 records arg_max(SnapshotDate) per
+  # (repo, language). The dedicated 'CodeQL' job below opts back in.
+  # See https://aka.ms/codeql3000 and https://aka.ms/sdlfaqcodeql.
+  Codeql.Enabled: false
+
 #Multi-configuration and multi-agent job options are not exported to YAML. Configure these options using documentation guidance: https://docs.microsoft.com/vsts/pipelines/process/phases
 jobs:
+
+# Owns the 'python' and 'javascript' CodeQL snapshots for this repo
+# (Microsoft.Security.CodeQL.10000). Both are interpreted languages, so CodeQL
+# extracts them straight from the checked-out sources and no build step is
+# needed between Init and Finalize. 'javascript' is graded because of
+# sdklab/meantimerecovery/aedes/aedes_server.js.
+- job: 'CodeQL'
+  displayName: 'CodeQL (python, javascript)'
+  variables:
+    # Only on main; this pipeline also runs on PRs, which need no snapshot.
+    Codeql.Enabled: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+    Codeql.Language: python,javascript
+  pool:
+    vmImage: 'ubuntu-24.04'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.x'
+      architecture: 'x64'
+  - task: CodeQL3000Init@0
+    displayName: 'Initialize CodeQL'
+  - task: CodeQL3000Finalize@0
+    displayName: 'Finalize CodeQL'
+    condition: always()
 
 - job: 'Static_Analysis'
   condition: false # Disabling this job since it is failing on recent runs. Must be re-enabled asap.

--- a/vsts/build.yaml
+++ b/vsts/build.yaml
@@ -19,8 +19,10 @@ jobs:
 # sdklab/meantimerecovery/aedes/aedes_server.js.
 - job: 'CodeQL'
   displayName: 'CodeQL (python, javascript)'
+  # Skip the job outright on PRs rather than only disabling the tasks, so PR runs
+  # do not pay for an agent, a checkout and a python install for nothing.
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   variables:
-    # Only on main; this pipeline also runs on PRs, which need no snapshot.
     Codeql.Enabled: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
     Codeql.Language: python,javascript
   pool:

--- a/vsts/horton-e2e.yaml
+++ b/vsts/horton-e2e.yaml
@@ -5,6 +5,11 @@ variables:
   Horton.Repo: $(Build.Repository.Uri)
   Horton.Commit: $(Build.SourceBranch)
   Horton.ForcedImage: ''
+  # This is an e2e gate, not the SDL scanning pipeline. Auto-injected CodeQL here
+  # produces incidental databases that displace the ones from the dedicated
+  # 'CodeQL' job in vsts/build.yaml, because S360 records arg_max(SnapshotDate)
+  # per (repo, language). See https://aka.ms/codeql3000.
+  Codeql.Enabled: false
 
 resources:
   repositories:

--- a/vsts/python-e2e.yaml
+++ b/vsts/python-e2e.yaml
@@ -1,5 +1,13 @@
 name: $(BuildID)_$(BuildDefinitionName)_$(SourceBranchName) 
 
+variables:
+  # E2E pipeline: it provisions an IoT Hub and runs tests, it does not build the
+  # product. Auto-injected CodeQL here produces incidental databases that
+  # displace the ones from the dedicated 'CodeQL' job in vsts/build.yaml,
+  # because S360 records arg_max(SnapshotDate) per (repo, language).
+  # See https://aka.ms/codeql3000.
+  Codeql.Enabled: false
+
 stages:
 - stage: setup
   jobs:

--- a/vsts/python-nightly.yaml
+++ b/vsts/python-nightly.yaml
@@ -62,6 +62,17 @@ stages:
 - stage: build_and_tests
   jobs:
   - job: 'Test'
+    # The Windows legs of this matrix run right up against Azure Pipelines' implicit
+    # 60-minute job timeout, so they get cancelled mid-run even though the suite
+    # itself passes. Measured in build 161689:
+    #   py39_windows_mqtt     60.4 min -> CANCELLED (pytest had already reported
+    #                                     "74 passed, 33 skipped" in 57:16)
+    #   py39_windows_mqttws   52.9 min -> passed, with only ~7 minutes of headroom
+    #   the seven linux legs  31.9 - 34.7 min
+    # Whichever Windows leg is slower on the day is the one that dies, which is why
+    # the failure appears to wander between py39_windows_mqtt and py39_windows_mqttws.
+    # Give the job a realistic budget instead.
+    timeoutInMinutes: 90
     variables:
       IOTHUB_CONNECTION_STRING: $[stageDependencies.setup.create_iot_hub_and_dps.outputs['createAzureResources.IOTHUB_CONNECTION_STRING']]
       EVENTHUB_CONNECTION_STRING: $[stageDependencies.setup.create_iot_hub_and_dps.outputs['createAzureResources.EVENTHUB_CONNECTION_STRING']]


### PR DESCRIPTION
Add a dedicated CodeQL job for python and javascript

S360 grades this repo on 'python' and 'javascript' for
Microsoft.Security.CodeQL.10000. Today both databases come from the central
CodeQL AutoBuilds service rather than from this repo's own pipelines, while the
auto-injected CodeQL in the e2e and horton pipelines uploads competing databases
from jobs that only provision Azure resources. S360 records
arg_max(SnapshotDate) per (repo, language), so whichever uploads last wins.

Add an explicit, cheap CodeQL job to vsts/build.yaml. Both languages are
interpreted, so CodeQL extracts them straight from the checked-out sources and
no build step is needed between Init and Finalize. ('javascript' is graded
because of sdklab/meantimerecovery/aedes/aedes_server.js.)

CodeQL is turned off at pipeline level so the five-way python test matrix does
not each build and upload a database, and off in vsts/python-e2e.yaml and
vsts/horton-e2e.yaml, which build nothing.

CodeQL is enabled only on main; these pipelines also run on PRs, which do not
need to produce a snapshot. CodeQL AutoBuilds remains as a backstop for periods
with no commits to main.
