### PR TITLE
fix: read sdklab connection string from environment

### DIFF
--- a/credscan_suppression.json
+++ b/credscan_suppression.json
@@ -40,6 +40,22 @@
     {
       "file": "\\tests\\unit\\iothub\\aio\\test_async_clients.py",
       "_justification": "Test containing fake signed data"
+    },
+    {
+      "file": "\\tests\\unit\\iothub\\pipeline\\test_pipeline_stages_iothub.py",
+      "_justification": "Test containing fake keys"
+    },
+    {
+      "file": "\\tests\\unit\\provisioning\\shared_client_tests.py",
+      "_justification": "Test containing fake keys"
+    },
+    {
+      "file": "\\tests\\unit\\provisioning\\pipeline\\test_pipeline_stages_provisioning.py",
+      "_justification": "Test containing fake keys"
+    },
+    {
+      "file": "\\tests\\unit\\common\\pipeline\\test_pipeline_stages_base.py",
+      "_justification": "Test containing fake signed data"
     }
   ]
 

--- a/sdklab/meantimerecovery/README.md
+++ b/sdklab/meantimerecovery/README.md
@@ -46,6 +46,18 @@ dead_duration : the amount of time the MQTT broker will be taken down for.
 
 Before running the the `mean_time_recover_with_docker.py` script make sure your docker engine is running.
 
+#### Connection string
+
+Both `mean_time_recover_with_docker.py` and `simple_send_message.py` read the device connection
+string from the `IOTHUB_DEVICE_CONNECTION_STRING` environment variable; neither script contains a
+connection string or key of its own. The local `aedes` broker does not verify the key, so any
+base64 value works, for example:
+
+`export IOTHUB_DEVICE_CONNECTION_STRING="HostName=localhost;DeviceId=devicemtr;SharedAccessKey=<base64 key>"`
+
+Use a throwaway value here. Never place a real IoT Hub device key in a shell history or a file
+that can be committed.
+
 #### Certificate creation
 
 There is another script which will create some self signed certificates for use in the `aedes` server.

--- a/sdklab/meantimerecovery/mean_time_recover_with_docker.py
+++ b/sdklab/meantimerecovery/mean_time_recover_with_docker.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 import docker
 import asyncio
+import os
 import uuid
 from azure.iot.device.aio import IoTHubDeviceClient
 from azure.iot.device import Message
@@ -140,7 +141,13 @@ async def main():
 
     # Do not delete sleep from here. Server needs some time to start.
     await asyncio.sleep(5)
-    conn_str = "HostName=localhost;DeviceId=devicemtr;SharedAccessKey=Zm9vYmFy"
+    conn_str = os.getenv("IOTHUB_DEVICE_CONNECTION_STRING")
+    if not conn_str:
+        raise RuntimeError(
+            "Set the IOTHUB_DEVICE_CONNECTION_STRING environment variable to the connection "
+            "string of the device used against the local test broker, e.g. "
+            "HostName=localhost;DeviceId=devicemtr;SharedAccessKey=<base64 key>"
+        )
     device_client = IoTHubDeviceClient.create_from_connection_string(
         conn_str, keep_alive=KEEP_ALIVE, server_verification_cert=root_ca_cert
     )

--- a/sdklab/meantimerecovery/mean_time_recover_with_docker.py
+++ b/sdklab/meantimerecovery/mean_time_recover_with_docker.py
@@ -125,6 +125,14 @@ def start_timer(duration, restart_count, signal_to_quit):
 
 async def main():
 
+    conn_str = os.getenv("IOTHUB_DEVICE_CONNECTION_STRING")
+    if not conn_str:
+        raise RuntimeError(
+            "Set the IOTHUB_DEVICE_CONNECTION_STRING environment variable to the connection "
+            "string of the device used against the local test broker, e.g. "
+            "HostName=localhost;DeviceId=devicemtr;SharedAccessKey=<base64 key>"
+        )
+
     ca_cert = "self_cert_localhost.pem"
     certfile = open(ca_cert)
     root_ca_cert = certfile.read()
@@ -141,13 +149,6 @@ async def main():
 
     # Do not delete sleep from here. Server needs some time to start.
     await asyncio.sleep(5)
-    conn_str = os.getenv("IOTHUB_DEVICE_CONNECTION_STRING")
-    if not conn_str:
-        raise RuntimeError(
-            "Set the IOTHUB_DEVICE_CONNECTION_STRING environment variable to the connection "
-            "string of the device used against the local test broker, e.g. "
-            "HostName=localhost;DeviceId=devicemtr;SharedAccessKey=<base64 key>"
-        )
     device_client = IoTHubDeviceClient.create_from_connection_string(
         conn_str, keep_alive=KEEP_ALIVE, server_verification_cert=root_ca_cert
     )

--- a/sdklab/meantimerecovery/simple_send_message.py
+++ b/sdklab/meantimerecovery/simple_send_message.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 import asyncio
+import os
 import uuid
 from azure.iot.device.aio import IoTHubDeviceClient
 from azure.iot.device import Message
@@ -41,7 +42,13 @@ async def main():
     # Scenario based values
     keep_alive = 15
 
-    conn_str = "HostName=localhost;DeviceId=devicemtr;SharedAccessKey=Zm9vYmFy"
+    conn_str = os.getenv("IOTHUB_DEVICE_CONNECTION_STRING")
+    if not conn_str:
+        raise RuntimeError(
+            "Set the IOTHUB_DEVICE_CONNECTION_STRING environment variable to the connection "
+            "string of the device used against the local test broker, e.g. "
+            "HostName=localhost;DeviceId=devicemtr;SharedAccessKey=<base64 key>"
+        )
     device_client = IoTHubDeviceClient.create_from_connection_string(
         conn_str, keep_alive=keep_alive
     )


### PR DESCRIPTION
## What the report claims

"Hardcoded symmetric key exposure enables device impersonation" in this repository.

## What is actually here

**No live credential exists in this repo.** I scanned the whole `main` tree and all 625 commits of history (`main` is the only branch; HEAD was `0d271b3` at the time of the scan) for base64 key literals, `SharedAccessKey=` connection strings and `symmetric_key=` literal assignments. Every hit is synthetic:

- `sdklab/meantimerecovery/simple_send_message.py` and `sdklab/meantimerecovery/mean_time_recover_with_docker.py` each contained
  `conn_str = "HostName=localhost;DeviceId=devicemtr;SharedAccessKey=Zm9vYmFy"`.
  `Zm9vYmFy` is base64 for the string `foobar`, and the host is `localhost` — the local `aedes` test broker, which does not verify the key. **This is almost certainly what the reporter saw.**
- The unit tests use the same `Zm9vYmFy` fake plus fixed fake signatures such as `ajsc8nLKacIjGsYyB4iYDFCZaRMmmDrUuY5lncYDYPI=`.
- The DPS samples (`samples/sync-samples/provision_symmetric_key*.py`, `samples/async-hub-scenarios/*`) already read the key from `PROVISIONING_SYMMETRIC_KEY`, and the group sample already warns not to store the group master key on the device.

So there is no key to revoke and no device-impersonation path originating from this repository. This PR removes the pattern that triggers the finding rather than fixing an exploitable bug.

## Changes

- Both `sdklab/meantimerecovery` scripts now read `IOTHUB_DEVICE_CONNECTION_STRING` from the environment — the convention the samples already use — and raise a clear `RuntimeError` when it is unset. No connection-string literal remains in either file.
- `sdklab/meantimerecovery/README.md` documents the new variable and warns against using a real device key.
- `credscan_suppression.json` is extended to cover the four remaining unit-test files that legitimately hold fake keys and fake signed data, so a clean scan does not need re-triage each run:
  - `tests/unit/provisioning/shared_client_tests.py`
  - `tests/unit/provisioning/pipeline/test_pipeline_stages_provisioning.py`
  - `tests/unit/iothub/pipeline/test_pipeline_stages_iothub.py`
  - `tests/unit/common/pipeline/test_pipeline_stages_base.py`

4 files, +44/-2. **No product code is touched** — only the `sdklab` lab scripts, their README, and the scan-suppression list.

## Caveats for the reviewer

- The ICM incident was not readable from my environment, so the file the reporter cited is *inferred* from the scan, not confirmed. If the incident names something else, please reopen.
- `GET /repos/Azure/azure-iot-sdk-python/secret-scanning/alerts` returned 404 for my token. GitHub returns 404 rather than 403 for endpoints a token cannot see, so this means my token lacks the security-alert read permission — **not** that there are no alerts. Someone with that access should confirm independently.
- I could not run `black`/`flake8` or `py_compile`: there is no Python interpreter in my container and no root to install one. The changes are hand-checked against the repo's black config (`line-length = 100`) and no changed line exceeds it. Please let CI confirm.
- Related: MSRC 136327 (ADO 39301920) tracks the equivalent "Hardcoded DPS enrollment key in public repo" report against `azure-iot-sdk-csharp`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
