### PR TITLE
Initialize sync direct method test state

### DIFF
--- a/tests/e2e/iothub_e2e/sync/test_sync_methods.py
+++ b/tests/e2e/iothub_e2e/sync/test_sync_methods.py
@@ -38,6 +38,8 @@ class TestMethods(object):
     ):
         leak_tracker.set_initial_object_list()
 
+        actual_request = None
+
         if include_request_payload:
             request_payload = get_random_dict()
         else:


### PR DESCRIPTION
## Summary

Initialize the synchronous direct-method test's `actual_request` closure state before registering the callback. This aligns the sync test with its async counterpart and makes the expected callback-populated state explicit to static analysis.

This does not fix an observed SDK runtime bug. The later cleanup assignment already creates a valid enclosing binding for `nonlocal`, and the successful test path assigns the request in the callback before reading it. Without the initialization, a missing callback would leave the closure cell unbound and the assertion path could raise `UnboundLocalError`; with it, the state is explicitly `None` until the callback runs.

## Validation

- `python -m py_compile tests/e2e/iothub_e2e/sync/test_sync_methods.py`
- `ruff check --select F821 tests/e2e/iothub_e2e/sync/test_sync_methods.py`

The E2E module cannot be collected offline because its `conftest` performs hostname resolution and iptables setup during import.