### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/issuelabeler.yml
+++ b/.github/workflows/issuelabeler.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: Naturalclar/issue-action@v1.0.0
+      - uses: Naturalclar/issue-action@596dfb92b8ba81449d4b3a0f34e9d3d279fab330 # v1.0.0
         with:
           keywords: '[""]'
           labels: '["IoTSDK"]'


### PR DESCRIPTION
## Summary

- pin `Naturalclar/issue-action@v1.0.0` to its full-length commit SHA
- add weekly grouped Dependabot updates for GitHub Actions
- apply a 7-day Dependabot cooldown for newly released action versions

## Why

Pinning Actions to immutable SHAs improves CI supply-chain security and reproducibility. The cooldown provides time for compromised releases to be detected before Dependabot proposes them.

This reproduces the changes from #1247 on an internal branch so trusted CI can run. Credit to @danfiedler-msft for the original contribution.

## Validation

- verified both changed YAML files parse successfully
- verified `596dfb92b8ba81449d4b3a0f34e9d3d279fab330` is the commit referenced by `Naturalclar/issue-action` tag `v1.0.0`
- verified the copied tree exactly matched the source commit from #1247