### PR TITLE
chore: Additional CI configuration

### DIFF
--- a/devbox_setup.md
+++ b/devbox_setup.md
@@ -21,7 +21,7 @@ uv run pre-commit install
 
 `uv sync` installs the SDK and all development dependency groups into `.venv`. Source changes are immediately reflected because the SDK and `dev_utils` are installed editably.
 
-The checked-in `uv.lock` provides a reproducible contributor environment. CI deliberately resolves an upgraded lockfile before caching, then runs `uv sync --locked` so the library is tested against the newest compatible dependencies without changing the cache key during a job.
+The checked-in `uv.lock` provides a reproducible contributor environment. Cached Azure Pipelines E2E jobs deliberately resolve an upgraded lockfile before caching, then run `uv sync --locked` so the library is tested against the newest compatible dependencies without changing the cache key during a job.
 
 Common commands:
 

--- a/devbox_setup.md
+++ b/devbox_setup.md
@@ -21,7 +21,7 @@ uv run pre-commit install
 
 `uv sync` installs the SDK and all development dependency groups into `.venv`. Source changes are immediately reflected because the SDK and `dev_utils` are installed editably.
 
-The checked-in `uv.lock` provides a reproducible contributor environment. CI deliberately runs `uv sync --upgrade` so the library is also tested against the newest compatible dependencies.
+The checked-in `uv.lock` provides a reproducible contributor environment. CI deliberately resolves an upgraded lockfile before caching, then runs `uv sync --locked` so the library is tested against the newest compatible dependencies without changing the cache key during a job.
 
 Common commands:
 

--- a/vsts/build.yaml
+++ b/vsts/build.yaml
@@ -4,6 +4,7 @@ trigger:
     - main
 
 pr:
+  autoCancel: true
   branches:
     include:
     - main

--- a/vsts/build.yaml
+++ b/vsts/build.yaml
@@ -7,7 +7,7 @@ pr:
   autoCancel: true
   branches:
     include:
-    - main
+    - '*'
 
 resources:
 - repo: self

--- a/vsts/dps-e2e.yaml
+++ b/vsts/dps-e2e.yaml
@@ -4,6 +4,7 @@ trigger:
     - main
 
 pr:
+  autoCancel: true
   branches:
     include:
     - main

--- a/vsts/dps-e2e.yaml
+++ b/vsts/dps-e2e.yaml
@@ -287,6 +287,13 @@ stages:
         versionSpec: '3.10'
         architecture: 'x64'
 
+    - script: 'python -m pip install uv'
+      displayName: 'Install uv'
+
+    # Resolve upgrades before Cache@2 hashes uv.lock so its save key stays stable.
+    - script: 'uv lock --upgrade --python 3.10 --no-cache'
+      displayName: 'Resolve latest dependencies'
+
     # Cache downloads without reusing the job environment.
     - task: Cache@2
       displayName: 'Cache uv'
@@ -297,10 +304,7 @@ stages:
           "uv" | "$(Agent.OS)"
         path: $(Pipeline.Workspace)/.uv-cache
 
-    - script: 'python -m pip install uv'
-      displayName: 'Install uv'
-
-    - script: 'uv sync --upgrade --python 3.10 --no-dev --group test --group e2e'
+    - script: 'uv sync --locked --python 3.10 --no-dev --group test --group e2e'
       displayName: 'Sync E2E environment'
       env:
         UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache

--- a/vsts/dps-e2e.yaml
+++ b/vsts/dps-e2e.yaml
@@ -7,7 +7,7 @@ pr:
   autoCancel: true
   branches:
     include:
-    - main
+    - '*'
 
 resources:
 - repo: self

--- a/vsts/horton-e2e.yaml
+++ b/vsts/horton-e2e.yaml
@@ -4,6 +4,7 @@ trigger:
     - main
 
 pr:
+  autoCancel: true
   branches:
     include:
     - main

--- a/vsts/horton-e2e.yaml
+++ b/vsts/horton-e2e.yaml
@@ -7,7 +7,7 @@ pr:
   autoCancel: true
   branches:
     include:
-    - main
+    - '*'
 
 variables:
   Horton.FrameworkRoot: $(Agent.BuildDirectory)/e2e-fx

--- a/vsts/python-canary.yaml
+++ b/vsts/python-canary.yaml
@@ -52,6 +52,13 @@ jobs:
         versionSpec: $(pv)
         architecture: 'x64'
 
+    - script: 'python -m pip install uv'
+      displayName: 'Install uv'
+
+    # Resolve upgrades before Cache@2 hashes uv.lock so its save key stays stable.
+    - script: 'uv lock --upgrade --python "$(pv)" --no-cache'
+      displayName: 'Resolve latest dependencies'
+
     # Cache downloads without reusing the job environment.
     - task: Cache@2
       displayName: 'Cache uv'
@@ -62,10 +69,7 @@ jobs:
           "uv" | "$(Agent.OS)"
         path: $(Pipeline.Workspace)/.uv-cache
 
-    - script: 'python -m pip install uv'
-      displayName: 'Install uv'
-
-    - script: 'uv sync --upgrade --python "$(pv)" --no-dev --group test --group e2e'
+    - script: 'uv sync --locked --python "$(pv)" --no-dev --group test --group e2e'
       displayName: 'Sync E2E environment'
       env:
         UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache
@@ -84,4 +88,3 @@ jobs:
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
       condition: always()
-

--- a/vsts/python-e2e.yaml
+++ b/vsts/python-e2e.yaml
@@ -4,6 +4,7 @@ trigger:
     - main
 
 pr:
+  autoCancel: true
   branches:
     include:
     - main

--- a/vsts/python-e2e.yaml
+++ b/vsts/python-e2e.yaml
@@ -7,7 +7,7 @@ pr:
   autoCancel: true
   branches:
     include:
-    - main
+    - '*'
 
 name: $(BuildID)_$(BuildDefinitionName)_$(SourceBranchName) 
 

--- a/vsts/python-e2e.yaml
+++ b/vsts/python-e2e.yaml
@@ -114,6 +114,13 @@ stages:
           versionSpec: $(pv)
           architecture: 'x64'
 
+      - script: 'python -m pip install uv'
+        displayName: 'Install uv'
+
+      # Resolve upgrades before Cache@2 hashes uv.lock so its save key stays stable.
+      - script: 'uv lock --upgrade --python "$(pv)" --no-cache'
+        displayName: 'Resolve latest dependencies'
+
       # Cache downloads without reusing the job environment.
       - task: Cache@2
         displayName: 'Cache uv'
@@ -124,10 +131,7 @@ stages:
             "uv" | "$(Agent.OS)"
           path: $(Pipeline.Workspace)/.uv-cache
 
-      - script: 'python -m pip install uv'
-        displayName: 'Install uv'
-
-      - script: 'uv sync --upgrade --python "$(pv)" --no-dev --group test --group e2e'
+      - script: 'uv sync --locked --python "$(pv)" --no-dev --group test --group e2e'
         displayName: 'Sync E2E environment'
         env:
           UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache
@@ -165,6 +169,13 @@ stages:
           versionSpec: $(pv)
           architecture: 'x64'
 
+      - script: 'python -m pip install uv'
+        displayName: 'Install uv'
+
+      # Resolve upgrades before Cache@2 hashes uv.lock so its save key stays stable.
+      - script: 'uv lock --upgrade --python "$(pv)" --no-cache'
+        displayName: 'Resolve latest dependencies'
+
       # Cache downloads without reusing the job environment.
       - task: Cache@2
         displayName: 'Cache uv'
@@ -175,10 +186,7 @@ stages:
             "uv" | "$(Agent.OS)"
           path: $(Pipeline.Workspace)/.uv-cache
 
-      - script: 'python -m pip install uv'
-        displayName: 'Install uv'
-
-      - script: 'uv sync --upgrade --python "$(pv)" --no-dev --group test --group e2e'
+      - script: 'uv sync --locked --python "$(pv)" --no-dev --group test --group e2e'
         displayName: 'Sync E2E environment'
         env:
           UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache

--- a/vsts/python-nightly.yaml
+++ b/vsts/python-nightly.yaml
@@ -165,6 +165,14 @@ stages:
           versionSpec: $(pv)
           architecture: 'x64'
           addToPath: true
+
+      - script: 'python -m pip install uv'
+        displayName: 'Install uv'
+
+      # Resolve upgrades before Cache@2 hashes uv.lock so its save key stays stable.
+      - script: 'uv lock --upgrade --python "$(pv)" --no-cache'
+        displayName: 'Resolve latest dependencies'
+
       # Cache downloads without reusing the job environment.
       - task: Cache@2
         displayName: 'Cache uv'
@@ -174,10 +182,8 @@ stages:
             "uv" | "$(Agent.OS)" | "$(pv)"
             "uv" | "$(Agent.OS)"
           path: $(Pipeline.Workspace)/.uv-cache
-      - script: 'python -m pip install uv'
-        displayName: 'Install uv'
 
-      - script: 'uv sync --upgrade --python "$(pv)" --no-dev --group test --group e2e'
+      - script: 'uv sync --locked --python "$(pv)" --no-dev --group test --group e2e'
         displayName: 'Sync E2E environment'
         env:
           UV_CACHE_DIR: $(Pipeline.Workspace)/.uv-cache


### PR DESCRIPTION
## Summary

- stabilize ADO `uv` cache keys by resolving dependency upgrades before `Cache@2` hashes `uv.lock`
- cancel superseded PR pipeline runs when a newer commit is pushed
- run all active ADO validation pipelines for stacked PRs targeting feature branches, while keeping push CI limited to `main`

## Details

The upgraded lockfile is now resolved without populating the download cache, then `Cache@2` restores the cache using the final lock hash and `uv sync --locked` installs from it. This preserves testing against newest compatible dependencies without changing the cache key between restore and save.

Build, DPS E2E, Python E2E, and Horton E2E now explicitly set `pr.autoCancel: true` and accept every PR target branch. GitHub Actions already has equivalent per-PR cancellation and an unrestricted `pull_request` trigger.

## Validation

- parsed all modified ADO YAML files
- mechanically verified install -> lock upgrade -> cache restore -> locked sync ordering in every cached job
- reproduced the reported pre/post lock hash change locally and verified `uv sync --locked` preserves the resolved hash
- verified push triggers remain restricted to `main`
- verified all four active ADO PR triggers use `autoCancel: true` and accept `'*'` target branches
