### PR TITLE
fix: repair two nightly e2e failures (empty random property value, leak check race)

### DIFF
--- a/dev_utils/dev_utils/leak_tracker.py
+++ b/dev_utils/dev_utils/leak_tracker.py
@@ -177,20 +177,55 @@ class LeakTracker(object):
 
         return remaining_objects
 
-    def check_for_leaks(self):
+    def _remove_collected_objects(self, objects):
+        """
+        Return a new list with objects that have already been collected removed.
+
+        The leak list is built from a snapshot of the garbage collector, so an object can
+        be collected between the moment the snapshot is taken and the moment the leak is
+        reported.  Objects that we could not take a weak reference to are always kept
+        since there is no way to know whether they were collected.
+        """
+        return [obj for obj in objects if obj.weakref is None or obj.weakref() is not None]
+
+    def check_for_leaks(self, attempts=5, delay=5):
         """
         Get all tracked objects from the garbage collector.  If any objects remain, list
         them and assert so the test fails.
+
+        Objects that are still being used by the pipeline (or callback) threads when this
+        runs are transiently reachable and show up as false positives.  This happens, for
+        example, while a SAS token renewal is in flight, since the operations driving that
+        renewal are collected shortly after they complete.  To avoid failing on these
+        transients, the check is retried for a bounded amount of time, and a leak is only
+        reported if the objects are still alive at the end.
+
+        :param attempts: How many times to check before reporting a leak.
+        :param delay: How many seconds to wait between attempts.
         """
-        remaining_objects = self.get_leaks()
+        attempts = max(1, attempts)
 
-        if self.filter_callback:
-            remaining_objects = self.filter_callback(remaining_objects)
+        for attempt in range(attempts):
+            remaining_objects = self.get_leaks()
 
-        if len(remaining_objects):
-            self.dump_leak_report(remaining_objects)
-        else:
-            logger.info("No leaks")
+            if self.filter_callback:
+                remaining_objects = self.filter_callback(remaining_objects)
+
+            remaining_objects = self._remove_collected_objects(remaining_objects)
+
+            if not remaining_objects:
+                logger.info("No leaks")
+                return
+
+            if attempt < attempts - 1:
+                logger.info(
+                    "{} objects still allocated after attempt {} of {}. Waiting {} seconds to see if they get collected".format(
+                        len(remaining_objects), attempt + 1, attempts, delay
+                    )
+                )
+                time.sleep(delay)
+
+        self.dump_leak_report(remaining_objects)
 
     def dump_leak_report(self, leaked_objects):
         """

--- a/dev_utils/dev_utils/random_content.py
+++ b/dev_utils/dev_utils/random_content.py
@@ -13,7 +13,10 @@ JSON_CONTENT_ENCODING = "utf-8"
 
 def get_random_string(length, random_length=False):
     if random_length:
-        length = random.randint(0, length)
+        # The lower bound is 1 (unless `length` is 0) because callers use the returned
+        # value as a truthy sentinel (eg. `if not value:`). An empty string would silently
+        # be treated as "no value", which makes tests fail in ways that are hard to diagnose.
+        length = random.randint(min(1, length), length)
 
     return "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(length))
 

--- a/tests/e2e/iothub_e2e/aio/test_twin_stress.py
+++ b/tests/e2e/iothub_e2e/aio/test_twin_stress.py
@@ -53,8 +53,6 @@ class TestTwinStress(object):
         """
         leak_tracker.set_initial_object_list()
 
-        leak_tracker.set_initial_object_list()
-
         await call_with_retry(client, client.patch_twin_reported_properties, reset_reported_props)
 
         for i in range(iteration_count):
@@ -97,8 +95,6 @@ class TestTwinStress(object):
         with `batch_size` overlapped calls in a batch. Verify that the updates arrive
         at the service.
         """
-        leak_tracker.set_initial_object_list()
-
         leak_tracker.set_initial_object_list()
 
         await call_with_retry(client, client.patch_twin_reported_properties, reset_reported_props)
@@ -304,8 +300,6 @@ class TestTwinStress(object):
                 assert twin[const.REPORTED][const.TEST_CONTENT] == last_property_value
 
         assert last_property_value, "No patches with updated properties were received"
-
-        leak_tracker.check_for_leaks()
 
         leak_tracker.check_for_leaks()
 


### PR DESCRIPTION
## Summary

Nightly build [161728](https://dev.azure.com/azure-iot-sdks/azure-iot-sdks/_build/results?buildId=161728&view=results) (`python-nightly`, `main` @ `feffb9ec`) failed in two `mqttws` jobs, each for a different reason. This fixes both.

## 1. `py313_linux_mqttws` — `test_stress_serial_get_twin_calls`

```
>       assert last_property_value, "No patches with updated properties were received"
E       AssertionError: No patches with updated properties were received
E       assert ''
```

**Root cause:** `get_random_string(length, random_length=True)` used `random.randint(0, length)`, so it could return an empty string.

The twin stress tests use the generated value as a *truthy sentinel* — both `if not current_property_value:` and the closing `assert last_property_value`. When the empty value is generated on the final iteration, it round-trips fine but leaves `last_property_value == ''`, and the closing assert fails.

The build log confirms it exactly — iterations 0-8 matched normally, then iteration 9 logged `patching to ` (nothing) and:

```
TwinRequestResponseStage(PatchTwinReportedPropertiesOperation): Sending reported properties patch: {'testContent': ''}
```

**Fix:** the lower bound for a randomly sized string is now 1, so it is never empty. Passing an explicit length of `0` still returns `""`. `test_stress_parallel_get_twin_calls` depends on the same truthiness and is fixed by the same change.

## 2. `py39_windows_mqttws` — `test_sas_renewal`

`leak_tracker.check_for_leaks()` reported 2 leaked objects: `ConnectOperation` and `ReauthorizeConnectionOperation`.

**Root cause:** this is a snapshot race, not a real leak. The test uses `@pytest.mark.sastoken_ttl(130)` and the log shows the token renewing every ~10 seconds:

| time | event |
|---|---|
| 18:58:54 | renewal #1 |
| 18:59:04 | renewal #2 — the one the test asserts on ("Client reconnected") |
| | test sends a message and waits for the EventHub arrival (~10s) |
| 18:59:14 | **renewal #3** starts: new `ReauthorizeConnectionOperation` spawns a `ConnectOperation` |
| 18:59:15 | renewal #3 completes |
| 18:59:16 | `check_for_leaks()` runs and flags those 2 ops |

The leak report itself proves the objects were not leaked: it logged `not recursing` for **both** objects. That branch is `if not obj.get_object():`, and `get_object()` returns `self.weakref()` — so the weak references were already dead, meaning the objects had been garbage collected before the report was even generated.

**Fix:** `check_for_leaks` now retries for a bounded time and drops objects that have already been collected (`_remove_collected_objects`) before reporting. A leak is only reported if the objects are still alive at the end.

## 3. Drive-by cleanup

Removed three duplicated copy/paste statements in `test_twin_stress.py` (two repeated `set_initial_object_list()` calls and a repeated `check_for_leaks()`). The duplicated `check_for_leaks()` is in the very test that failed, and it matters more now that the check retries.

## Verification

- **`get_random_string`:** 200k samples of `get_random_string(100, True)` produce zero empty strings, lengths span 1..100. `get_random_string(16)` still returns exactly 16 chars; `get_random_string(0)` and `get_random_string(0, True)` both still return `""`.
- **Leak tracker** (synthetic tracked module):
  - no-leak path passes and returns on the first attempt without sleeping;
  - a real, persistent leak is **still reported**;
  - a transient object released after 2s passes with the retry, but is reported as a leak with `attempts=1` — confirming the retry is what fixes it;
  - `attempts=0`/negative no longer raise `UnboundLocalError` and still report real leaks.
- `flake8` (repo `.flake8`) clean and `black --check` (line-length 100) clean on all three files.
- All 6 tests in `test_twin_stress.py` now have exactly one `set_initial_object_list()` and one `check_for_leaks()`.

## Notes

Failure 1 is deterministic once the empty value lands on the last iteration (~1% per 10-iteration run, higher for the 50-iteration variants), which matches how intermittently it shows up in nightly. Failure 2 depends on where the leak check lands in the ~10s renewal cycle, which is why only one of the four `test_sas_renews` parametrizations failed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
