### PR TITLE
tests: replace timing sleeps with condition-based waits

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,8 @@ import pytest
 
 
 @pytest.fixture
-def wait_for():
-    def wait_for_condition(condition, timeout=5, interval=0.01):
+def poll_until():
+    def poll_until_condition(condition, timeout=5, interval=0.01):
         deadline = time.monotonic() + timeout
         while not condition():
             remaining = deadline - time.monotonic()
@@ -22,12 +22,12 @@ def wait_for():
                 pytest.fail("Timed out waiting for condition")
             time.sleep(min(interval, remaining))
 
-    return wait_for_condition
+    return poll_until_condition
 
 
 @pytest.fixture
-def async_wait_for():
-    async def wait_for_condition(condition, timeout=5, interval=0.01):
+def async_poll_until():
+    async def poll_until_condition(condition, timeout=5, interval=0.01):
         async def poll_condition():
             while not condition():
                 await asyncio.sleep(interval)
@@ -37,7 +37,7 @@ def async_wait_for():
         except asyncio.TimeoutError:
             pytest.fail("Timed out waiting for condition")
 
-    return wait_for_condition
+    return poll_until_condition
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ import pytest
 def poll_until():
     """Return a helper that polls a condition without exceeding a timeout."""
 
-    def poll_until_condition(condition, timeout=5, interval=0.01):
+    def poll_until_condition(condition, *, timeout, interval=0.01):
         deadline = time.monotonic() + timeout
         while not condition():
             remaining = deadline - time.monotonic()
@@ -31,7 +31,7 @@ def poll_until():
 def async_poll_until():
     """Return an async helper that polls a condition without blocking the event loop."""
 
-    async def poll_until_condition(condition, timeout=5, interval=0.01):
+    async def poll_until_condition(condition, *, timeout, interval=0.01):
         async def poll_condition():
             while not condition():
                 await asyncio.sleep(interval)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,54 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import asyncio
+import threading
+import time
+
 import pytest
+
+
+@pytest.fixture
+def wait_for():
+    def wait_for_condition(condition, timeout=5, interval=0.01):
+        deadline = time.monotonic() + timeout
+        while not condition():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                pytest.fail("Timed out waiting for condition")
+            time.sleep(min(interval, remaining))
+
+    return wait_for_condition
+
+
+@pytest.fixture
+def async_wait_for():
+    async def wait_for_condition(condition, timeout=5, interval=0.01):
+        deadline = time.monotonic() + timeout
+        while not condition():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                pytest.fail("Timed out waiting for condition")
+            await asyncio.sleep(min(interval, remaining))
+
+    return wait_for_condition
+
+
+@pytest.fixture
+def track_call_started(mocker):
+    def track_call(obj, method_name):
+        call_started = threading.Event()
+        original_method = getattr(obj, method_name)
+
+        def tracked_call(*args, **kwargs):
+            call_started.set()
+            return original_method(*args, **kwargs)
+
+        mocker.patch.object(obj, method_name, side_effect=tracked_call)
+        return call_started
+
+    return track_call
+
 
 """
 NOTE: ALL (yes, ALL) tests need some kind of non-specific, arbitrary exception should use

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 
 import asyncio
+import concurrent.futures
 import threading
 import time
 
@@ -51,6 +52,27 @@ def track_call_started(mocker):
         return call_started
 
     return track_call
+
+
+@pytest.fixture
+def run_in_daemon_thread():
+    def run(fn, *args, **kwargs):
+        future = concurrent.futures.Future()
+
+        def invoke():
+            if not future.set_running_or_notify_cancel():
+                return
+            try:
+                result = fn(*args, **kwargs)
+            except BaseException as e:
+                future.set_exception(e)
+            else:
+                future.set_result(result)
+
+        threading.Thread(target=invoke, daemon=True).start()
+        return future
+
+    return run
 
 
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,24 +45,6 @@ def async_poll_until():
 
 
 @pytest.fixture
-def track_call_started(mocker):
-    """Return a helper that signals when a method invocation begins."""
-
-    def track_call(obj, method_name):
-        call_started = threading.Event()
-        original_method = getattr(obj, method_name)
-
-        def tracked_call(*args, **kwargs):
-            call_started.set()
-            return original_method(*args, **kwargs)
-
-        mocker.patch.object(obj, method_name, side_effect=tracked_call)
-        return call_started
-
-    return track_call
-
-
-@pytest.fixture
 def run_in_daemon_thread():
     """Return a helper that runs a function in a daemon thread and exposes its result."""
 
@@ -83,6 +65,29 @@ def run_in_daemon_thread():
         return future
 
     return run
+
+
+@pytest.fixture
+def assert_call_blocks(mocker, run_in_daemon_thread):
+    """Return a helper that verifies a call blocks until an action releases it."""
+
+    def assert_blocks(fn, *, blocked_on, release, args=(), kwargs=None, timeout=5):
+        call_started = threading.Event()
+
+        def tracked_call(*args, **kwargs):
+            call_started.set()
+            return blocked_on(*args, **kwargs)
+
+        mocker.patch.object(blocked_on.__self__, blocked_on.__name__, side_effect=tracked_call)
+        future = run_in_daemon_thread(fn, *args, **(kwargs or {}))
+        try:
+            assert call_started.wait(timeout=timeout)
+            assert not future.done()
+        finally:
+            release()
+        return future.result(timeout=timeout)
+
+    return assert_blocks
 
 
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,12 +28,14 @@ def wait_for():
 @pytest.fixture
 def async_wait_for():
     async def wait_for_condition(condition, timeout=5, interval=0.01):
-        deadline = time.monotonic() + timeout
-        while not condition():
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                pytest.fail("Timed out waiting for condition")
-            await asyncio.sleep(min(interval, remaining))
+        async def poll_condition():
+            while not condition():
+                await asyncio.sleep(interval)
+
+        try:
+            await asyncio.wait_for(poll_condition(), timeout=timeout)
+        except asyncio.TimeoutError:
+            pytest.fail("Timed out waiting for condition")
 
     return wait_for_condition
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ import pytest
 
 @pytest.fixture
 def poll_until():
+    """Return a helper that polls a condition without exceeding a timeout."""
+
     def poll_until_condition(condition, timeout=5, interval=0.01):
         deadline = time.monotonic() + timeout
         while not condition():
@@ -27,6 +29,8 @@ def poll_until():
 
 @pytest.fixture
 def async_poll_until():
+    """Return an async helper that polls a condition without blocking the event loop."""
+
     async def poll_until_condition(condition, timeout=5, interval=0.01):
         async def poll_condition():
             while not condition():
@@ -42,6 +46,8 @@ def async_poll_until():
 
 @pytest.fixture
 def track_call_started(mocker):
+    """Return a helper that signals when a method invocation begins."""
+
     def track_call(obj, method_name):
         call_started = threading.Event()
         original_method = getattr(obj, method_name)
@@ -58,6 +64,8 @@ def track_call_started(mocker):
 
 @pytest.fixture
 def run_in_daemon_thread():
+    """Return a helper that runs a function in a daemon thread and exposes its result."""
+
     def run(fn, *args, **kwargs):
         future = concurrent.futures.Future()
 

--- a/tests/unit/common/pipeline/test_pipeline_stages_base.py
+++ b/tests/unit/common/pipeline/test_pipeline_stages_base.py
@@ -187,6 +187,7 @@ class TestPipelineRootStageHandlePipelineEventWithConnectedEvent(
         mock_handler = mocker.MagicMock()
         stage.on_connected_handler = mock_handler
         stage.handle_pipeline_event(event)
+        # Wait for the handler invocation to complete
         poll_until(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
@@ -207,6 +208,7 @@ class TestPipelineRootStageHandlePipelineEventWithDisconnectedEvent(
         mock_handler = mocker.MagicMock()
         stage.on_disconnected_handler = mock_handler
         stage.handle_pipeline_event(event)
+        # Wait for the handler invocation to complete
         poll_until(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
@@ -227,6 +229,7 @@ class TestPipelineRootStageHandlePipelineEventWithNewSasTokenRequiredEvent(
         mock_handler = mocker.MagicMock()
         stage.on_new_sastoken_required_handler = mock_handler
         stage.handle_pipeline_event(event)
+        # Wait for the handler invocation to complete
         poll_until(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
@@ -249,6 +252,7 @@ class TestPipelineRootStageHandlePipelineEventWithBackgroundExceptionEvent(
         mock_handler = mocker.MagicMock()
         stage.on_background_exception_handler = mock_handler
         stage.handle_pipeline_event(event)
+        # Wait for the handler invocation to complete
         poll_until(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(event.e)
@@ -269,6 +273,7 @@ class TestPipelineRootStageHandlePipelineEventWithArbitraryEvent(
         mock_handler = mocker.MagicMock()
         stage.on_pipeline_event_handler = mock_handler
         stage.handle_pipeline_event(event)
+        # Wait for the handler invocation to complete
         poll_until(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(event)

--- a/tests/unit/common/pipeline/test_pipeline_stages_base.py
+++ b/tests/unit/common/pipeline/test_pipeline_stages_base.py
@@ -27,6 +27,7 @@ from azure.iot.device.common.pipeline.pipeline_nucleus import ConnectionState
 from .helpers import StageRunOpTestBase, StageHandlePipelineEventTestBase
 from .fixtures import ArbitraryOperation
 from tests.unit.common.pipeline import pipeline_stage_test
+from tests.unit.helpers import PROMPT_TIMEOUT
 
 this_module = sys.modules[__name__]
 logging.basicConfig(level=logging.DEBUG)
@@ -188,7 +189,7 @@ class TestPipelineRootStageHandlePipelineEventWithConnectedEvent(
         stage.on_connected_handler = mock_handler
         stage.handle_pipeline_event(event)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=PROMPT_TIMEOUT)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
@@ -209,7 +210,7 @@ class TestPipelineRootStageHandlePipelineEventWithDisconnectedEvent(
         stage.on_disconnected_handler = mock_handler
         stage.handle_pipeline_event(event)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=PROMPT_TIMEOUT)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
@@ -230,7 +231,7 @@ class TestPipelineRootStageHandlePipelineEventWithNewSasTokenRequiredEvent(
         stage.on_new_sastoken_required_handler = mock_handler
         stage.handle_pipeline_event(event)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=PROMPT_TIMEOUT)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
@@ -253,7 +254,7 @@ class TestPipelineRootStageHandlePipelineEventWithBackgroundExceptionEvent(
         stage.on_background_exception_handler = mock_handler
         stage.handle_pipeline_event(event)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=PROMPT_TIMEOUT)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(event.e)
 
@@ -274,7 +275,7 @@ class TestPipelineRootStageHandlePipelineEventWithArbitraryEvent(
         stage.on_pipeline_event_handler = mock_handler
         stage.handle_pipeline_event(event)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=PROMPT_TIMEOUT)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(event)
 

--- a/tests/unit/common/pipeline/test_pipeline_stages_base.py
+++ b/tests/unit/common/pipeline/test_pipeline_stages_base.py
@@ -183,11 +183,11 @@ class TestPipelineRootStageHandlePipelineEventWithConnectedEvent(
         return pipeline_events_base.ConnectedEvent()
 
     @pytest.mark.it("Invokes the 'on_connected_handler' handler function, if set")
-    def test_invoke_handler(self, mocker, stage, event, wait_for):
+    def test_invoke_handler(self, mocker, stage, event, poll_until):
         mock_handler = mocker.MagicMock()
         stage.on_connected_handler = mock_handler
         stage.handle_pipeline_event(event)
-        wait_for(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
@@ -203,11 +203,11 @@ class TestPipelineRootStageHandlePipelineEventWithDisconnectedEvent(
         return pipeline_events_base.DisconnectedEvent()
 
     @pytest.mark.it("Invokes the 'on_disconnected_handler' handler function, if set")
-    def test_invoke_handler(self, mocker, stage, event, wait_for):
+    def test_invoke_handler(self, mocker, stage, event, poll_until):
         mock_handler = mocker.MagicMock()
         stage.on_disconnected_handler = mock_handler
         stage.handle_pipeline_event(event)
-        wait_for(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
@@ -223,11 +223,11 @@ class TestPipelineRootStageHandlePipelineEventWithNewSasTokenRequiredEvent(
         return pipeline_events_base.NewSasTokenRequiredEvent()
 
     @pytest.mark.it("Invokes the 'on_new_sastoken_required_handler' handler function, if set")
-    def test_invoke_handler(self, mocker, stage, event, wait_for):
+    def test_invoke_handler(self, mocker, stage, event, poll_until):
         mock_handler = mocker.MagicMock()
         stage.on_new_sastoken_required_handler = mock_handler
         stage.handle_pipeline_event(event)
-        wait_for(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
@@ -245,11 +245,11 @@ class TestPipelineRootStageHandlePipelineEventWithBackgroundExceptionEvent(
     @pytest.mark.it(
         "Invokes the 'on_background_exception_handler' handler function, passing the exception object, if set"
     )
-    def test_invoke_handler(self, mocker, stage, event, wait_for):
+    def test_invoke_handler(self, mocker, stage, event, poll_until):
         mock_handler = mocker.MagicMock()
         stage.on_background_exception_handler = mock_handler
         stage.handle_pipeline_event(event)
-        wait_for(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(event.e)
 
@@ -265,11 +265,11 @@ class TestPipelineRootStageHandlePipelineEventWithArbitraryEvent(
         return arbitrary_event
 
     @pytest.mark.it("Invokes the 'on_pipeline_event_handler' handler function, if set")
-    def test_invoke_handler(self, mocker, stage, event, wait_for):
+    def test_invoke_handler(self, mocker, stage, event, poll_until):
         mock_handler = mocker.MagicMock()
         stage.on_pipeline_event_handler = mock_handler
         stage.handle_pipeline_event(event)
-        wait_for(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(event)
 

--- a/tests/unit/common/pipeline/test_pipeline_stages_base.py
+++ b/tests/unit/common/pipeline/test_pipeline_stages_base.py
@@ -28,7 +28,6 @@ from .helpers import StageRunOpTestBase, StageHandlePipelineEventTestBase
 from .fixtures import ArbitraryOperation
 from tests.unit.common.pipeline import pipeline_stage_test
 
-
 this_module = sys.modules[__name__]
 logging.basicConfig(level=logging.DEBUG)
 pytestmark = pytest.mark.usefixtures("fake_pipeline_thread")
@@ -184,11 +183,11 @@ class TestPipelineRootStageHandlePipelineEventWithConnectedEvent(
         return pipeline_events_base.ConnectedEvent()
 
     @pytest.mark.it("Invokes the 'on_connected_handler' handler function, if set")
-    def test_invoke_handler(self, mocker, stage, event):
+    def test_invoke_handler(self, mocker, stage, event, wait_for):
         mock_handler = mocker.MagicMock()
         stage.on_connected_handler = mock_handler
         stage.handle_pipeline_event(event)
-        time.sleep(0.1)  # Needs a brief sleep so thread can switch
+        wait_for(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
@@ -204,11 +203,11 @@ class TestPipelineRootStageHandlePipelineEventWithDisconnectedEvent(
         return pipeline_events_base.DisconnectedEvent()
 
     @pytest.mark.it("Invokes the 'on_disconnected_handler' handler function, if set")
-    def test_invoke_handler(self, mocker, stage, event):
+    def test_invoke_handler(self, mocker, stage, event, wait_for):
         mock_handler = mocker.MagicMock()
         stage.on_disconnected_handler = mock_handler
         stage.handle_pipeline_event(event)
-        time.sleep(0.1)  # Needs a brief sleep so thread can switch
+        wait_for(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
@@ -224,11 +223,11 @@ class TestPipelineRootStageHandlePipelineEventWithNewSasTokenRequiredEvent(
         return pipeline_events_base.NewSasTokenRequiredEvent()
 
     @pytest.mark.it("Invokes the 'on_new_sastoken_required_handler' handler function, if set")
-    def test_invoke_handler(self, mocker, stage, event):
+    def test_invoke_handler(self, mocker, stage, event, wait_for):
         mock_handler = mocker.MagicMock()
         stage.on_new_sastoken_required_handler = mock_handler
         stage.handle_pipeline_event(event)
-        time.sleep(0.1)  # Needs a brief sleep so thread can switch
+        wait_for(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
@@ -246,11 +245,11 @@ class TestPipelineRootStageHandlePipelineEventWithBackgroundExceptionEvent(
     @pytest.mark.it(
         "Invokes the 'on_background_exception_handler' handler function, passing the exception object, if set"
     )
-    def test_invoke_handler(self, mocker, stage, event):
+    def test_invoke_handler(self, mocker, stage, event, wait_for):
         mock_handler = mocker.MagicMock()
         stage.on_background_exception_handler = mock_handler
         stage.handle_pipeline_event(event)
-        time.sleep(0.1)  # Needs a brief sleep so thread can switch
+        wait_for(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(event.e)
 
@@ -266,11 +265,11 @@ class TestPipelineRootStageHandlePipelineEventWithArbitraryEvent(
         return arbitrary_event
 
     @pytest.mark.it("Invokes the 'on_pipeline_event_handler' handler function, if set")
-    def test_invoke_handler(self, mocker, stage, event):
+    def test_invoke_handler(self, mocker, stage, event, wait_for):
         mock_handler = mocker.MagicMock()
         stage.on_pipeline_event_handler = mock_handler
         stage.handle_pipeline_event(event)
-        time.sleep(0.1)  # Needs a brief sleep so thread can switch
+        wait_for(lambda: mock_handler.call_count >= 1)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(event)
 

--- a/tests/unit/common/pipeline/test_pipeline_stages_base.py
+++ b/tests/unit/common/pipeline/test_pipeline_stages_base.py
@@ -188,7 +188,7 @@ class TestPipelineRootStageHandlePipelineEventWithConnectedEvent(
         stage.on_connected_handler = mock_handler
         stage.handle_pipeline_event(event)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
@@ -209,7 +209,7 @@ class TestPipelineRootStageHandlePipelineEventWithDisconnectedEvent(
         stage.on_disconnected_handler = mock_handler
         stage.handle_pipeline_event(event)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
@@ -230,7 +230,7 @@ class TestPipelineRootStageHandlePipelineEventWithNewSasTokenRequiredEvent(
         stage.on_new_sastoken_required_handler = mock_handler
         stage.handle_pipeline_event(event)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call()
 
@@ -253,7 +253,7 @@ class TestPipelineRootStageHandlePipelineEventWithBackgroundExceptionEvent(
         stage.on_background_exception_handler = mock_handler
         stage.handle_pipeline_event(event)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(event.e)
 
@@ -274,7 +274,7 @@ class TestPipelineRootStageHandlePipelineEventWithArbitraryEvent(
         stage.on_pipeline_event_handler = mock_handler
         stage.handle_pipeline_event(event)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
         assert mock_handler.call_count == 1
         assert mock_handler.call_args == mocker.call(event)
 

--- a/tests/unit/common/test_alarm.py
+++ b/tests/unit/common/test_alarm.py
@@ -42,9 +42,8 @@ class TestAlarm(object):
         a.start()
 
         assert desired_function.call_count == 0
-        time.sleep(1)  # hasn't been 2 seconds yet
-        assert desired_function.call_count == 0
-        time.sleep(1.1)  # it has now been just over 2 seconds, so the call HAS been made
+        assert a.finished.wait(timeout=5)
+        assert time.time() >= alarm_time
         assert desired_function.call_count == 1
         assert desired_function.call_args == mocker.call(*args, **kwargs)
 
@@ -55,9 +54,10 @@ class TestAlarm(object):
         a.start()
 
         assert desired_function.call_count == 0
-        time.sleep(1.1)  # it has now been just over 1 second, so the call HAS been made
+        assert a.finished.wait(timeout=5)
+        assert time.time() >= alarm_time
         assert desired_function.call_count == 1
-        desired_function.call_args == mocker.call()
+        assert desired_function.call_args == mocker.call()
 
     @pytest.mark.it("Invokes the function immediately if the given alarm time is in the past")
     def test_alarm_already_expired(self, mocker, desired_function):
@@ -65,6 +65,7 @@ class TestAlarm(object):
         a = Alarm(alarm_time=alarm_time, function=desired_function)
         a.start()
 
+        assert a.finished.wait(timeout=5)
         assert desired_function.call_count == 1
 
     @pytest.mark.it(
@@ -76,8 +77,7 @@ class TestAlarm(object):
         a.start()
 
         assert desired_function.call_count == 0
-        time.sleep(1)  # hasn't been 2 seconds yet
-        assert desired_function.call_count == 0
         a.cancel()  # cancel the alarm
-        time.sleep(1.5)  # it has now been more than 2 seconds
-        assert desired_function.call_count == 0  # still not called
+        a.join(timeout=5)
+        assert not a.is_alive()
+        assert desired_function.call_count == 0

--- a/tests/unit/common/test_alarm.py
+++ b/tests/unit/common/test_alarm.py
@@ -42,6 +42,8 @@ class TestAlarm(object):
         a.start()
 
         assert desired_function.call_count == 0
+        assert not a.finished.wait(timeout=1)
+        assert desired_function.call_count == 0
         assert a.finished.wait(timeout=5)
         assert time.time() >= alarm_time
         assert desired_function.call_count == 1
@@ -76,6 +78,8 @@ class TestAlarm(object):
         a = Alarm(alarm_time=alarm_time, function=desired_function)
         a.start()
 
+        assert desired_function.call_count == 0
+        assert not a.finished.wait(timeout=1)
         assert desired_function.call_count == 0
         a.cancel()  # cancel the alarm
         a.join(timeout=5)

--- a/tests/unit/common/test_async_adapter.py
+++ b/tests/unit/common/test_async_adapter.py
@@ -86,9 +86,7 @@ class TestAwaitableCallback(object):
         callback = async_adapter.AwaitableCallback()
         assert not callback.future.done()
         callback()
-        await asyncio.wait_for(callback.completion(), timeout=0.1)
-        assert callback.future.done()
-        assert not callback.future.exception()
+        assert await asyncio.wait_for(callback.completion(), timeout=0.1) is None
 
     @pytest.mark.it(
         "Completes the instance Future when a call is invoked on the instance (with return_arg_name)"
@@ -100,8 +98,6 @@ class TestAwaitableCallback(object):
         assert not callback.future.done()
         callback(arg_name=fake_return_arg_value)
         result = await asyncio.wait_for(callback.completion(), timeout=0.1)
-        assert callback.future.done()
-        assert not callback.future.exception()
         assert result == fake_return_arg_value
 
     @pytest.mark.it(
@@ -123,8 +119,7 @@ class TestAwaitableCallback(object):
         callback(error=arbitrary_exception)
         with pytest.raises(arbitrary_exception.__class__) as e_info:
             await asyncio.wait_for(callback.completion(), timeout=0.1)
-        assert callback.future.done()
-        assert callback.future.exception() == arbitrary_exception
+        assert callback.future.exception() is arbitrary_exception
         assert e_info.value is arbitrary_exception
 
     @pytest.mark.it(
@@ -136,6 +131,5 @@ class TestAwaitableCallback(object):
         callback(error=arbitrary_exception)
         with pytest.raises(arbitrary_exception.__class__) as e_info:
             await asyncio.wait_for(callback.completion(), timeout=0.1)
-        assert callback.future.done()
-        assert callback.future.exception() == arbitrary_exception
+        assert callback.future.exception() is arbitrary_exception
         assert e_info.value is arbitrary_exception

--- a/tests/unit/common/test_async_adapter.py
+++ b/tests/unit/common/test_async_adapter.py
@@ -12,6 +12,8 @@ import azure.iot.device.common.async_adapter as async_adapter
 
 logging.basicConfig(level=logging.DEBUG)
 
+PROMPT_COMPLETION_TIMEOUT = 0.1
+
 
 @pytest.fixture
 def dummy_value():
@@ -86,7 +88,9 @@ class TestAwaitableCallback(object):
         callback = async_adapter.AwaitableCallback()
         assert not callback.future.done()
         callback()
-        assert await asyncio.wait_for(callback.completion(), timeout=0.1) is None
+        assert (
+            await asyncio.wait_for(callback.completion(), timeout=PROMPT_COMPLETION_TIMEOUT) is None
+        )
 
     @pytest.mark.it(
         "Completes the instance Future when a call is invoked on the instance (with return_arg_name)"
@@ -97,7 +101,7 @@ class TestAwaitableCallback(object):
         callback = async_adapter.AwaitableCallback(return_arg_name="arg_name")
         assert not callback.future.done()
         callback(arg_name=fake_return_arg_value)
-        result = await asyncio.wait_for(callback.completion(), timeout=0.1)
+        result = await asyncio.wait_for(callback.completion(), timeout=PROMPT_COMPLETION_TIMEOUT)
         assert result == fake_return_arg_value
 
     @pytest.mark.it(
@@ -118,7 +122,7 @@ class TestAwaitableCallback(object):
         assert not callback.future.done()
         callback(error=arbitrary_exception)
         with pytest.raises(arbitrary_exception.__class__) as e_info:
-            await asyncio.wait_for(callback.completion(), timeout=0.1)
+            await asyncio.wait_for(callback.completion(), timeout=PROMPT_COMPLETION_TIMEOUT)
         assert callback.future.exception() is arbitrary_exception
         assert e_info.value is arbitrary_exception
 
@@ -130,6 +134,6 @@ class TestAwaitableCallback(object):
         assert not callback.future.done()
         callback(error=arbitrary_exception)
         with pytest.raises(arbitrary_exception.__class__) as e_info:
-            await asyncio.wait_for(callback.completion(), timeout=0.1)
+            await asyncio.wait_for(callback.completion(), timeout=PROMPT_COMPLETION_TIMEOUT)
         assert callback.future.exception() is arbitrary_exception
         assert e_info.value is arbitrary_exception

--- a/tests/unit/common/test_async_adapter.py
+++ b/tests/unit/common/test_async_adapter.py
@@ -6,6 +6,7 @@
 
 import pytest
 import inspect
+import asyncio
 import logging
 import azure.iot.device.common.async_adapter as async_adapter
 
@@ -85,7 +86,7 @@ class TestAwaitableCallback(object):
         callback = async_adapter.AwaitableCallback()
         assert not callback.future.done()
         callback()
-        await callback.completion()
+        await asyncio.wait_for(callback.completion(), timeout=0.1)
         assert callback.future.done()
         assert not callback.future.exception()
 
@@ -98,7 +99,7 @@ class TestAwaitableCallback(object):
         callback = async_adapter.AwaitableCallback(return_arg_name="arg_name")
         assert not callback.future.done()
         callback(arg_name=fake_return_arg_value)
-        result = await callback.completion()
+        result = await asyncio.wait_for(callback.completion(), timeout=0.1)
         assert callback.future.done()
         assert not callback.future.exception()
         assert result == fake_return_arg_value
@@ -121,7 +122,7 @@ class TestAwaitableCallback(object):
         assert not callback.future.done()
         callback(error=arbitrary_exception)
         with pytest.raises(arbitrary_exception.__class__) as e_info:
-            await callback.completion()
+            await asyncio.wait_for(callback.completion(), timeout=0.1)
         assert callback.future.done()
         assert callback.future.exception() == arbitrary_exception
         assert e_info.value is arbitrary_exception
@@ -134,7 +135,7 @@ class TestAwaitableCallback(object):
         assert not callback.future.done()
         callback(error=arbitrary_exception)
         with pytest.raises(arbitrary_exception.__class__) as e_info:
-            await callback.completion()
+            await asyncio.wait_for(callback.completion(), timeout=0.1)
         assert callback.future.done()
         assert callback.future.exception() == arbitrary_exception
         assert e_info.value is arbitrary_exception

--- a/tests/unit/common/test_async_adapter.py
+++ b/tests/unit/common/test_async_adapter.py
@@ -9,10 +9,9 @@ import inspect
 import asyncio
 import logging
 import azure.iot.device.common.async_adapter as async_adapter
+from tests.unit.helpers import PROMPT_TIMEOUT
 
 logging.basicConfig(level=logging.DEBUG)
-
-PROMPT_COMPLETION_TIMEOUT = 0.1
 
 
 @pytest.fixture
@@ -88,9 +87,7 @@ class TestAwaitableCallback(object):
         callback = async_adapter.AwaitableCallback()
         assert not callback.future.done()
         callback()
-        assert (
-            await asyncio.wait_for(callback.completion(), timeout=PROMPT_COMPLETION_TIMEOUT) is None
-        )
+        assert await asyncio.wait_for(callback.completion(), timeout=PROMPT_TIMEOUT) is None
 
     @pytest.mark.it(
         "Completes the instance Future when a call is invoked on the instance (with return_arg_name)"
@@ -101,7 +98,7 @@ class TestAwaitableCallback(object):
         callback = async_adapter.AwaitableCallback(return_arg_name="arg_name")
         assert not callback.future.done()
         callback(arg_name=fake_return_arg_value)
-        result = await asyncio.wait_for(callback.completion(), timeout=PROMPT_COMPLETION_TIMEOUT)
+        result = await asyncio.wait_for(callback.completion(), timeout=PROMPT_TIMEOUT)
         assert result == fake_return_arg_value
 
     @pytest.mark.it(
@@ -122,7 +119,7 @@ class TestAwaitableCallback(object):
         assert not callback.future.done()
         callback(error=arbitrary_exception)
         with pytest.raises(arbitrary_exception.__class__) as e_info:
-            await asyncio.wait_for(callback.completion(), timeout=PROMPT_COMPLETION_TIMEOUT)
+            await asyncio.wait_for(callback.completion(), timeout=PROMPT_TIMEOUT)
         assert callback.future.exception() is arbitrary_exception
         assert e_info.value is arbitrary_exception
 
@@ -134,6 +131,6 @@ class TestAwaitableCallback(object):
         assert not callback.future.done()
         callback(error=arbitrary_exception)
         with pytest.raises(arbitrary_exception.__class__) as e_info:
-            await asyncio.wait_for(callback.completion(), timeout=PROMPT_COMPLETION_TIMEOUT)
+            await asyncio.wait_for(callback.completion(), timeout=PROMPT_TIMEOUT)
         assert callback.future.exception() is arbitrary_exception
         assert e_info.value is arbitrary_exception

--- a/tests/unit/common/test_async_adapter.py
+++ b/tests/unit/common/test_async_adapter.py
@@ -6,7 +6,6 @@
 
 import pytest
 import inspect
-import asyncio
 import logging
 import azure.iot.device.common.async_adapter as async_adapter
 
@@ -86,10 +85,9 @@ class TestAwaitableCallback(object):
         callback = async_adapter.AwaitableCallback()
         assert not callback.future.done()
         callback()
-        await asyncio.sleep(0.1)  # wait to give time to complete the callback
+        await callback.completion()
         assert callback.future.done()
         assert not callback.future.exception()
-        await callback.completion()
 
     @pytest.mark.it(
         "Completes the instance Future when a call is invoked on the instance (with return_arg_name)"
@@ -100,10 +98,10 @@ class TestAwaitableCallback(object):
         callback = async_adapter.AwaitableCallback(return_arg_name="arg_name")
         assert not callback.future.done()
         callback(arg_name=fake_return_arg_value)
-        await asyncio.sleep(0.1)  # wait to give time to complete the callback
+        result = await callback.completion()
         assert callback.future.done()
         assert not callback.future.exception()
-        assert await callback.completion() == fake_return_arg_value
+        assert result == fake_return_arg_value
 
     @pytest.mark.it(
         "Raises a TypeError when a call is invoked on the instance without the correct return argument (with return_arg_name)"
@@ -122,11 +120,10 @@ class TestAwaitableCallback(object):
         callback = async_adapter.AwaitableCallback()
         assert not callback.future.done()
         callback(error=arbitrary_exception)
-        await asyncio.sleep(0.1)  # wait to give time to complete the callback
-        assert callback.future.done()
-        assert callback.future.exception() == arbitrary_exception
         with pytest.raises(arbitrary_exception.__class__) as e_info:
             await callback.completion()
+        assert callback.future.done()
+        assert callback.future.exception() == arbitrary_exception
         assert e_info.value is arbitrary_exception
 
     @pytest.mark.it(
@@ -136,9 +133,8 @@ class TestAwaitableCallback(object):
         callback = async_adapter.AwaitableCallback(return_arg_name="arg_name")
         assert not callback.future.done()
         callback(error=arbitrary_exception)
-        await asyncio.sleep(0.1)  # wait to give time to complete the callback
-        assert callback.future.done()
-        assert callback.future.exception() == arbitrary_exception
         with pytest.raises(arbitrary_exception.__class__) as e_info:
             await callback.completion()
+        assert callback.future.done()
+        assert callback.future.exception() == arbitrary_exception
         assert e_info.value is arbitrary_exception

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,0 +1,8 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+# Maximum time allowed for an operation expected to complete promptly.
+PROMPT_TIMEOUT = 0.1

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -7,5 +7,5 @@
 # Maximum time allowed for an operation expected to complete promptly.
 PROMPT_TIMEOUT = 0.1
 
-# Maximum time allowed for asynchronous work crossing threads or event loops.
-EVENTUAL_TIMEOUT = 1
+# Maximum time allowed for a prompt batch of asynchronous operations.
+BATCH_COMPLETION_TIMEOUT = 0.5

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -6,3 +6,6 @@
 
 # Maximum time allowed for an operation expected to complete promptly.
 PROMPT_TIMEOUT = 0.1
+
+# Maximum time allowed for asynchronous work crossing threads or event loops.
+EVENTUAL_TIMEOUT = 1

--- a/tests/unit/iothub/aio/test_async_clients.py
+++ b/tests/unit/iothub/aio/test_async_clients.py
@@ -25,6 +25,7 @@ from azure.iot.device.iothub.abstract_clients import (
 from azure.iot.device.iothub.aio.async_inbox import AsyncClientInbox
 from azure.iot.device.common import async_adapter
 from azure.iot.device import constant as device_constant
+from tests.unit.helpers import PROMPT_TIMEOUT
 from ..shared_client_tests import (
     SharedIoTHubClientInstantiationTests,
     SharedIoTHubClientPROPERTYHandlerTests,
@@ -45,8 +46,6 @@ from ..shared_client_tests import (
 )
 
 logging.basicConfig(level=logging.DEBUG)
-
-PROMPT_COMPLETION_TIMEOUT = 0.1
 
 
 async def create_completed_future(result=None):
@@ -734,9 +733,7 @@ class SharedClientReceiveMethodRequestTests(object):
         mqtt_pipeline.feature_enabled.__getitem__.return_value = (
             False  # Method Requests will appear disabled
         )
-        await asyncio.wait_for(
-            client.receive_method_request(method_name), timeout=PROMPT_COMPLETION_TIMEOUT
-        )
+        await asyncio.wait_for(client.receive_method_request(method_name), timeout=PROMPT_TIMEOUT)
         assert mqtt_pipeline.enable_feature.call_count == 1
         assert mqtt_pipeline.enable_feature.call_args[0][0] == pipeline_constant.METHODS
 
@@ -746,9 +743,7 @@ class SharedClientReceiveMethodRequestTests(object):
         mqtt_pipeline.feature_enabled.__getitem__.return_value = (
             True  # Input Messages will appear enabled
         )
-        await asyncio.wait_for(
-            client.receive_method_request(method_name), timeout=PROMPT_COMPLETION_TIMEOUT
-        )
+        await asyncio.wait_for(client.receive_method_request(method_name), timeout=PROMPT_TIMEOUT)
         assert mqtt_pipeline.enable_feature.call_count == 0
 
     @pytest.mark.it(
@@ -767,7 +762,7 @@ class SharedClientReceiveMethodRequestTests(object):
         )
 
         received_request = await asyncio.wait_for(
-            client.receive_method_request(), timeout=PROMPT_COMPLETION_TIMEOUT
+            client.receive_method_request(), timeout=PROMPT_TIMEOUT
         )
         assert manager_get_inbox_mock.call_count == 1
         assert manager_get_inbox_mock.call_args == mocker.call(None)
@@ -791,7 +786,7 @@ class SharedClientReceiveMethodRequestTests(object):
         )
 
         received_request = await asyncio.wait_for(
-            client.receive_method_request(method_name), timeout=PROMPT_COMPLETION_TIMEOUT
+            client.receive_method_request(method_name), timeout=PROMPT_TIMEOUT
         )
         assert manager_get_inbox_mock.call_count == 1
         assert manager_get_inbox_mock.call_args == mocker.call(method_name)
@@ -810,9 +805,7 @@ class SharedClientReceiveMethodRequestTests(object):
         )
 
         assert client._receive_type is RECEIVE_TYPE_NONE_SET
-        await asyncio.wait_for(
-            client.receive_method_request(method_name), timeout=PROMPT_COMPLETION_TIMEOUT
-        )
+        await asyncio.wait_for(client.receive_method_request(method_name), timeout=PROMPT_TIMEOUT)
         assert client._receive_type is RECEIVE_TYPE_API
 
     @pytest.mark.it(
@@ -829,9 +822,7 @@ class SharedClientReceiveMethodRequestTests(object):
         )
 
         client._receive_type = RECEIVE_TYPE_API
-        await asyncio.wait_for(
-            client.receive_method_request(method_name), timeout=PROMPT_COMPLETION_TIMEOUT
-        )
+        await asyncio.wait_for(client.receive_method_request(method_name), timeout=PROMPT_TIMEOUT)
         assert client._receive_type is RECEIVE_TYPE_API
 
     @pytest.mark.it(
@@ -854,7 +845,7 @@ class SharedClientReceiveMethodRequestTests(object):
         with pytest.raises(client_exceptions.ClientError):
             await asyncio.wait_for(
                 client.receive_method_request(method_name),
-                timeout=PROMPT_COMPLETION_TIMEOUT,
+                timeout=PROMPT_TIMEOUT,
             )
         # Feature was not enabled
         assert mqtt_pipeline.enable_feature.call_count == 0
@@ -1196,7 +1187,7 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
         )
         await asyncio.wait_for(
             client.receive_twin_desired_properties_patch(),
-            timeout=PROMPT_COMPLETION_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         assert mqtt_pipeline.enable_feature.call_count == 1
         assert mqtt_pipeline.enable_feature.call_args[0][0] == pipeline_constant.TWIN_PATCHES
@@ -1209,7 +1200,7 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
         )
         await asyncio.wait_for(
             client.receive_twin_desired_properties_patch(),
-            timeout=PROMPT_COMPLETION_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         assert mqtt_pipeline.enable_feature.call_count == 0
 
@@ -1223,7 +1214,7 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
 
         received_patch = await asyncio.wait_for(
             client.receive_twin_desired_properties_patch(),
-            timeout=PROMPT_COMPLETION_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         assert manager_get_inbox_mock.call_count == 1
         assert inbox_mock.get.call_count == 1
@@ -1239,7 +1230,7 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
         assert client._receive_type is RECEIVE_TYPE_NONE_SET
         await asyncio.wait_for(
             client.receive_twin_desired_properties_patch(),
-            timeout=PROMPT_COMPLETION_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         assert client._receive_type is RECEIVE_TYPE_API
 
@@ -1255,7 +1246,7 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
         client._receive_type = RECEIVE_TYPE_API
         await asyncio.wait_for(
             client.receive_twin_desired_properties_patch(),
-            timeout=PROMPT_COMPLETION_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         assert client._receive_type is RECEIVE_TYPE_API
 
@@ -1275,7 +1266,7 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
         with pytest.raises(client_exceptions.ClientError):
             await asyncio.wait_for(
                 client.receive_twin_desired_properties_patch(),
-                timeout=PROMPT_COMPLETION_TIMEOUT,
+                timeout=PROMPT_TIMEOUT,
             )
         # Feature was not enabled
         assert mqtt_pipeline.enable_feature.call_count == 0
@@ -1448,7 +1439,7 @@ class TestIoTHubDeviceClientReceiveC2DMessage(IoTHubDeviceClientTestsConfig):
 
         # Verify C2D Messaging enabled if not enabled
         mqtt_pipeline.feature_enabled.__getitem__.return_value = False  # C2D will appear disabled
-        await asyncio.wait_for(client.receive_message(), timeout=PROMPT_COMPLETION_TIMEOUT)
+        await asyncio.wait_for(client.receive_message(), timeout=PROMPT_TIMEOUT)
         assert mqtt_pipeline.enable_feature.call_count == 1
         assert mqtt_pipeline.enable_feature.call_args[0][0] == pipeline_constant.C2D_MSG
 
@@ -1456,7 +1447,7 @@ class TestIoTHubDeviceClientReceiveC2DMessage(IoTHubDeviceClientTestsConfig):
 
         # Verify C2D Messaging not enabled if already enabled
         mqtt_pipeline.feature_enabled.__getitem__.return_value = True  # C2D will appear enabled
-        await asyncio.wait_for(client.receive_message(), timeout=PROMPT_COMPLETION_TIMEOUT)
+        await asyncio.wait_for(client.receive_message(), timeout=PROMPT_TIMEOUT)
         assert mqtt_pipeline.enable_feature.call_count == 0
 
     @pytest.mark.it("Returns a message from the C2D inbox, if available")
@@ -1467,9 +1458,7 @@ class TestIoTHubDeviceClientReceiveC2DMessage(IoTHubDeviceClientTestsConfig):
             client._inbox_manager, "get_c2d_message_inbox", return_value=inbox_mock
         )
 
-        received_message = await asyncio.wait_for(
-            client.receive_message(), timeout=PROMPT_COMPLETION_TIMEOUT
-        )
+        received_message = await asyncio.wait_for(client.receive_message(), timeout=PROMPT_TIMEOUT)
         assert manager_get_inbox_mock.call_count == 1
         assert inbox_mock.get.call_count == 1
         assert received_message is message
@@ -1482,7 +1471,7 @@ class TestIoTHubDeviceClientReceiveC2DMessage(IoTHubDeviceClientTestsConfig):
         )
 
         assert client._receive_type is RECEIVE_TYPE_NONE_SET
-        await asyncio.wait_for(client.receive_message(), timeout=PROMPT_COMPLETION_TIMEOUT)
+        await asyncio.wait_for(client.receive_message(), timeout=PROMPT_TIMEOUT)
         assert client._receive_type is RECEIVE_TYPE_API
 
     @pytest.mark.it(
@@ -1495,7 +1484,7 @@ class TestIoTHubDeviceClientReceiveC2DMessage(IoTHubDeviceClientTestsConfig):
         )
 
         client._receive_type = RECEIVE_TYPE_API
-        await asyncio.wait_for(client.receive_message(), timeout=PROMPT_COMPLETION_TIMEOUT)
+        await asyncio.wait_for(client.receive_message(), timeout=PROMPT_TIMEOUT)
         assert client._receive_type is RECEIVE_TYPE_API
 
     @pytest.mark.it(
@@ -1512,7 +1501,7 @@ class TestIoTHubDeviceClientReceiveC2DMessage(IoTHubDeviceClientTestsConfig):
         client._receive_type = RECEIVE_TYPE_HANDLER
         # Error was raised
         with pytest.raises(client_exceptions.ClientError):
-            await asyncio.wait_for(client.receive_message(), timeout=PROMPT_COMPLETION_TIMEOUT)
+            await asyncio.wait_for(client.receive_message(), timeout=PROMPT_TIMEOUT)
         # Feature was not enabled
         assert mqtt_pipeline.enable_feature.call_count == 0
         # Inbox get was not called
@@ -2181,7 +2170,7 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         )
         await asyncio.wait_for(
             client.receive_message_on_input(input_name),
-            timeout=PROMPT_COMPLETION_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         assert mqtt_pipeline.enable_feature.call_count == 1
         assert mqtt_pipeline.enable_feature.call_args[0][0] == pipeline_constant.INPUT_MSG
@@ -2194,7 +2183,7 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         )
         await asyncio.wait_for(
             client.receive_message_on_input(input_name),
-            timeout=PROMPT_COMPLETION_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         assert mqtt_pipeline.enable_feature.call_count == 0
 
@@ -2209,7 +2198,7 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         input_name = "some_input"
         received_message = await asyncio.wait_for(
             client.receive_message_on_input(input_name),
-            timeout=PROMPT_COMPLETION_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         assert manager_get_inbox_mock.call_count == 1
         assert manager_get_inbox_mock.call_args == mocker.call(input_name)
@@ -2226,7 +2215,7 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         assert client._receive_type is RECEIVE_TYPE_NONE_SET
         await asyncio.wait_for(
             client.receive_message_on_input("some_input"),
-            timeout=PROMPT_COMPLETION_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         assert client._receive_type is RECEIVE_TYPE_API
 
@@ -2242,7 +2231,7 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         client._receive_type = RECEIVE_TYPE_API
         await asyncio.wait_for(
             client.receive_message_on_input("some_input"),
-            timeout=PROMPT_COMPLETION_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         assert client._receive_type is RECEIVE_TYPE_API
 
@@ -2262,7 +2251,7 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         with pytest.raises(client_exceptions.ClientError):
             await asyncio.wait_for(
                 client.receive_message_on_input("some_input"),
-                timeout=PROMPT_COMPLETION_TIMEOUT,
+                timeout=PROMPT_TIMEOUT,
             )
         # Feature was not enabled
         assert mqtt_pipeline.enable_feature.call_count == 0

--- a/tests/unit/iothub/aio/test_async_clients.py
+++ b/tests/unit/iothub/aio/test_async_clients.py
@@ -46,6 +46,8 @@ from ..shared_client_tests import (
 
 logging.basicConfig(level=logging.DEBUG)
 
+PROMPT_COMPLETION_TIMEOUT = 0.1
+
 
 async def create_completed_future(result=None):
     f = asyncio.Future()
@@ -732,7 +734,9 @@ class SharedClientReceiveMethodRequestTests(object):
         mqtt_pipeline.feature_enabled.__getitem__.return_value = (
             False  # Method Requests will appear disabled
         )
-        await client.receive_method_request(method_name)
+        await asyncio.wait_for(
+            client.receive_method_request(method_name), timeout=PROMPT_COMPLETION_TIMEOUT
+        )
         assert mqtt_pipeline.enable_feature.call_count == 1
         assert mqtt_pipeline.enable_feature.call_args[0][0] == pipeline_constant.METHODS
 
@@ -742,7 +746,9 @@ class SharedClientReceiveMethodRequestTests(object):
         mqtt_pipeline.feature_enabled.__getitem__.return_value = (
             True  # Input Messages will appear enabled
         )
-        await client.receive_method_request(method_name)
+        await asyncio.wait_for(
+            client.receive_method_request(method_name), timeout=PROMPT_COMPLETION_TIMEOUT
+        )
         assert mqtt_pipeline.enable_feature.call_count == 0
 
     @pytest.mark.it(
@@ -760,7 +766,9 @@ class SharedClientReceiveMethodRequestTests(object):
             return_value=inbox_mock,
         )
 
-        received_request = await client.receive_method_request()
+        received_request = await asyncio.wait_for(
+            client.receive_method_request(), timeout=PROMPT_COMPLETION_TIMEOUT
+        )
         assert manager_get_inbox_mock.call_count == 1
         assert manager_get_inbox_mock.call_args == mocker.call(None)
         assert inbox_mock.get.call_count == 1
@@ -782,7 +790,9 @@ class SharedClientReceiveMethodRequestTests(object):
             return_value=inbox_mock,
         )
 
-        received_request = await client.receive_method_request(method_name)
+        received_request = await asyncio.wait_for(
+            client.receive_method_request(method_name), timeout=PROMPT_COMPLETION_TIMEOUT
+        )
         assert manager_get_inbox_mock.call_count == 1
         assert manager_get_inbox_mock.call_args == mocker.call(method_name)
         assert inbox_mock.get.call_count == 1
@@ -800,7 +810,9 @@ class SharedClientReceiveMethodRequestTests(object):
         )
 
         assert client._receive_type is RECEIVE_TYPE_NONE_SET
-        await client.receive_method_request(method_name)
+        await asyncio.wait_for(
+            client.receive_method_request(method_name), timeout=PROMPT_COMPLETION_TIMEOUT
+        )
         assert client._receive_type is RECEIVE_TYPE_API
 
     @pytest.mark.it(
@@ -817,7 +829,9 @@ class SharedClientReceiveMethodRequestTests(object):
         )
 
         client._receive_type = RECEIVE_TYPE_API
-        await client.receive_method_request(method_name)
+        await asyncio.wait_for(
+            client.receive_method_request(method_name), timeout=PROMPT_COMPLETION_TIMEOUT
+        )
         assert client._receive_type is RECEIVE_TYPE_API
 
     @pytest.mark.it(
@@ -838,7 +852,10 @@ class SharedClientReceiveMethodRequestTests(object):
         client._receive_type = RECEIVE_TYPE_HANDLER
         # Error was raised
         with pytest.raises(client_exceptions.ClientError):
-            await client.receive_method_request(method_name)
+            await asyncio.wait_for(
+                client.receive_method_request(method_name),
+                timeout=PROMPT_COMPLETION_TIMEOUT,
+            )
         # Feature was not enabled
         assert mqtt_pipeline.enable_feature.call_count == 0
         # Inbox get was not called
@@ -1177,7 +1194,10 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
         mqtt_pipeline.feature_enabled.__getitem__.return_value = (
             False  # twin patches will appear disabled
         )
-        await client.receive_twin_desired_properties_patch()
+        await asyncio.wait_for(
+            client.receive_twin_desired_properties_patch(),
+            timeout=PROMPT_COMPLETION_TIMEOUT,
+        )
         assert mqtt_pipeline.enable_feature.call_count == 1
         assert mqtt_pipeline.enable_feature.call_args[0][0] == pipeline_constant.TWIN_PATCHES
 
@@ -1187,7 +1207,10 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
         mqtt_pipeline.feature_enabled.__getitem__.return_value = (
             True  # twin patches will appear enabled
         )
-        await client.receive_twin_desired_properties_patch()
+        await asyncio.wait_for(
+            client.receive_twin_desired_properties_patch(),
+            timeout=PROMPT_COMPLETION_TIMEOUT,
+        )
         assert mqtt_pipeline.enable_feature.call_count == 0
 
     @pytest.mark.it("Returns a message from the twin patch inbox, if available")
@@ -1198,7 +1221,10 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
             client._inbox_manager, "get_twin_patch_inbox", return_value=inbox_mock
         )
 
-        received_patch = await client.receive_twin_desired_properties_patch()
+        received_patch = await asyncio.wait_for(
+            client.receive_twin_desired_properties_patch(),
+            timeout=PROMPT_COMPLETION_TIMEOUT,
+        )
         assert manager_get_inbox_mock.call_count == 1
         assert inbox_mock.get.call_count == 1
         assert received_patch is twin_patch_desired
@@ -1211,7 +1237,10 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
         )
 
         assert client._receive_type is RECEIVE_TYPE_NONE_SET
-        await client.receive_twin_desired_properties_patch()
+        await asyncio.wait_for(
+            client.receive_twin_desired_properties_patch(),
+            timeout=PROMPT_COMPLETION_TIMEOUT,
+        )
         assert client._receive_type is RECEIVE_TYPE_API
 
     @pytest.mark.it(
@@ -1224,7 +1253,10 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
         )
 
         client._receive_type = RECEIVE_TYPE_API
-        await client.receive_twin_desired_properties_patch()
+        await asyncio.wait_for(
+            client.receive_twin_desired_properties_patch(),
+            timeout=PROMPT_COMPLETION_TIMEOUT,
+        )
         assert client._receive_type is RECEIVE_TYPE_API
 
     @pytest.mark.it(
@@ -1241,7 +1273,10 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
         client._receive_type = RECEIVE_TYPE_HANDLER
         # Error was raised
         with pytest.raises(client_exceptions.ClientError):
-            await client.receive_twin_desired_properties_patch()
+            await asyncio.wait_for(
+                client.receive_twin_desired_properties_patch(),
+                timeout=PROMPT_COMPLETION_TIMEOUT,
+            )
         # Feature was not enabled
         assert mqtt_pipeline.enable_feature.call_count == 0
         # Inbox get was not called
@@ -1413,7 +1448,7 @@ class TestIoTHubDeviceClientReceiveC2DMessage(IoTHubDeviceClientTestsConfig):
 
         # Verify C2D Messaging enabled if not enabled
         mqtt_pipeline.feature_enabled.__getitem__.return_value = False  # C2D will appear disabled
-        await client.receive_message()
+        await asyncio.wait_for(client.receive_message(), timeout=PROMPT_COMPLETION_TIMEOUT)
         assert mqtt_pipeline.enable_feature.call_count == 1
         assert mqtt_pipeline.enable_feature.call_args[0][0] == pipeline_constant.C2D_MSG
 
@@ -1421,7 +1456,7 @@ class TestIoTHubDeviceClientReceiveC2DMessage(IoTHubDeviceClientTestsConfig):
 
         # Verify C2D Messaging not enabled if already enabled
         mqtt_pipeline.feature_enabled.__getitem__.return_value = True  # C2D will appear enabled
-        await client.receive_message()
+        await asyncio.wait_for(client.receive_message(), timeout=PROMPT_COMPLETION_TIMEOUT)
         assert mqtt_pipeline.enable_feature.call_count == 0
 
     @pytest.mark.it("Returns a message from the C2D inbox, if available")
@@ -1432,7 +1467,9 @@ class TestIoTHubDeviceClientReceiveC2DMessage(IoTHubDeviceClientTestsConfig):
             client._inbox_manager, "get_c2d_message_inbox", return_value=inbox_mock
         )
 
-        received_message = await client.receive_message()
+        received_message = await asyncio.wait_for(
+            client.receive_message(), timeout=PROMPT_COMPLETION_TIMEOUT
+        )
         assert manager_get_inbox_mock.call_count == 1
         assert inbox_mock.get.call_count == 1
         assert received_message is message
@@ -1445,7 +1482,7 @@ class TestIoTHubDeviceClientReceiveC2DMessage(IoTHubDeviceClientTestsConfig):
         )
 
         assert client._receive_type is RECEIVE_TYPE_NONE_SET
-        await client.receive_message()
+        await asyncio.wait_for(client.receive_message(), timeout=PROMPT_COMPLETION_TIMEOUT)
         assert client._receive_type is RECEIVE_TYPE_API
 
     @pytest.mark.it(
@@ -1458,7 +1495,7 @@ class TestIoTHubDeviceClientReceiveC2DMessage(IoTHubDeviceClientTestsConfig):
         )
 
         client._receive_type = RECEIVE_TYPE_API
-        await client.receive_message()
+        await asyncio.wait_for(client.receive_message(), timeout=PROMPT_COMPLETION_TIMEOUT)
         assert client._receive_type is RECEIVE_TYPE_API
 
     @pytest.mark.it(
@@ -1475,7 +1512,7 @@ class TestIoTHubDeviceClientReceiveC2DMessage(IoTHubDeviceClientTestsConfig):
         client._receive_type = RECEIVE_TYPE_HANDLER
         # Error was raised
         with pytest.raises(client_exceptions.ClientError):
-            await client.receive_message()
+            await asyncio.wait_for(client.receive_message(), timeout=PROMPT_COMPLETION_TIMEOUT)
         # Feature was not enabled
         assert mqtt_pipeline.enable_feature.call_count == 0
         # Inbox get was not called
@@ -2142,7 +2179,10 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         mqtt_pipeline.feature_enabled.__getitem__.return_value = (
             False  # Input Messages will appear disabled
         )
-        await client.receive_message_on_input(input_name)
+        await asyncio.wait_for(
+            client.receive_message_on_input(input_name),
+            timeout=PROMPT_COMPLETION_TIMEOUT,
+        )
         assert mqtt_pipeline.enable_feature.call_count == 1
         assert mqtt_pipeline.enable_feature.call_args[0][0] == pipeline_constant.INPUT_MSG
 
@@ -2152,7 +2192,10 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         mqtt_pipeline.feature_enabled.__getitem__.return_value = (
             True  # Input Messages will appear enabled
         )
-        await client.receive_message_on_input(input_name)
+        await asyncio.wait_for(
+            client.receive_message_on_input(input_name),
+            timeout=PROMPT_COMPLETION_TIMEOUT,
+        )
         assert mqtt_pipeline.enable_feature.call_count == 0
 
     @pytest.mark.it("Returns a message from the input inbox, if available")
@@ -2164,7 +2207,10 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         )
 
         input_name = "some_input"
-        received_message = await client.receive_message_on_input(input_name)
+        received_message = await asyncio.wait_for(
+            client.receive_message_on_input(input_name),
+            timeout=PROMPT_COMPLETION_TIMEOUT,
+        )
         assert manager_get_inbox_mock.call_count == 1
         assert manager_get_inbox_mock.call_args == mocker.call(input_name)
         assert inbox_mock.get.call_count == 1
@@ -2178,7 +2224,10 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         )
 
         assert client._receive_type is RECEIVE_TYPE_NONE_SET
-        await client.receive_message_on_input("some_input")
+        await asyncio.wait_for(
+            client.receive_message_on_input("some_input"),
+            timeout=PROMPT_COMPLETION_TIMEOUT,
+        )
         assert client._receive_type is RECEIVE_TYPE_API
 
     @pytest.mark.it(
@@ -2191,7 +2240,10 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         )
 
         client._receive_type = RECEIVE_TYPE_API
-        await client.receive_message_on_input("some_input")
+        await asyncio.wait_for(
+            client.receive_message_on_input("some_input"),
+            timeout=PROMPT_COMPLETION_TIMEOUT,
+        )
         assert client._receive_type is RECEIVE_TYPE_API
 
     @pytest.mark.it(
@@ -2208,7 +2260,10 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         client._receive_type = RECEIVE_TYPE_HANDLER
         # Error was raised
         with pytest.raises(client_exceptions.ClientError):
-            await client.receive_message_on_input("some_input")
+            await asyncio.wait_for(
+                client.receive_message_on_input("some_input"),
+                timeout=PROMPT_COMPLETION_TIMEOUT,
+            )
         # Feature was not enabled
         assert mqtt_pipeline.enable_feature.call_count == 0
         # Inbox get was not called

--- a/tests/unit/iothub/aio/test_async_handler_manager.py
+++ b/tests/unit/iothub/aio/test_async_handler_manager.py
@@ -412,6 +412,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to the associated inbox, triggering the handler
         mock_obj = mocker.MagicMock()
         inbox.put(mock_obj)
+        # Wait for the handler invocation to complete
         await async_poll_until(lambda: handler_checker.handler_called)
 
         # Handler has been called with the item from the inbox
@@ -439,6 +440,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add 5 items to the associated inbox, triggering the handler
         for _ in range(5):
             inbox.put(mocker.MagicMock())
+        # Wait for all handler invocations to complete
         await async_poll_until(lambda: handler_checker.handler_call_count >= 5)
 
         # Handler has been called 5 times
@@ -456,6 +458,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         handler_checker,
         inbox,
     ):
+        # Intercept inbox operations so the runner can be paused with work remaining
         original_get = inbox.get
         original_put = inbox.put
         runner_paused = threading.Event()
@@ -491,19 +494,23 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Set the handler
         setattr(handler_manager, handler_name, handler)
         try:
+            # Runner is paused after retrieving one item, with more items still pending
             assert runner_paused.wait(timeout=5)
             assert handler_checker.handler_call_count < 100
             assert not inbox.empty()
 
-            # Remove the handler while items are still pending
+            # Begin handler removal, which blocks until the runner exits
             loop = asyncio.get_running_loop()
             removal_future = loop.run_in_executor(
                 None, setattr, handler_manager, handler_name, None
             )
+            # Removal has queued its sentinel but cannot complete while the runner is paused
             assert sentinel_added.wait(timeout=5)
             assert not removal_future.done()
         finally:
+            # Always release the runner so a failed assertion cannot strand it
             resume_runner.set()
+        # Handler removal completes after the runner processes all pending items
         await asyncio.wait_for(removal_future, timeout=5)
 
         # Despite removal, handler has been called for everything that was in the inbox at the
@@ -542,6 +549,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
+        # Wait for the background exception handler to be called
         await async_poll_until(lambda: background_exc_spy.call_count >= 1)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
@@ -558,6 +566,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
+        # Wait for the background exception handler to be called
         await async_poll_until(lambda: background_exc_spy.call_count >= 1)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
@@ -585,18 +594,21 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         setattr(handler_manager, handler_name, handler1)
 
         inbox.put(mocker.MagicMock())
+        # Wait for handler1 to replace itself with handler2
         await async_poll_until(lambda: getattr(handler_manager, handler_name) is handler2)
         # The set handler (handler1) has been replaced with a new handler (handler2)
         assert getattr(handler_manager, handler_name) is not handler1
         assert getattr(handler_manager, handler_name) is handler2
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
+        # Wait for handler2 to replace itself with the mock
         await async_poll_until(lambda: getattr(handler_manager, handler_name) is mock_handler)
         # The set handler (handler2) has now been replaced by a mock handler
         assert getattr(handler_manager, handler_name) is not handler2
         assert getattr(handler_manager, handler_name) is mock_handler
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
+        # Wait for the mock handler invocation to complete
         await async_poll_until(lambda: mock_handler.call_count >= 1)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
@@ -689,6 +701,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
 
         # Add the event to the client inbox
         inbox.put(event)
+        # Wait for the handler invocation to complete
         await async_poll_until(lambda: handler_checker.handler_call_count >= 1)
 
         # Handler has been called with the arguments from the event
@@ -698,6 +711,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add a non-matching event ot the client event inbox
         non_matching_event = client_event.ClientEvent("NON_MATCHING_EVENT")
         inbox.put(non_matching_event)
+        # Wait for the runner to consume the non-matching event
         await async_poll_until(inbox.empty)
 
         # Handler has not been called again
@@ -724,6 +738,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add 5 items to the corresponding inbox, triggering the handler
         for _ in range(5):
             inbox.put(event)
+        # Wait for all handler invocations to complete
         await async_poll_until(lambda: handler_checker.handler_call_count >= 5)
 
         # Handler has been called 5 times
@@ -757,6 +772,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(event)
+        # Wait for the background exception handler to be called
         await async_poll_until(lambda: background_exc_spy.call_count >= 1)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
@@ -773,6 +789,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(event)
+        # Wait for the background exception handler to be called
         await async_poll_until(lambda: background_exc_spy.call_count >= 1)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
@@ -800,18 +817,21 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         setattr(handler_manager, handler_name, handler1)
 
         inbox.put(event)
+        # Wait for handler1 to replace itself with handler2
         await async_poll_until(lambda: getattr(handler_manager, handler_name) is handler2)
         # The set handler (handler1) has been replaced with a new handler (handler2)
         assert getattr(handler_manager, handler_name) is not handler1
         assert getattr(handler_manager, handler_name) is handler2
         # Add a new item to the inbox
         inbox.put(event)
+        # Wait for handler2 to replace itself with the mock
         await async_poll_until(lambda: getattr(handler_manager, handler_name) is mock_handler)
         # The set handler (handler2) has now been replaced by a mock handler
         assert getattr(handler_manager, handler_name) is not handler2
         assert getattr(handler_manager, handler_name) is mock_handler
         # Add a new item to the inbox
         inbox.put(event)
+        # Wait for the mock handler invocation to complete
         await async_poll_until(lambda: mock_handler.call_count >= 1)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1

--- a/tests/unit/iothub/aio/test_async_handler_manager.py
+++ b/tests/unit/iothub/aio/test_async_handler_manager.py
@@ -18,7 +18,7 @@ from azure.iot.device.iothub.sync_handler_manager import (
 from azure.iot.device.iothub.sync_handler_manager import MESSAGE, METHOD, TWIN_DP_PATCH
 from azure.iot.device.iothub.inbox_manager import InboxManager
 from azure.iot.device.iothub.aio.async_inbox import AsyncClientInbox
-from tests.unit.helpers import EVENTUAL_TIMEOUT
+from tests.unit.helpers import BATCH_COMPLETION_TIMEOUT, PROMPT_TIMEOUT
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -414,7 +414,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         mock_obj = mocker.MagicMock()
         inbox.put(mock_obj)
         # Wait for the handler invocation to complete
-        await async_poll_until(lambda: handler_checker.handler_called, timeout=EVENTUAL_TIMEOUT)
+        await async_poll_until(lambda: handler_checker.handler_called, timeout=PROMPT_TIMEOUT)
 
         # Handler has been called with the item from the inbox
         assert handler_checker.handler_called is True
@@ -443,7 +443,8 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
             inbox.put(mocker.MagicMock())
         # Wait for all handler invocations to complete
         await async_poll_until(
-            lambda: handler_checker.handler_call_count >= 5, timeout=EVENTUAL_TIMEOUT
+            lambda: handler_checker.handler_call_count >= 5,
+            timeout=BATCH_COMPLETION_TIMEOUT,
         )
 
         # Handler has been called 5 times
@@ -553,7 +554,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
         # Wait for the background exception handler to be called
-        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=PROMPT_TIMEOUT)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -570,7 +571,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
         # Wait for the background exception handler to be called
-        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=PROMPT_TIMEOUT)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -600,7 +601,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Wait for handler1 to replace itself with handler2
         await async_poll_until(
             lambda: getattr(handler_manager, handler_name) is handler2,
-            timeout=EVENTUAL_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         # The set handler (handler1) has been replaced with a new handler (handler2)
         assert getattr(handler_manager, handler_name) is not handler1
@@ -610,7 +611,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Wait for handler2 to replace itself with the mock
         await async_poll_until(
             lambda: getattr(handler_manager, handler_name) is mock_handler,
-            timeout=EVENTUAL_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         # The set handler (handler2) has now been replaced by a mock handler
         assert getattr(handler_manager, handler_name) is not handler2
@@ -618,7 +619,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
         # Wait for the mock handler invocation to complete
-        await async_poll_until(lambda: mock_handler.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
+        await async_poll_until(lambda: mock_handler.call_count >= 1, timeout=PROMPT_TIMEOUT)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 
@@ -712,7 +713,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         inbox.put(event)
         # Wait for the handler invocation to complete
         await async_poll_until(
-            lambda: handler_checker.handler_call_count >= 1, timeout=EVENTUAL_TIMEOUT
+            lambda: handler_checker.handler_call_count >= 1, timeout=PROMPT_TIMEOUT
         )
 
         # Handler has been called with the arguments from the event
@@ -723,7 +724,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         non_matching_event = client_event.ClientEvent("NON_MATCHING_EVENT")
         inbox.put(non_matching_event)
         # Wait for the runner to consume the non-matching event
-        await async_poll_until(inbox.empty, timeout=EVENTUAL_TIMEOUT)
+        await async_poll_until(inbox.empty, timeout=PROMPT_TIMEOUT)
 
         # Handler has not been called again
         assert handler_checker.handler_call_count == 1
@@ -751,7 +752,8 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
             inbox.put(event)
         # Wait for all handler invocations to complete
         await async_poll_until(
-            lambda: handler_checker.handler_call_count >= 5, timeout=EVENTUAL_TIMEOUT
+            lambda: handler_checker.handler_call_count >= 5,
+            timeout=BATCH_COMPLETION_TIMEOUT,
         )
 
         # Handler has been called 5 times
@@ -786,7 +788,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(event)
         # Wait for the background exception handler to be called
-        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=PROMPT_TIMEOUT)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -803,7 +805,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(event)
         # Wait for the background exception handler to be called
-        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=PROMPT_TIMEOUT)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -833,7 +835,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Wait for handler1 to replace itself with handler2
         await async_poll_until(
             lambda: getattr(handler_manager, handler_name) is handler2,
-            timeout=EVENTUAL_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         # The set handler (handler1) has been replaced with a new handler (handler2)
         assert getattr(handler_manager, handler_name) is not handler1
@@ -843,7 +845,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Wait for handler2 to replace itself with the mock
         await async_poll_until(
             lambda: getattr(handler_manager, handler_name) is mock_handler,
-            timeout=EVENTUAL_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         # The set handler (handler2) has now been replaced by a mock handler
         assert getattr(handler_manager, handler_name) is not handler2
@@ -851,7 +853,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add a new item to the inbox
         inbox.put(event)
         # Wait for the mock handler invocation to complete
-        await async_poll_until(lambda: mock_handler.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
+        await async_poll_until(lambda: mock_handler.call_count >= 1, timeout=PROMPT_TIMEOUT)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 

--- a/tests/unit/iothub/aio/test_async_handler_manager.py
+++ b/tests/unit/iothub/aio/test_async_handler_manager.py
@@ -413,7 +413,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         mock_obj = mocker.MagicMock()
         inbox.put(mock_obj)
         # Wait for the handler invocation to complete
-        await async_poll_until(lambda: handler_checker.handler_called)
+        await async_poll_until(lambda: handler_checker.handler_called, timeout=5)
 
         # Handler has been called with the item from the inbox
         assert handler_checker.handler_called is True
@@ -441,7 +441,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         for _ in range(5):
             inbox.put(mocker.MagicMock())
         # Wait for all handler invocations to complete
-        await async_poll_until(lambda: handler_checker.handler_call_count >= 5)
+        await async_poll_until(lambda: handler_checker.handler_call_count >= 5, timeout=5)
 
         # Handler has been called 5 times
         assert handler_checker.handler_call_count == 5
@@ -550,7 +550,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
         # Wait for the background exception handler to be called
-        await async_poll_until(lambda: background_exc_spy.call_count >= 1)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=5)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -567,7 +567,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
         # Wait for the background exception handler to be called
-        await async_poll_until(lambda: background_exc_spy.call_count >= 1)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=5)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -595,21 +595,25 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
 
         inbox.put(mocker.MagicMock())
         # Wait for handler1 to replace itself with handler2
-        await async_poll_until(lambda: getattr(handler_manager, handler_name) is handler2)
+        await async_poll_until(
+            lambda: getattr(handler_manager, handler_name) is handler2, timeout=5
+        )
         # The set handler (handler1) has been replaced with a new handler (handler2)
         assert getattr(handler_manager, handler_name) is not handler1
         assert getattr(handler_manager, handler_name) is handler2
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
         # Wait for handler2 to replace itself with the mock
-        await async_poll_until(lambda: getattr(handler_manager, handler_name) is mock_handler)
+        await async_poll_until(
+            lambda: getattr(handler_manager, handler_name) is mock_handler, timeout=5
+        )
         # The set handler (handler2) has now been replaced by a mock handler
         assert getattr(handler_manager, handler_name) is not handler2
         assert getattr(handler_manager, handler_name) is mock_handler
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
         # Wait for the mock handler invocation to complete
-        await async_poll_until(lambda: mock_handler.call_count >= 1)
+        await async_poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 
@@ -702,7 +706,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add the event to the client inbox
         inbox.put(event)
         # Wait for the handler invocation to complete
-        await async_poll_until(lambda: handler_checker.handler_call_count >= 1)
+        await async_poll_until(lambda: handler_checker.handler_call_count >= 1, timeout=5)
 
         # Handler has been called with the arguments from the event
         assert handler_checker.handler_call_count == 1
@@ -712,7 +716,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         non_matching_event = client_event.ClientEvent("NON_MATCHING_EVENT")
         inbox.put(non_matching_event)
         # Wait for the runner to consume the non-matching event
-        await async_poll_until(inbox.empty)
+        await async_poll_until(inbox.empty, timeout=5)
 
         # Handler has not been called again
         assert handler_checker.handler_call_count == 1
@@ -739,7 +743,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         for _ in range(5):
             inbox.put(event)
         # Wait for all handler invocations to complete
-        await async_poll_until(lambda: handler_checker.handler_call_count >= 5)
+        await async_poll_until(lambda: handler_checker.handler_call_count >= 5, timeout=5)
 
         # Handler has been called 5 times
         assert handler_checker.handler_call_count == 5
@@ -773,7 +777,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(event)
         # Wait for the background exception handler to be called
-        await async_poll_until(lambda: background_exc_spy.call_count >= 1)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=5)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -790,7 +794,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(event)
         # Wait for the background exception handler to be called
-        await async_poll_until(lambda: background_exc_spy.call_count >= 1)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=5)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -818,21 +822,25 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
 
         inbox.put(event)
         # Wait for handler1 to replace itself with handler2
-        await async_poll_until(lambda: getattr(handler_manager, handler_name) is handler2)
+        await async_poll_until(
+            lambda: getattr(handler_manager, handler_name) is handler2, timeout=5
+        )
         # The set handler (handler1) has been replaced with a new handler (handler2)
         assert getattr(handler_manager, handler_name) is not handler1
         assert getattr(handler_manager, handler_name) is handler2
         # Add a new item to the inbox
         inbox.put(event)
         # Wait for handler2 to replace itself with the mock
-        await async_poll_until(lambda: getattr(handler_manager, handler_name) is mock_handler)
+        await async_poll_until(
+            lambda: getattr(handler_manager, handler_name) is mock_handler, timeout=5
+        )
         # The set handler (handler2) has now been replaced by a mock handler
         assert getattr(handler_manager, handler_name) is not handler2
         assert getattr(handler_manager, handler_name) is mock_handler
         # Add a new item to the inbox
         inbox.put(event)
         # Wait for the mock handler invocation to complete
-        await async_poll_until(lambda: mock_handler.call_count >= 1)
+        await async_poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 

--- a/tests/unit/iothub/aio/test_async_handler_manager.py
+++ b/tests/unit/iothub/aio/test_async_handler_manager.py
@@ -5,7 +5,6 @@
 # --------------------------------------------------------------------------
 import logging
 import pytest
-import asyncio
 import threading
 import concurrent.futures
 from azure.iot.device.common import handle_exceptions
@@ -26,9 +25,9 @@ logging.basicConfig(level=logging.DEBUG)
 # This means we must be very careful to always change both test modules when a change is made to
 # shared behavior, or when shared features are added.
 
-# NOTE ON TIMING/DELAY
-# Several tests in this module have sleeps/delays in their implementation due to needing to wait
-# for things to happen in other threads.
+# NOTE ON SYNCHRONIZATION
+# Handler work happens on other threads and event loops. Wait for observable outcomes rather than
+# assuming that work will complete within a fixed delay.
 
 
 all_internal_receiver_handlers = [MESSAGE, METHOD, TWIN_DP_PATCH]
@@ -205,7 +204,6 @@ class TestStop(object):
         assert mock_msg_handler.call_count < 200
         assert mock_mth_handler.call_count < 200
         hm.stop()
-        await asyncio.sleep(0.1)
         assert mock_msg_handler.call_count == 200
         assert mock_mth_handler.call_count == 200
         assert msg_inbox.empty()
@@ -392,7 +390,14 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         "Is invoked by the runner when the Inbox corresponding to the handler receives an object, passing that object to the handler"
     )
     async def test_handler_invoked(
-        self, mocker, handler_name, handler_manager, handler, handler_checker, inbox
+        self,
+        mocker,
+        handler_name,
+        handler_manager,
+        handler,
+        handler_checker,
+        inbox,
+        async_wait_for,
     ):
         # Set the handler
         setattr(handler_manager, handler_name, handler)
@@ -403,7 +408,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to the associated inbox, triggering the handler
         mock_obj = mocker.MagicMock()
         inbox.put(mock_obj)
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: handler_checker.handler_called)
 
         # Handler has been called with the item from the inbox
         assert handler_checker.handler_called is True
@@ -413,7 +418,14 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         "Is invoked by the runner every time the Inbox corresponding to the handler receives an object"
     )
     async def test_handler_invoked_multiple(
-        self, mocker, handler_name, handler_manager, handler, handler_checker, inbox
+        self,
+        mocker,
+        handler_name,
+        handler_manager,
+        handler,
+        handler_checker,
+        inbox,
+        async_wait_for,
     ):
         # Set the handler
         setattr(handler_manager, handler_name, handler)
@@ -423,7 +435,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add 5 items to the associated inbox, triggering the handler
         for _ in range(5):
             inbox.put(mocker.MagicMock())
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: handler_checker.handler_call_count >= 5)
 
         # Handler has been called 5 times
         assert handler_checker.handler_call_count == 5
@@ -432,7 +444,14 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         "Is invoked for every item already in the corresponding Inbox at the moment of handler removal"
     )
     async def test_handler_resolve_pending_items_before_handler_removal(
-        self, mocker, handler_name, handler_manager, handler, handler_checker, inbox
+        self,
+        mocker,
+        handler_name,
+        handler_manager,
+        handler,
+        handler_checker,
+        inbox,
+        async_wait_for,
     ):
         assert inbox.empty()
         # Queue up a bunch of items in the inbox
@@ -444,16 +463,9 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         assert not inbox.empty()
         # Set the handler
         setattr(handler_manager, handler_name, handler)
-        # The handler has not yet been called for everything that was in the inbox
-        # NOTE: I'd really like to show that the handler call count is also > 0 here, but
-        # it's pretty difficult to make the timing work
-        await asyncio.sleep(0.1)
-        handler_checker.handler_call_count < 100
-
         # Immediately remove the handler
         setattr(handler_manager, handler_name, None)
-        # Wait to give a chance for the handler runner to finish calling everything
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: handler_checker.handler_call_count >= 100)
         # Despite removal, handler has been called for everything that was in the inbox at the
         # time of the removal
         assert handler_checker.handler_call_count == 100
@@ -462,17 +474,16 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add some more items
         for _ in range(100):
             inbox.put(mocker.MagicMock())
-        # Wait to give a chance for the handler to be called (it won't)
-        await asyncio.sleep(0.1)
         # Despite more items added to inbox, no further handler calls have been made beyond the
         # initial calls that were made when the original items were added
         assert handler_checker.handler_call_count == 100
+        assert not inbox.empty()
 
     @pytest.mark.it(
         "Sends a HandlerManagerException to the background exception handler if any exception is raised during its invocation"
     )
     async def test_exception_in_handler(
-        self, mocker, handler_name, handler_manager, inbox, arbitrary_exception
+        self, mocker, handler_name, handler_manager, inbox, arbitrary_exception, async_wait_for
     ):
         # NOTE: this test tests both coroutines and functions without the need for parametrization
         background_exc_spy = mocker.spy(handle_exceptions, "handle_background_exception")
@@ -489,7 +500,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: background_exc_spy.call_count >= 1)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -505,7 +516,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: background_exc_spy.call_count >= 1)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -515,7 +526,9 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
     @pytest.mark.it(
         "Can be updated with a new value that the corresponding handler runner will immediately begin using for handler invocations instead"
     )
-    async def test_handler_update_handler(self, mocker, handler_name, handler_manager, inbox):
+    async def test_handler_update_handler(
+        self, mocker, handler_name, handler_manager, inbox, async_wait_for
+    ):
         # NOTE: this test tests both coroutines and functions without the need for parametrization
         mock_handler = mocker.MagicMock()
 
@@ -530,19 +543,19 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         setattr(handler_manager, handler_name, handler1)
 
         inbox.put(mocker.MagicMock())
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: getattr(handler_manager, handler_name) is handler2)
         # The set handler (handler1) has been replaced with a new handler (handler2)
         assert getattr(handler_manager, handler_name) is not handler1
         assert getattr(handler_manager, handler_name) is handler2
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: getattr(handler_manager, handler_name) is mock_handler)
         # The set handler (handler2) has now been replaced by a mock handler
         assert getattr(handler_manager, handler_name) is not handler2
         assert getattr(handler_manager, handler_name) is mock_handler
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: mock_handler.call_count >= 1)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 
@@ -617,7 +630,15 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         "Is invoked by the runner only when the Client Event Inbox receives a matching event, passing any arguments to the handler"
     )
     async def test_handler_invoked(
-        self, mocker, handler_name, handler_manager, handler_checker, handler, inbox, event
+        self,
+        mocker,
+        handler_name,
+        handler_manager,
+        handler_checker,
+        handler,
+        inbox,
+        event,
+        async_wait_for,
     ):
         # Set the handler
         setattr(handler_manager, handler_name, handler)
@@ -626,7 +647,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
 
         # Add the event to the client inbox
         inbox.put(event)
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: handler_checker.handler_call_count >= 1)
 
         # Handler has been called with the arguments from the event
         assert handler_checker.handler_call_count == 1
@@ -635,7 +656,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add a non-matching event ot the client event inbox
         non_matching_event = client_event.ClientEvent("NON_MATCHING_EVENT")
         inbox.put(non_matching_event)
-        await asyncio.sleep(0.1)
+        await async_wait_for(inbox.empty)
 
         # Handler has not been called again
         assert handler_checker.handler_call_count == 1
@@ -644,7 +665,14 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         "Is invoked by the runner every time the Client Event Inbox receives a matching Client Event"
     )
     async def test_handler_invoked_multiple(
-        self, handler_name, handler_manager, handler, handler_checker, inbox, event
+        self,
+        handler_name,
+        handler_manager,
+        handler,
+        handler_checker,
+        inbox,
+        event,
+        async_wait_for,
     ):
         # Set the handler
         setattr(handler_manager, handler_name, handler)
@@ -654,7 +682,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add 5 items to the corresponding inbox, triggering the handler
         for _ in range(5):
             inbox.put(event)
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: handler_checker.handler_call_count >= 5)
 
         # Handler has been called 5 times
         assert handler_checker.handler_call_count == 5
@@ -663,7 +691,14 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         "Sends a HandlerManagerException to the background exception handler if any exception is raised during its invocation"
     )
     async def test_exception_in_handler(
-        self, mocker, handler_name, handler_manager, inbox, event, arbitrary_exception
+        self,
+        mocker,
+        handler_name,
+        handler_manager,
+        inbox,
+        event,
+        arbitrary_exception,
+        async_wait_for,
     ):
         # NOTE: this test tests both coroutines and functions without the need for parametrization
         background_exc_spy = mocker.spy(handle_exceptions, "handle_background_exception")
@@ -680,7 +715,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(event)
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: background_exc_spy.call_count >= 1)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -696,7 +731,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(event)
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: background_exc_spy.call_count >= 1)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -707,7 +742,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         "Can be updated with a new value that the corresponding handler runner will immediately begin using for handler invocations instead"
     )
     async def test_handler_update_handler(
-        self, mocker, handler_name, handler_manager, inbox, event
+        self, mocker, handler_name, handler_manager, inbox, event, async_wait_for
     ):
         # NOTE: this test tests both coroutines and functions without the need for parametrization
         mock_handler = mocker.MagicMock()
@@ -723,19 +758,19 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         setattr(handler_manager, handler_name, handler1)
 
         inbox.put(event)
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: getattr(handler_manager, handler_name) is handler2)
         # The set handler (handler1) has been replaced with a new handler (handler2)
         assert getattr(handler_manager, handler_name) is not handler1
         assert getattr(handler_manager, handler_name) is handler2
         # Add a new item to the inbox
         inbox.put(event)
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: getattr(handler_manager, handler_name) is mock_handler)
         # The set handler (handler2) has now been replaced by a mock handler
         assert getattr(handler_manager, handler_name) is not handler2
         assert getattr(handler_manager, handler_name) is mock_handler
         # Add a new item to the inbox
         inbox.put(event)
-        await asyncio.sleep(0.1)
+        await async_wait_for(lambda: mock_handler.call_count >= 1)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 

--- a/tests/unit/iothub/aio/test_async_handler_manager.py
+++ b/tests/unit/iothub/aio/test_async_handler_manager.py
@@ -463,6 +463,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         handler,
         handler_checker,
         inbox,
+        async_poll_until,
     ):
         # Intercept inbox operations so the runner can be paused with work remaining
         original_get = inbox.get
@@ -518,6 +519,12 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
             resume_runner.set()
         # Handler removal completes after the runner processes all pending items
         await asyncio.wait_for(removal_future, timeout=5)
+
+        # Coroutine handlers may still be completing on the handler loop
+        await async_poll_until(
+            lambda: handler_checker.handler_call_count >= 100,
+            timeout=BATCH_COMPLETION_TIMEOUT,
+        )
 
         # Despite removal, handler has been called for everything that was in the inbox at the
         # time of the removal

--- a/tests/unit/iothub/aio/test_async_handler_manager.py
+++ b/tests/unit/iothub/aio/test_async_handler_manager.py
@@ -427,6 +427,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         self,
         mocker,
         handler_name,
+        handler_name_internal,
         handler_manager,
         handler,
         handler_checker,
@@ -457,6 +458,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         self,
         mocker,
         handler_name,
+        handler_name_internal,
         handler_manager,
         handler,
         handler_checker,
@@ -521,12 +523,12 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # time of the removal
         assert handler_checker.handler_call_count == 100
         assert inbox.empty()
+        assert getattr(handler_manager, handler_name) is None
+        assert handler_manager._receiver_handler_runners[handler_name_internal] is None
 
         # Add some more items
         for _ in range(100):
             inbox.put(mocker.MagicMock())
-        # Give any incorrectly retained runner an opportunity to invoke the handler
-        await asyncio.sleep(0.1)
         # Despite more items added to inbox, no further handler calls have been made beyond the
         # initial calls that were made when the original items were added
         assert handler_checker.handler_call_count == 100

--- a/tests/unit/iothub/aio/test_async_handler_manager.py
+++ b/tests/unit/iothub/aio/test_async_handler_manager.py
@@ -5,12 +5,16 @@
 # --------------------------------------------------------------------------
 import logging
 import pytest
+import asyncio
 import threading
 import concurrent.futures
 from azure.iot.device.common import handle_exceptions
 from azure.iot.device.iothub import client_event
 from azure.iot.device.iothub.aio.async_handler_manager import AsyncHandlerManager
-from azure.iot.device.iothub.sync_handler_manager import HandlerManagerException
+from azure.iot.device.iothub.sync_handler_manager import (
+    HandlerManagerException,
+    HandlerRunnerKillerSentinel,
+)
 from azure.iot.device.iothub.sync_handler_manager import MESSAGE, METHOD, TWIN_DP_PATCH
 from azure.iot.device.iothub.inbox_manager import InboxManager
 from azure.iot.device.iothub.aio.async_inbox import AsyncClientInbox
@@ -451,8 +455,31 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         handler,
         handler_checker,
         inbox,
-        async_wait_for,
     ):
+        original_get = inbox.get
+        original_put = inbox.put
+        runner_paused = threading.Event()
+        resume_runner = threading.Event()
+        sentinel_added = threading.Event()
+        get_count = 0
+
+        async def controlled_get():
+            nonlocal get_count
+            item = await original_get()
+            get_count += 1
+            if get_count == 2:
+                runner_paused.set()
+                assert await asyncio.to_thread(resume_runner.wait, 5)
+            return item
+
+        def tracked_put(item):
+            original_put(item)
+            if isinstance(item, HandlerRunnerKillerSentinel):
+                sentinel_added.set()
+
+        mocker.patch.object(inbox, "get", side_effect=controlled_get)
+        mocker.patch.object(inbox, "put", side_effect=tracked_put)
+
         assert inbox.empty()
         # Queue up a bunch of items in the inbox
         for _ in range(100):
@@ -463,9 +490,22 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         assert not inbox.empty()
         # Set the handler
         setattr(handler_manager, handler_name, handler)
-        # Immediately remove the handler
-        setattr(handler_manager, handler_name, None)
-        await async_wait_for(lambda: handler_checker.handler_call_count >= 100)
+        try:
+            assert runner_paused.wait(timeout=5)
+            assert handler_checker.handler_call_count < 100
+            assert not inbox.empty()
+
+            # Remove the handler while items are still pending
+            loop = asyncio.get_running_loop()
+            removal_future = loop.run_in_executor(
+                None, setattr, handler_manager, handler_name, None
+            )
+            assert sentinel_added.wait(timeout=5)
+            assert not removal_future.done()
+        finally:
+            resume_runner.set()
+        await asyncio.wait_for(removal_future, timeout=5)
+
         # Despite removal, handler has been called for everything that was in the inbox at the
         # time of the removal
         assert handler_checker.handler_call_count == 100
@@ -474,6 +514,8 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add some more items
         for _ in range(100):
             inbox.put(mocker.MagicMock())
+        # Give any incorrectly retained runner an opportunity to invoke the handler
+        await asyncio.sleep(0.1)
         # Despite more items added to inbox, no further handler calls have been made beyond the
         # initial calls that were made when the original items were added
         assert handler_checker.handler_call_count == 100

--- a/tests/unit/iothub/aio/test_async_handler_manager.py
+++ b/tests/unit/iothub/aio/test_async_handler_manager.py
@@ -18,6 +18,7 @@ from azure.iot.device.iothub.sync_handler_manager import (
 from azure.iot.device.iothub.sync_handler_manager import MESSAGE, METHOD, TWIN_DP_PATCH
 from azure.iot.device.iothub.inbox_manager import InboxManager
 from azure.iot.device.iothub.aio.async_inbox import AsyncClientInbox
+from tests.unit.helpers import EVENTUAL_TIMEOUT
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -413,7 +414,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         mock_obj = mocker.MagicMock()
         inbox.put(mock_obj)
         # Wait for the handler invocation to complete
-        await async_poll_until(lambda: handler_checker.handler_called, timeout=5)
+        await async_poll_until(lambda: handler_checker.handler_called, timeout=EVENTUAL_TIMEOUT)
 
         # Handler has been called with the item from the inbox
         assert handler_checker.handler_called is True
@@ -441,7 +442,9 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         for _ in range(5):
             inbox.put(mocker.MagicMock())
         # Wait for all handler invocations to complete
-        await async_poll_until(lambda: handler_checker.handler_call_count >= 5, timeout=5)
+        await async_poll_until(
+            lambda: handler_checker.handler_call_count >= 5, timeout=EVENTUAL_TIMEOUT
+        )
 
         # Handler has been called 5 times
         assert handler_checker.handler_call_count == 5
@@ -550,7 +553,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
         # Wait for the background exception handler to be called
-        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=5)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -567,7 +570,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
         # Wait for the background exception handler to be called
-        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=5)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -596,7 +599,8 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         inbox.put(mocker.MagicMock())
         # Wait for handler1 to replace itself with handler2
         await async_poll_until(
-            lambda: getattr(handler_manager, handler_name) is handler2, timeout=5
+            lambda: getattr(handler_manager, handler_name) is handler2,
+            timeout=EVENTUAL_TIMEOUT,
         )
         # The set handler (handler1) has been replaced with a new handler (handler2)
         assert getattr(handler_manager, handler_name) is not handler1
@@ -605,7 +609,8 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         inbox.put(mocker.MagicMock())
         # Wait for handler2 to replace itself with the mock
         await async_poll_until(
-            lambda: getattr(handler_manager, handler_name) is mock_handler, timeout=5
+            lambda: getattr(handler_manager, handler_name) is mock_handler,
+            timeout=EVENTUAL_TIMEOUT,
         )
         # The set handler (handler2) has now been replaced by a mock handler
         assert getattr(handler_manager, handler_name) is not handler2
@@ -613,7 +618,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
         # Wait for the mock handler invocation to complete
-        await async_poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
+        await async_poll_until(lambda: mock_handler.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 
@@ -706,7 +711,9 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add the event to the client inbox
         inbox.put(event)
         # Wait for the handler invocation to complete
-        await async_poll_until(lambda: handler_checker.handler_call_count >= 1, timeout=5)
+        await async_poll_until(
+            lambda: handler_checker.handler_call_count >= 1, timeout=EVENTUAL_TIMEOUT
+        )
 
         # Handler has been called with the arguments from the event
         assert handler_checker.handler_call_count == 1
@@ -716,7 +723,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         non_matching_event = client_event.ClientEvent("NON_MATCHING_EVENT")
         inbox.put(non_matching_event)
         # Wait for the runner to consume the non-matching event
-        await async_poll_until(inbox.empty, timeout=5)
+        await async_poll_until(inbox.empty, timeout=EVENTUAL_TIMEOUT)
 
         # Handler has not been called again
         assert handler_checker.handler_call_count == 1
@@ -743,7 +750,9 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         for _ in range(5):
             inbox.put(event)
         # Wait for all handler invocations to complete
-        await async_poll_until(lambda: handler_checker.handler_call_count >= 5, timeout=5)
+        await async_poll_until(
+            lambda: handler_checker.handler_call_count >= 5, timeout=EVENTUAL_TIMEOUT
+        )
 
         # Handler has been called 5 times
         assert handler_checker.handler_call_count == 5
@@ -777,7 +786,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(event)
         # Wait for the background exception handler to be called
-        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=5)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -794,7 +803,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(event)
         # Wait for the background exception handler to be called
-        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=5)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -823,7 +832,8 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         inbox.put(event)
         # Wait for handler1 to replace itself with handler2
         await async_poll_until(
-            lambda: getattr(handler_manager, handler_name) is handler2, timeout=5
+            lambda: getattr(handler_manager, handler_name) is handler2,
+            timeout=EVENTUAL_TIMEOUT,
         )
         # The set handler (handler1) has been replaced with a new handler (handler2)
         assert getattr(handler_manager, handler_name) is not handler1
@@ -832,7 +842,8 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         inbox.put(event)
         # Wait for handler2 to replace itself with the mock
         await async_poll_until(
-            lambda: getattr(handler_manager, handler_name) is mock_handler, timeout=5
+            lambda: getattr(handler_manager, handler_name) is mock_handler,
+            timeout=EVENTUAL_TIMEOUT,
         )
         # The set handler (handler2) has now been replaced by a mock handler
         assert getattr(handler_manager, handler_name) is not handler2
@@ -840,7 +851,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add a new item to the inbox
         inbox.put(event)
         # Wait for the mock handler invocation to complete
-        await async_poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
+        await async_poll_until(lambda: mock_handler.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 

--- a/tests/unit/iothub/aio/test_async_handler_manager.py
+++ b/tests/unit/iothub/aio/test_async_handler_manager.py
@@ -465,7 +465,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
 
         async def controlled_get():
             nonlocal get_count
-            item = await original_get()
+            item = await asyncio.wait_for(original_get(), timeout=5)
             get_count += 1
             if get_count == 2:
                 runner_paused.set()

--- a/tests/unit/iothub/aio/test_async_handler_manager.py
+++ b/tests/unit/iothub/aio/test_async_handler_manager.py
@@ -401,7 +401,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         handler,
         handler_checker,
         inbox,
-        async_wait_for,
+        async_poll_until,
     ):
         # Set the handler
         setattr(handler_manager, handler_name, handler)
@@ -412,7 +412,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to the associated inbox, triggering the handler
         mock_obj = mocker.MagicMock()
         inbox.put(mock_obj)
-        await async_wait_for(lambda: handler_checker.handler_called)
+        await async_poll_until(lambda: handler_checker.handler_called)
 
         # Handler has been called with the item from the inbox
         assert handler_checker.handler_called is True
@@ -429,7 +429,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         handler,
         handler_checker,
         inbox,
-        async_wait_for,
+        async_poll_until,
     ):
         # Set the handler
         setattr(handler_manager, handler_name, handler)
@@ -439,7 +439,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add 5 items to the associated inbox, triggering the handler
         for _ in range(5):
             inbox.put(mocker.MagicMock())
-        await async_wait_for(lambda: handler_checker.handler_call_count >= 5)
+        await async_poll_until(lambda: handler_checker.handler_call_count >= 5)
 
         # Handler has been called 5 times
         assert handler_checker.handler_call_count == 5
@@ -525,7 +525,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         "Sends a HandlerManagerException to the background exception handler if any exception is raised during its invocation"
     )
     async def test_exception_in_handler(
-        self, mocker, handler_name, handler_manager, inbox, arbitrary_exception, async_wait_for
+        self, mocker, handler_name, handler_manager, inbox, arbitrary_exception, async_poll_until
     ):
         # NOTE: this test tests both coroutines and functions without the need for parametrization
         background_exc_spy = mocker.spy(handle_exceptions, "handle_background_exception")
@@ -542,7 +542,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
-        await async_wait_for(lambda: background_exc_spy.call_count >= 1)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -558,7 +558,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
-        await async_wait_for(lambda: background_exc_spy.call_count >= 1)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -569,7 +569,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         "Can be updated with a new value that the corresponding handler runner will immediately begin using for handler invocations instead"
     )
     async def test_handler_update_handler(
-        self, mocker, handler_name, handler_manager, inbox, async_wait_for
+        self, mocker, handler_name, handler_manager, inbox, async_poll_until
     ):
         # NOTE: this test tests both coroutines and functions without the need for parametrization
         mock_handler = mocker.MagicMock()
@@ -585,19 +585,19 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         setattr(handler_manager, handler_name, handler1)
 
         inbox.put(mocker.MagicMock())
-        await async_wait_for(lambda: getattr(handler_manager, handler_name) is handler2)
+        await async_poll_until(lambda: getattr(handler_manager, handler_name) is handler2)
         # The set handler (handler1) has been replaced with a new handler (handler2)
         assert getattr(handler_manager, handler_name) is not handler1
         assert getattr(handler_manager, handler_name) is handler2
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
-        await async_wait_for(lambda: getattr(handler_manager, handler_name) is mock_handler)
+        await async_poll_until(lambda: getattr(handler_manager, handler_name) is mock_handler)
         # The set handler (handler2) has now been replaced by a mock handler
         assert getattr(handler_manager, handler_name) is not handler2
         assert getattr(handler_manager, handler_name) is mock_handler
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
-        await async_wait_for(lambda: mock_handler.call_count >= 1)
+        await async_poll_until(lambda: mock_handler.call_count >= 1)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 
@@ -680,7 +680,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         handler,
         inbox,
         event,
-        async_wait_for,
+        async_poll_until,
     ):
         # Set the handler
         setattr(handler_manager, handler_name, handler)
@@ -689,7 +689,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
 
         # Add the event to the client inbox
         inbox.put(event)
-        await async_wait_for(lambda: handler_checker.handler_call_count >= 1)
+        await async_poll_until(lambda: handler_checker.handler_call_count >= 1)
 
         # Handler has been called with the arguments from the event
         assert handler_checker.handler_call_count == 1
@@ -698,7 +698,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add a non-matching event ot the client event inbox
         non_matching_event = client_event.ClientEvent("NON_MATCHING_EVENT")
         inbox.put(non_matching_event)
-        await async_wait_for(inbox.empty)
+        await async_poll_until(inbox.empty)
 
         # Handler has not been called again
         assert handler_checker.handler_call_count == 1
@@ -714,7 +714,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         handler_checker,
         inbox,
         event,
-        async_wait_for,
+        async_poll_until,
     ):
         # Set the handler
         setattr(handler_manager, handler_name, handler)
@@ -724,7 +724,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add 5 items to the corresponding inbox, triggering the handler
         for _ in range(5):
             inbox.put(event)
-        await async_wait_for(lambda: handler_checker.handler_call_count >= 5)
+        await async_poll_until(lambda: handler_checker.handler_call_count >= 5)
 
         # Handler has been called 5 times
         assert handler_checker.handler_call_count == 5
@@ -740,7 +740,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         inbox,
         event,
         arbitrary_exception,
-        async_wait_for,
+        async_poll_until,
     ):
         # NOTE: this test tests both coroutines and functions without the need for parametrization
         background_exc_spy = mocker.spy(handle_exceptions, "handle_background_exception")
@@ -757,7 +757,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(event)
-        await async_wait_for(lambda: background_exc_spy.call_count >= 1)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -773,7 +773,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(event)
-        await async_wait_for(lambda: background_exc_spy.call_count >= 1)
+        await async_poll_until(lambda: background_exc_spy.call_count >= 1)
         # Background exception handler was called
         assert background_exc_spy.call_count == 1
         e = background_exc_spy.call_args[0][0]
@@ -784,7 +784,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         "Can be updated with a new value that the corresponding handler runner will immediately begin using for handler invocations instead"
     )
     async def test_handler_update_handler(
-        self, mocker, handler_name, handler_manager, inbox, event, async_wait_for
+        self, mocker, handler_name, handler_manager, inbox, event, async_poll_until
     ):
         # NOTE: this test tests both coroutines and functions without the need for parametrization
         mock_handler = mocker.MagicMock()
@@ -800,19 +800,19 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         setattr(handler_manager, handler_name, handler1)
 
         inbox.put(event)
-        await async_wait_for(lambda: getattr(handler_manager, handler_name) is handler2)
+        await async_poll_until(lambda: getattr(handler_manager, handler_name) is handler2)
         # The set handler (handler1) has been replaced with a new handler (handler2)
         assert getattr(handler_manager, handler_name) is not handler1
         assert getattr(handler_manager, handler_name) is handler2
         # Add a new item to the inbox
         inbox.put(event)
-        await async_wait_for(lambda: getattr(handler_manager, handler_name) is mock_handler)
+        await async_poll_until(lambda: getattr(handler_manager, handler_name) is mock_handler)
         # The set handler (handler2) has now been replaced by a mock handler
         assert getattr(handler_manager, handler_name) is not handler2
         assert getattr(handler_manager, handler_name) is mock_handler
         # Add a new item to the inbox
         inbox.put(event)
-        await async_wait_for(lambda: mock_handler.call_count >= 1)
+        await async_poll_until(lambda: mock_handler.call_count >= 1)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 

--- a/tests/unit/iothub/aio/test_async_inbox.py
+++ b/tests/unit/iothub/aio/test_async_inbox.py
@@ -39,7 +39,7 @@ class TestAsyncClientInbox(object):
         assert inbox.empty()
         inbox.put(mocker.MagicMock())
         assert not inbox.empty()
-        await inbox.get()
+        await asyncio.wait_for(inbox.get(), timeout=5)
         assert inbox.empty()
         await asyncio.sleep(0.01)  # Do this to prevent RuntimeWarning from janus
 
@@ -54,9 +54,9 @@ class TestAsyncClientInbox(object):
         inbox.put(item2)
         inbox.put(item3)
 
-        assert await inbox.get() is item1
-        assert await inbox.get() is item2
-        assert await inbox.get() is item3
+        assert await asyncio.wait_for(inbox.get(), timeout=5) is item1
+        assert await asyncio.wait_for(inbox.get(), timeout=5) is item2
+        assert await asyncio.wait_for(inbox.get(), timeout=5) is item3
 
         await asyncio.sleep(0.01)  # Do this to prevent RuntimeWarning from janus
 
@@ -83,7 +83,7 @@ class TestAsyncClientInboxGet(object):
         item = mocker.MagicMock()
         inbox.put(item)
         assert not inbox.empty()
-        retrieved_item = await inbox.get()
+        retrieved_item = await asyncio.wait_for(inbox.get(), timeout=5)
         assert retrieved_item is item
         assert inbox.empty()
 

--- a/tests/unit/iothub/aio/test_async_inbox.py
+++ b/tests/unit/iothub/aio/test_async_inbox.py
@@ -11,6 +11,9 @@ from azure.iot.device.iothub.aio.async_inbox import AsyncClientInbox
 
 logging.basicConfig(level=logging.DEBUG)
 
+# get() crosses the client internal event loop, but an available item should return promptly.
+PROMPT_GET_TIMEOUT = 0.1
+
 # Note that some small delays need to be added at the end of async tests due to
 # RuntimeWarnings being thrown by the test ending before janus can correctly
 # resolve its Futures. This may be a bug in janus.
@@ -39,7 +42,7 @@ class TestAsyncClientInbox(object):
         assert inbox.empty()
         inbox.put(mocker.MagicMock())
         assert not inbox.empty()
-        await asyncio.wait_for(inbox.get(), timeout=5)
+        await asyncio.wait_for(inbox.get(), timeout=PROMPT_GET_TIMEOUT)
         assert inbox.empty()
         await asyncio.sleep(0.01)  # Do this to prevent RuntimeWarning from janus
 
@@ -54,9 +57,9 @@ class TestAsyncClientInbox(object):
         inbox.put(item2)
         inbox.put(item3)
 
-        assert await asyncio.wait_for(inbox.get(), timeout=5) is item1
-        assert await asyncio.wait_for(inbox.get(), timeout=5) is item2
-        assert await asyncio.wait_for(inbox.get(), timeout=5) is item3
+        assert await asyncio.wait_for(inbox.get(), timeout=PROMPT_GET_TIMEOUT) is item1
+        assert await asyncio.wait_for(inbox.get(), timeout=PROMPT_GET_TIMEOUT) is item2
+        assert await asyncio.wait_for(inbox.get(), timeout=PROMPT_GET_TIMEOUT) is item3
 
         await asyncio.sleep(0.01)  # Do this to prevent RuntimeWarning from janus
 
@@ -83,7 +86,7 @@ class TestAsyncClientInboxGet(object):
         item = mocker.MagicMock()
         inbox.put(item)
         assert not inbox.empty()
-        retrieved_item = await asyncio.wait_for(inbox.get(), timeout=5)
+        retrieved_item = await asyncio.wait_for(inbox.get(), timeout=PROMPT_GET_TIMEOUT)
         assert retrieved_item is item
         assert inbox.empty()
 
@@ -103,7 +106,7 @@ class TestAsyncClientInboxGet(object):
         assert not get_task.done()
         # Add the item, allowing the get task to complete
         inbox.put(item)
-        assert await asyncio.wait_for(get_task, timeout=5) is item
+        assert await asyncio.wait_for(get_task, timeout=PROMPT_GET_TIMEOUT) is item
 
 
 @pytest.mark.describe("AsyncClientInbox - .clear()")

--- a/tests/unit/iothub/aio/test_async_inbox.py
+++ b/tests/unit/iothub/aio/test_async_inbox.py
@@ -8,25 +8,31 @@ import pytest
 import asyncio
 import logging
 from azure.iot.device.iothub.aio.async_inbox import AsyncClientInbox
+from azure.iot.device.iothub.aio import loop_management
 from tests.unit.helpers import PROMPT_TIMEOUT
 
 logging.basicConfig(level=logging.DEBUG)
 
-# Note that some small delays need to be added at the end of async tests due to
-# RuntimeWarnings being thrown by the test ending before janus can correctly
-# resolve its Futures. This may be a bug in janus.
+
+@pytest.fixture
+def inbox():
+    inbox = AsyncClientInbox()
+    yield inbox
+
+    # Close the Janus queue on the internal loop where its async API is bound
+    loop = loop_management.get_client_internal_loop()
+    close_future = asyncio.run_coroutine_threadsafe(inbox._queue.aclose(), loop)
+    close_future.result(timeout=PROMPT_TIMEOUT)
 
 
 @pytest.mark.describe("AsyncClientInbox")
 class TestAsyncClientInbox(object):
     @pytest.mark.it("Instantiates empty")
-    def test_instantiates_empty(self):
-        inbox = AsyncClientInbox()
+    def test_instantiates_empty(self, inbox):
         assert inbox.empty()
 
     @pytest.mark.it("Can be checked regarding whether or not it contains an item")
-    def test_check_item_is_in_inbox(self, mocker):
-        inbox = AsyncClientInbox()
+    def test_check_item_is_in_inbox(self, mocker, inbox):
         assert inbox.empty()
         item = mocker.MagicMock()
         assert item not in inbox
@@ -35,19 +41,16 @@ class TestAsyncClientInbox(object):
 
     @pytest.mark.it("Can be checked regarding whether or not it is empty")
     @pytest.mark.asyncio
-    async def test_can_check_if_empty(self, mocker):
-        inbox = AsyncClientInbox()
+    async def test_can_check_if_empty(self, mocker, inbox):
         assert inbox.empty()
         inbox.put(mocker.MagicMock())
         assert not inbox.empty()
         await asyncio.wait_for(inbox.get(), timeout=PROMPT_TIMEOUT)
         assert inbox.empty()
-        await asyncio.sleep(0.01)  # Do this to prevent RuntimeWarning from janus
 
     @pytest.mark.it("Operates according to FIFO")
     @pytest.mark.asyncio
-    async def test_operates_according_to_FIFO(self, mocker):
-        inbox = AsyncClientInbox()
+    async def test_operates_according_to_FIFO(self, mocker, inbox):
         item1 = mocker.MagicMock()
         item2 = mocker.MagicMock()
         item3 = mocker.MagicMock()
@@ -59,14 +62,11 @@ class TestAsyncClientInbox(object):
         assert await asyncio.wait_for(inbox.get(), timeout=PROMPT_TIMEOUT) is item2
         assert await asyncio.wait_for(inbox.get(), timeout=PROMPT_TIMEOUT) is item3
 
-        await asyncio.sleep(0.01)  # Do this to prevent RuntimeWarning from janus
-
 
 @pytest.mark.describe("AsyncClientInbox - .put()")
 class TestAsyncClientInboxPut(object):
     @pytest.mark.it("Adds the given item to the inbox")
-    def test_adds_item_to_inbox(self, mocker):
-        inbox = AsyncClientInbox()
+    def test_adds_item_to_inbox(self, mocker, inbox):
         assert inbox.empty()
         item = mocker.MagicMock()
         inbox.put(item)
@@ -78,8 +78,7 @@ class TestAsyncClientInboxPut(object):
 @pytest.mark.asyncio
 class TestAsyncClientInboxGet(object):
     @pytest.mark.it("Returns and removes the next item from the inbox, if there is one")
-    async def test_removes_item_from_inbox_if_already_there(self, mocker):
-        inbox = AsyncClientInbox()
+    async def test_removes_item_from_inbox_if_already_there(self, mocker, inbox):
         assert inbox.empty()
         item = mocker.MagicMock()
         inbox.put(item)
@@ -88,13 +87,10 @@ class TestAsyncClientInboxGet(object):
         assert retrieved_item is item
         assert inbox.empty()
 
-        await asyncio.sleep(0.01)  # Do this to prevent RuntimeWarning from janus
-
     @pytest.mark.it(
         "Blocks on an empty inbox until an item is available to remove and return, if using blocking mode"
     )
-    async def test_get_waits_for_item_to_be_added_if_inbox_empty(self, mocker):
-        inbox = AsyncClientInbox()
+    async def test_get_waits_for_item_to_be_added_if_inbox_empty(self, mocker, inbox):
         assert inbox.empty()
         item = mocker.MagicMock()
 
@@ -110,8 +106,7 @@ class TestAsyncClientInboxGet(object):
 @pytest.mark.describe("AsyncClientInbox - .clear()")
 class TestAsyncClientInboxClear(object):
     @pytest.mark.it("Clears all items from the inbox")
-    def test_can_clear_all_items(self, mocker):
-        inbox = AsyncClientInbox()
+    def test_can_clear_all_items(self, mocker, inbox):
         item1 = mocker.MagicMock()
         item2 = mocker.MagicMock()
         item3 = mocker.MagicMock()

--- a/tests/unit/iothub/aio/test_async_inbox.py
+++ b/tests/unit/iothub/aio/test_async_inbox.py
@@ -97,15 +97,11 @@ class TestAsyncClientInboxGet(object):
         assert inbox.empty()
         item = mocker.MagicMock()
 
-        async def wait_for_item():
-            retrieved_item = await inbox.get()
-            assert retrieved_item is item
-
-        async def insert_item():
-            await asyncio.sleep(1)  # wait before adding item to ensure the above coroutine is first
-            inbox.put(item)
-
-        await asyncio.gather(wait_for_item(), insert_item())
+        get_task = asyncio.create_task(inbox.get())
+        await asyncio.sleep(0)
+        assert not get_task.done()
+        inbox.put(item)
+        assert await asyncio.wait_for(get_task, timeout=5) is item
 
 
 @pytest.mark.describe("AsyncClientInbox - .clear()")

--- a/tests/unit/iothub/aio/test_async_inbox.py
+++ b/tests/unit/iothub/aio/test_async_inbox.py
@@ -97,9 +97,11 @@ class TestAsyncClientInboxGet(object):
         assert inbox.empty()
         item = mocker.MagicMock()
 
+        # Begin waiting for an item and give the get task a chance to block
         get_task = asyncio.create_task(inbox.get())
         await asyncio.sleep(0)
         assert not get_task.done()
+        # Add the item, allowing the get task to complete
         inbox.put(item)
         assert await asyncio.wait_for(get_task, timeout=5) is item
 

--- a/tests/unit/iothub/aio/test_async_inbox.py
+++ b/tests/unit/iothub/aio/test_async_inbox.py
@@ -8,11 +8,9 @@ import pytest
 import asyncio
 import logging
 from azure.iot.device.iothub.aio.async_inbox import AsyncClientInbox
+from tests.unit.helpers import PROMPT_TIMEOUT
 
 logging.basicConfig(level=logging.DEBUG)
-
-# get() crosses the client internal event loop, but an available item should return promptly.
-PROMPT_GET_TIMEOUT = 0.1
 
 # Note that some small delays need to be added at the end of async tests due to
 # RuntimeWarnings being thrown by the test ending before janus can correctly
@@ -42,7 +40,7 @@ class TestAsyncClientInbox(object):
         assert inbox.empty()
         inbox.put(mocker.MagicMock())
         assert not inbox.empty()
-        await asyncio.wait_for(inbox.get(), timeout=PROMPT_GET_TIMEOUT)
+        await asyncio.wait_for(inbox.get(), timeout=PROMPT_TIMEOUT)
         assert inbox.empty()
         await asyncio.sleep(0.01)  # Do this to prevent RuntimeWarning from janus
 
@@ -57,9 +55,9 @@ class TestAsyncClientInbox(object):
         inbox.put(item2)
         inbox.put(item3)
 
-        assert await asyncio.wait_for(inbox.get(), timeout=PROMPT_GET_TIMEOUT) is item1
-        assert await asyncio.wait_for(inbox.get(), timeout=PROMPT_GET_TIMEOUT) is item2
-        assert await asyncio.wait_for(inbox.get(), timeout=PROMPT_GET_TIMEOUT) is item3
+        assert await asyncio.wait_for(inbox.get(), timeout=PROMPT_TIMEOUT) is item1
+        assert await asyncio.wait_for(inbox.get(), timeout=PROMPT_TIMEOUT) is item2
+        assert await asyncio.wait_for(inbox.get(), timeout=PROMPT_TIMEOUT) is item3
 
         await asyncio.sleep(0.01)  # Do this to prevent RuntimeWarning from janus
 
@@ -86,7 +84,7 @@ class TestAsyncClientInboxGet(object):
         item = mocker.MagicMock()
         inbox.put(item)
         assert not inbox.empty()
-        retrieved_item = await asyncio.wait_for(inbox.get(), timeout=PROMPT_GET_TIMEOUT)
+        retrieved_item = await asyncio.wait_for(inbox.get(), timeout=PROMPT_TIMEOUT)
         assert retrieved_item is item
         assert inbox.empty()
 
@@ -106,7 +104,7 @@ class TestAsyncClientInboxGet(object):
         assert not get_task.done()
         # Add the item, allowing the get task to complete
         inbox.put(item)
-        assert await asyncio.wait_for(get_task, timeout=PROMPT_GET_TIMEOUT) is item
+        assert await asyncio.wait_for(get_task, timeout=PROMPT_TIMEOUT) is item
 
 
 @pytest.mark.describe("AsyncClientInbox - .clear()")

--- a/tests/unit/iothub/test_sync_clients.py
+++ b/tests/unit/iothub/test_sync_clients.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import concurrent.futures
 import pytest
 import logging
 import threading
@@ -822,25 +823,24 @@ class SharedClientReceiveMethodRequestTests(object):
         "method_name",
         [pytest.param(None, id="Generic Method"), pytest.param("method_x", id="Named Method")],
     )
-    def test_no_method_request_in_inbox_blocking_mode(self, client, method_name):
+    def test_no_method_request_in_inbox_blocking_mode(
+        self, client, method_name, track_call_started
+    ):
         request = MethodRequest(request_id="1", name=method_name, payload={"key": "value"})
 
         inbox = client._inbox_manager.get_method_request_inbox(method_name)
         assert inbox.empty()
+        get_started = track_call_started(inbox, "get")
 
-        def insert_item_after_delay():
-            time.sleep(0.01)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            receive_future = executor.submit(
+                client.receive_method_request, method_name=method_name, block=True
+            )
+            assert get_started.wait(timeout=5)
+            assert not receive_future.done()
             inbox.put(request)
-
-        insertion_thread = threading.Thread(target=insert_item_after_delay)
-        insertion_thread.start()
-
-        received_request = client.receive_method_request(method_name, block=True)
+            received_request = receive_future.result(timeout=5)
         assert received_request is request
-        # This proves that the blocking happens because 'received_request' can't be
-        # 'request' until after a 10 millisecond delay on the insert. But because the
-        # 'received_request' IS 'request', it means that client.receive_method_request
-        # did not return until after the delay.
 
     @pytest.mark.it(
         "Returns None after a timeout while blocking, in blocking mode with a specified timeout"
@@ -1317,24 +1317,23 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
         assert inbox_mock.get.call_args == mocker.call(block=True, timeout=None)
 
     @pytest.mark.it("Blocks until a patch is available, in blocking mode")
-    def test_no_message_in_inbox_blocking_mode(self, client, twin_patch_desired):
+    def test_no_message_in_inbox_blocking_mode(
+        self, client, twin_patch_desired, track_call_started
+    ):
 
         twin_patch_inbox = client._inbox_manager.get_twin_patch_inbox()
         assert twin_patch_inbox.empty()
+        get_started = track_call_started(twin_patch_inbox, "get")
 
-        def insert_item_after_delay():
-            time.sleep(0.01)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            receive_future = executor.submit(
+                client.receive_twin_desired_properties_patch, block=True
+            )
+            assert get_started.wait(timeout=5)
+            assert not receive_future.done()
             twin_patch_inbox.put(twin_patch_desired)
-
-        insertion_thread = threading.Thread(target=insert_item_after_delay)
-        insertion_thread.start()
-
-        received_patch = client.receive_twin_desired_properties_patch(block=True)
+            received_patch = receive_future.result(timeout=5)
         assert received_patch is twin_patch_desired
-        # This proves that the blocking happens because 'received_patch' can't be
-        # 'twin_patch_desired' until after a 10 millisecond delay on the insert. But because the
-        # 'received_patch' IS 'twin_patch_desired', it means that client.receive_twin_desired_properties_patch
-        # did not return until after the delay.
 
     @pytest.mark.it(
         "Returns None after a timeout while blocking, in blocking mode with a specified timeout"
@@ -1630,23 +1629,18 @@ class TestIoTHubDeviceClientReceiveC2DMessage(
         assert inbox_mock.get.call_args == mocker.call(block=True, timeout=None)
 
     @pytest.mark.it("Blocks until a message is available, in blocking mode")
-    def test_no_message_in_inbox_blocking_mode(self, client, message):
+    def test_no_message_in_inbox_blocking_mode(self, client, message, track_call_started):
         c2d_inbox = client._inbox_manager.get_c2d_message_inbox()
         assert c2d_inbox.empty()
+        get_started = track_call_started(c2d_inbox, "get")
 
-        def insert_item_after_delay():
-            time.sleep(0.01)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            receive_future = executor.submit(client.receive_message, block=True)
+            assert get_started.wait(timeout=5)
+            assert not receive_future.done()
             c2d_inbox.put(message)
-
-        insertion_thread = threading.Thread(target=insert_item_after_delay)
-        insertion_thread.start()
-
-        received_message = client.receive_message(block=True)
+            received_message = receive_future.result(timeout=5)
         assert received_message is message
-        # This proves that the blocking happens because 'received_message' can't be
-        # 'message' until after a 10 millisecond delay on the insert. But because the
-        # 'received_message' IS 'message', it means that client.receive_message
-        # did not return until after the delay.
 
     @pytest.mark.it(
         "Returns None after a timeout while blocking, in blocking mode with a specified timeout"
@@ -2438,25 +2432,22 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         assert inbox_mock.get.call_args == mocker.call(block=True, timeout=None)
 
     @pytest.mark.it("Blocks until a message is available, in blocking mode")
-    def test_no_message_in_inbox_blocking_mode(self, client, message):
+    def test_no_message_in_inbox_blocking_mode(self, client, message, track_call_started):
         input_name = "some_input"
 
         input_inbox = client._inbox_manager.get_input_message_inbox(input_name)
         assert input_inbox.empty()
+        get_started = track_call_started(input_inbox, "get")
 
-        def insert_item_after_delay():
-            time.sleep(0.01)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            receive_future = executor.submit(
+                client.receive_message_on_input, input_name, block=True
+            )
+            assert get_started.wait(timeout=5)
+            assert not receive_future.done()
             input_inbox.put(message)
-
-        insertion_thread = threading.Thread(target=insert_item_after_delay)
-        insertion_thread.start()
-
-        received_message = client.receive_message_on_input(input_name, block=True)
+            received_message = receive_future.result(timeout=5)
         assert received_message is message
-        # This proves that the blocking happens because 'received_message' can't be
-        # 'message' until after a 10 millisecond delay on the insert. But because the
-        # 'received_message' IS 'message', it means that client.receive_message_on_input
-        # did not return until after the delay.
 
     @pytest.mark.it(
         "Returns None after a timeout while blocking, in blocking mode with a specified timeout"

--- a/tests/unit/iothub/test_sync_clients.py
+++ b/tests/unit/iothub/test_sync_clients.py
@@ -829,16 +829,21 @@ class SharedClientReceiveMethodRequestTests(object):
 
         inbox = client._inbox_manager.get_method_request_inbox(method_name)
         assert inbox.empty()
+        # Track when receive reaches the blocking inbox operation
         get_started = track_call_started(inbox, "get")
 
+        # Begin receiving on a background thread
         receive_future = run_in_daemon_thread(
             client.receive_method_request, method_name=method_name, block=True
         )
         try:
+            # Receive is blocked waiting for a request
             assert get_started.wait(timeout=5)
             assert not receive_future.done()
         finally:
+            # Always add the request so a failed assertion cannot strand the background thread
             inbox.put(request)
+        # Receive returns once the request is available
         received_request = receive_future.result(timeout=5)
         assert received_request is request
 
@@ -1323,16 +1328,21 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
 
         twin_patch_inbox = client._inbox_manager.get_twin_patch_inbox()
         assert twin_patch_inbox.empty()
+        # Track when receive reaches the blocking inbox operation
         get_started = track_call_started(twin_patch_inbox, "get")
 
+        # Begin receiving on a background thread
         receive_future = run_in_daemon_thread(
             client.receive_twin_desired_properties_patch, block=True
         )
         try:
+            # Receive is blocked waiting for a patch
             assert get_started.wait(timeout=5)
             assert not receive_future.done()
         finally:
+            # Always add the patch so a failed assertion cannot strand the background thread
             twin_patch_inbox.put(twin_patch_desired)
+        # Receive returns once the patch is available
         received_patch = receive_future.result(timeout=5)
         assert received_patch is twin_patch_desired
 
@@ -1635,14 +1645,19 @@ class TestIoTHubDeviceClientReceiveC2DMessage(
     ):
         c2d_inbox = client._inbox_manager.get_c2d_message_inbox()
         assert c2d_inbox.empty()
+        # Track when receive reaches the blocking inbox operation
         get_started = track_call_started(c2d_inbox, "get")
 
+        # Begin receiving on a background thread
         receive_future = run_in_daemon_thread(client.receive_message, block=True)
         try:
+            # Receive is blocked waiting for a message
             assert get_started.wait(timeout=5)
             assert not receive_future.done()
         finally:
+            # Always add the message so a failed assertion cannot strand the background thread
             c2d_inbox.put(message)
+        # Receive returns once the message is available
         received_message = receive_future.result(timeout=5)
         assert received_message is message
 
@@ -2443,16 +2458,21 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
 
         input_inbox = client._inbox_manager.get_input_message_inbox(input_name)
         assert input_inbox.empty()
+        # Track when receive reaches the blocking inbox operation
         get_started = track_call_started(input_inbox, "get")
 
+        # Begin receiving on a background thread
         receive_future = run_in_daemon_thread(
             client.receive_message_on_input, input_name, block=True
         )
         try:
+            # Receive is blocked waiting for a message
             assert get_started.wait(timeout=5)
             assert not receive_future.done()
         finally:
+            # Always add the message so a failed assertion cannot strand the background thread
             input_inbox.put(message)
+        # Receive returns once the message is available
         received_message = receive_future.result(timeout=5)
         assert received_message is message
 

--- a/tests/unit/iothub/test_sync_clients.py
+++ b/tests/unit/iothub/test_sync_clients.py
@@ -4,7 +4,6 @@
 # license information.
 # --------------------------------------------------------------------------
 
-import concurrent.futures
 import pytest
 import logging
 import threading
@@ -824,7 +823,7 @@ class SharedClientReceiveMethodRequestTests(object):
         [pytest.param(None, id="Generic Method"), pytest.param("method_x", id="Named Method")],
     )
     def test_no_method_request_in_inbox_blocking_mode(
-        self, client, method_name, track_call_started
+        self, client, method_name, track_call_started, run_in_daemon_thread
     ):
         request = MethodRequest(request_id="1", name=method_name, payload={"key": "value"})
 
@@ -832,14 +831,15 @@ class SharedClientReceiveMethodRequestTests(object):
         assert inbox.empty()
         get_started = track_call_started(inbox, "get")
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            receive_future = executor.submit(
-                client.receive_method_request, method_name=method_name, block=True
-            )
+        receive_future = run_in_daemon_thread(
+            client.receive_method_request, method_name=method_name, block=True
+        )
+        try:
             assert get_started.wait(timeout=5)
             assert not receive_future.done()
+        finally:
             inbox.put(request)
-            received_request = receive_future.result(timeout=5)
+        received_request = receive_future.result(timeout=5)
         assert received_request is request
 
     @pytest.mark.it(
@@ -1318,21 +1318,22 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
 
     @pytest.mark.it("Blocks until a patch is available, in blocking mode")
     def test_no_message_in_inbox_blocking_mode(
-        self, client, twin_patch_desired, track_call_started
+        self, client, twin_patch_desired, track_call_started, run_in_daemon_thread
     ):
 
         twin_patch_inbox = client._inbox_manager.get_twin_patch_inbox()
         assert twin_patch_inbox.empty()
         get_started = track_call_started(twin_patch_inbox, "get")
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            receive_future = executor.submit(
-                client.receive_twin_desired_properties_patch, block=True
-            )
+        receive_future = run_in_daemon_thread(
+            client.receive_twin_desired_properties_patch, block=True
+        )
+        try:
             assert get_started.wait(timeout=5)
             assert not receive_future.done()
+        finally:
             twin_patch_inbox.put(twin_patch_desired)
-            received_patch = receive_future.result(timeout=5)
+        received_patch = receive_future.result(timeout=5)
         assert received_patch is twin_patch_desired
 
     @pytest.mark.it(
@@ -1629,17 +1630,20 @@ class TestIoTHubDeviceClientReceiveC2DMessage(
         assert inbox_mock.get.call_args == mocker.call(block=True, timeout=None)
 
     @pytest.mark.it("Blocks until a message is available, in blocking mode")
-    def test_no_message_in_inbox_blocking_mode(self, client, message, track_call_started):
+    def test_no_message_in_inbox_blocking_mode(
+        self, client, message, track_call_started, run_in_daemon_thread
+    ):
         c2d_inbox = client._inbox_manager.get_c2d_message_inbox()
         assert c2d_inbox.empty()
         get_started = track_call_started(c2d_inbox, "get")
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            receive_future = executor.submit(client.receive_message, block=True)
+        receive_future = run_in_daemon_thread(client.receive_message, block=True)
+        try:
             assert get_started.wait(timeout=5)
             assert not receive_future.done()
+        finally:
             c2d_inbox.put(message)
-            received_message = receive_future.result(timeout=5)
+        received_message = receive_future.result(timeout=5)
         assert received_message is message
 
     @pytest.mark.it(
@@ -2432,21 +2436,24 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         assert inbox_mock.get.call_args == mocker.call(block=True, timeout=None)
 
     @pytest.mark.it("Blocks until a message is available, in blocking mode")
-    def test_no_message_in_inbox_blocking_mode(self, client, message, track_call_started):
+    def test_no_message_in_inbox_blocking_mode(
+        self, client, message, track_call_started, run_in_daemon_thread
+    ):
         input_name = "some_input"
 
         input_inbox = client._inbox_manager.get_input_message_inbox(input_name)
         assert input_inbox.empty()
         get_started = track_call_started(input_inbox, "get")
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            receive_future = executor.submit(
-                client.receive_message_on_input, input_name, block=True
-            )
+        receive_future = run_in_daemon_thread(
+            client.receive_message_on_input, input_name, block=True
+        )
+        try:
             assert get_started.wait(timeout=5)
             assert not receive_future.done()
+        finally:
             input_inbox.put(message)
-            received_message = receive_future.result(timeout=5)
+        received_message = receive_future.result(timeout=5)
         assert received_message is message
 
     @pytest.mark.it(

--- a/tests/unit/iothub/test_sync_clients.py
+++ b/tests/unit/iothub/test_sync_clients.py
@@ -823,28 +823,20 @@ class SharedClientReceiveMethodRequestTests(object):
         [pytest.param(None, id="Generic Method"), pytest.param("method_x", id="Named Method")],
     )
     def test_no_method_request_in_inbox_blocking_mode(
-        self, client, method_name, track_call_started, run_in_daemon_thread
+        self, client, method_name, assert_call_blocks
     ):
         request = MethodRequest(request_id="1", name=method_name, payload={"key": "value"})
 
         inbox = client._inbox_manager.get_method_request_inbox(method_name)
         assert inbox.empty()
-        # Track when receive reaches the blocking inbox operation
-        get_started = track_call_started(inbox, "get")
 
-        # Begin receiving on a background thread
-        receive_future = run_in_daemon_thread(
-            client.receive_method_request, method_name=method_name, block=True
+        # Receive blocks on the empty inbox until the request is added
+        received_request = assert_call_blocks(
+            client.receive_method_request,
+            blocked_on=inbox.get,
+            release=lambda: inbox.put(request),
+            kwargs={"method_name": method_name, "block": True},
         )
-        try:
-            # Receive is blocked waiting for a request
-            assert get_started.wait(timeout=5)
-            assert not receive_future.done()
-        finally:
-            # Always add the request so a failed assertion cannot strand the background thread
-            inbox.put(request)
-        # Receive returns once the request is available
-        received_request = receive_future.result(timeout=5)
         assert received_request is request
 
     @pytest.mark.it(
@@ -1323,27 +1315,19 @@ class SharedClientReceiveTwinDesiredPropertiesPatchTests(object):
 
     @pytest.mark.it("Blocks until a patch is available, in blocking mode")
     def test_no_message_in_inbox_blocking_mode(
-        self, client, twin_patch_desired, track_call_started, run_in_daemon_thread
+        self, client, twin_patch_desired, assert_call_blocks
     ):
 
         twin_patch_inbox = client._inbox_manager.get_twin_patch_inbox()
         assert twin_patch_inbox.empty()
-        # Track when receive reaches the blocking inbox operation
-        get_started = track_call_started(twin_patch_inbox, "get")
 
-        # Begin receiving on a background thread
-        receive_future = run_in_daemon_thread(
-            client.receive_twin_desired_properties_patch, block=True
+        # Receive blocks on the empty inbox until the patch is added
+        received_patch = assert_call_blocks(
+            client.receive_twin_desired_properties_patch,
+            blocked_on=twin_patch_inbox.get,
+            release=lambda: twin_patch_inbox.put(twin_patch_desired),
+            kwargs={"block": True},
         )
-        try:
-            # Receive is blocked waiting for a patch
-            assert get_started.wait(timeout=5)
-            assert not receive_future.done()
-        finally:
-            # Always add the patch so a failed assertion cannot strand the background thread
-            twin_patch_inbox.put(twin_patch_desired)
-        # Receive returns once the patch is available
-        received_patch = receive_future.result(timeout=5)
         assert received_patch is twin_patch_desired
 
     @pytest.mark.it(
@@ -1640,25 +1624,17 @@ class TestIoTHubDeviceClientReceiveC2DMessage(
         assert inbox_mock.get.call_args == mocker.call(block=True, timeout=None)
 
     @pytest.mark.it("Blocks until a message is available, in blocking mode")
-    def test_no_message_in_inbox_blocking_mode(
-        self, client, message, track_call_started, run_in_daemon_thread
-    ):
+    def test_no_message_in_inbox_blocking_mode(self, client, message, assert_call_blocks):
         c2d_inbox = client._inbox_manager.get_c2d_message_inbox()
         assert c2d_inbox.empty()
-        # Track when receive reaches the blocking inbox operation
-        get_started = track_call_started(c2d_inbox, "get")
 
-        # Begin receiving on a background thread
-        receive_future = run_in_daemon_thread(client.receive_message, block=True)
-        try:
-            # Receive is blocked waiting for a message
-            assert get_started.wait(timeout=5)
-            assert not receive_future.done()
-        finally:
-            # Always add the message so a failed assertion cannot strand the background thread
-            c2d_inbox.put(message)
-        # Receive returns once the message is available
-        received_message = receive_future.result(timeout=5)
+        # Receive blocks on the empty inbox until the message is added
+        received_message = assert_call_blocks(
+            client.receive_message,
+            blocked_on=c2d_inbox.get,
+            release=lambda: c2d_inbox.put(message),
+            kwargs={"block": True},
+        )
         assert received_message is message
 
     @pytest.mark.it(
@@ -2451,29 +2427,20 @@ class TestIoTHubModuleClientReceiveInputMessage(IoTHubModuleClientTestsConfig):
         assert inbox_mock.get.call_args == mocker.call(block=True, timeout=None)
 
     @pytest.mark.it("Blocks until a message is available, in blocking mode")
-    def test_no_message_in_inbox_blocking_mode(
-        self, client, message, track_call_started, run_in_daemon_thread
-    ):
+    def test_no_message_in_inbox_blocking_mode(self, client, message, assert_call_blocks):
         input_name = "some_input"
 
         input_inbox = client._inbox_manager.get_input_message_inbox(input_name)
         assert input_inbox.empty()
-        # Track when receive reaches the blocking inbox operation
-        get_started = track_call_started(input_inbox, "get")
 
-        # Begin receiving on a background thread
-        receive_future = run_in_daemon_thread(
-            client.receive_message_on_input, input_name, block=True
+        # Receive blocks on the empty inbox until the message is added
+        received_message = assert_call_blocks(
+            client.receive_message_on_input,
+            blocked_on=input_inbox.get,
+            release=lambda: input_inbox.put(message),
+            args=(input_name,),
+            kwargs={"block": True},
         )
-        try:
-            # Receive is blocked waiting for a message
-            assert get_started.wait(timeout=5)
-            assert not receive_future.done()
-        finally:
-            # Always add the message so a failed assertion cannot strand the background thread
-            input_inbox.put(message)
-        # Receive returns once the message is available
-        received_message = receive_future.result(timeout=5)
         assert received_message is message
 
     @pytest.mark.it(

--- a/tests/unit/iothub/test_sync_handler_manager.py
+++ b/tests/unit/iothub/test_sync_handler_manager.py
@@ -362,6 +362,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         mock_obj = mocker.MagicMock()
         inbox.put(mock_obj)
+        # Wait for the handler invocation to complete
         poll_until(lambda: mock_handler.call_count >= 1)
 
         # Handler has been called with the item from the inbox
@@ -383,6 +384,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add 5 items to the corresponding inbox, triggering the handler
         for _ in range(5):
             inbox.put(mocker.MagicMock())
+        # Wait for all handler invocations to complete
         poll_until(lambda: mock_handler.call_count >= 5)
 
         # Handler has been called 5 times
@@ -394,6 +396,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
     def test_handler_resolve_pending_items_before_handler_removal(
         self, mocker, handler_name, handler_manager, inbox, run_in_daemon_thread
     ):
+        # Intercept inbox operations so the runner can be paused with work remaining
         original_get = inbox.get
         original_put = inbox.put
         runner_paused = threading.Event()
@@ -431,17 +434,21 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Set the handler
         setattr(handler_manager, handler_name, mock_handler)
         try:
+            # Runner is paused after retrieving one item, with more items still pending
             assert runner_paused.wait(timeout=5)
             assert mock_handler.call_count < 100
             assert not inbox.empty()
 
-            # Remove the handler while items are still pending
+            # Begin handler removal, which blocks until the runner exits
             removal_future = run_in_daemon_thread(setattr, handler_manager, handler_name, None)
+            # Removal has queued its sentinel but cannot complete while the runner is paused
             assert sentinel_added.wait(timeout=5)
             assert not removal_future.done()
+            # Release the runner so it can process all pending items
             resume_runner.set()
             removal_future.result(timeout=5)
         finally:
+            # Always release the runner so a failed assertion cannot strand it
             resume_runner.set()
 
         # Despite removal, handler has been called for everything that was in the inbox at the
@@ -477,6 +484,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
+        # Wait for the background exception handler to be called
         poll_until(lambda: background_exc_spy.call_count >= 1)
         # Handler has now been called
         assert mock_handler.call_count == 1
@@ -497,12 +505,14 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         setattr(handler_manager, handler_name, handler)
 
         inbox.put(mocker.MagicMock())
+        # Wait for the handler to replace itself with the mock
         poll_until(lambda: getattr(handler_manager, handler_name) is not handler)
         # Handler has been replaced with a mock, but the mock has not been invoked
         assert getattr(handler_manager, handler_name) is not handler
         assert getattr(handler_manager, handler_name).call_count == 0
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
+        # Wait for the mock handler invocation to complete
         poll_until(lambda: getattr(handler_manager, handler_name).call_count >= 1)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
@@ -586,6 +596,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
 
         # Add the event to the client event inbox
         inbox.put(event)
+        # Wait for the handler invocation to complete
         poll_until(lambda: mock_handler.call_count >= 1)
 
         # Handler has been called with the arguments from the event
@@ -595,6 +606,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add non-matching event to the client event inbox
         non_matching_event = client_event.ClientEvent("NON_MATCHING_EVENT")
         inbox.put(non_matching_event)
+        # Wait for the runner to consume the non-matching event
         poll_until(inbox.empty)
 
         # Handler has not been called again
@@ -615,6 +627,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add 5 matching events to the corresponding inbox, triggering the handler
         for _ in range(5):
             inbox.put(event)
+        # Wait for all handler invocations to complete
         poll_until(lambda: mock_handler.call_count >= 5)
 
         # Handler has been called 5 times
@@ -638,6 +651,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add the event to the client event inbox, triggering the handler
         inbox.put(event)
+        # Wait for the background exception handler to be called
         poll_until(lambda: background_exc_spy.call_count >= 1)
         # Handler has now been called
         assert mock_handler.call_count == 1
@@ -658,12 +672,14 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         setattr(handler_manager, handler_name, handler)
 
         inbox.put(event)
+        # Wait for the handler to replace itself with the mock
         poll_until(lambda: getattr(handler_manager, handler_name) is not handler)
         # Handler has been replaced with a mock, but the mock has not been invoked
         assert getattr(handler_manager, handler_name) is not handler
         assert getattr(handler_manager, handler_name).call_count == 0
         # Add a new event to the inbox
         inbox.put(event)
+        # Wait for the mock handler invocation to complete
         poll_until(lambda: getattr(handler_manager, handler_name).call_count >= 1)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1

--- a/tests/unit/iothub/test_sync_handler_manager.py
+++ b/tests/unit/iothub/test_sync_handler_manager.py
@@ -7,7 +7,6 @@ import logging
 import pytest
 import threading
 import time
-import concurrent.futures
 from azure.iot.device.common import handle_exceptions
 from azure.iot.device.iothub import client_event
 from azure.iot.device.iothub.sync_handler_manager import (
@@ -391,7 +390,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         "Is invoked for every item already in the corresponding Inbox at the moment of handler removal"
     )
     def test_handler_resolve_pending_items_before_handler_removal(
-        self, mocker, handler_name, handler_manager, inbox
+        self, mocker, handler_name, handler_manager, inbox, run_in_daemon_thread
     ):
         original_get = inbox.get
         original_put = inbox.put
@@ -435,14 +434,11 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
             assert not inbox.empty()
 
             # Remove the handler while items are still pending
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                removal_future = executor.submit(setattr, handler_manager, handler_name, None)
-                try:
-                    assert sentinel_added.wait(timeout=5)
-                    assert not removal_future.done()
-                finally:
-                    resume_runner.set()
-                removal_future.result(timeout=5)
+            removal_future = run_in_daemon_thread(setattr, handler_manager, handler_name, None)
+            assert sentinel_added.wait(timeout=5)
+            assert not removal_future.done()
+            resume_runner.set()
+            removal_future.result(timeout=5)
         finally:
             resume_runner.set()
 

--- a/tests/unit/iothub/test_sync_handler_manager.py
+++ b/tests/unit/iothub/test_sync_handler_manager.py
@@ -17,6 +17,7 @@ from azure.iot.device.iothub.sync_handler_manager import (
 from azure.iot.device.iothub.sync_handler_manager import MESSAGE, METHOD, TWIN_DP_PATCH
 from azure.iot.device.iothub.inbox_manager import InboxManager
 from azure.iot.device.iothub.sync_inbox import SyncClientInbox
+from tests.unit.helpers import EVENTUAL_TIMEOUT
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -363,7 +364,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         mock_obj = mocker.MagicMock()
         inbox.put(mock_obj)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
 
         # Handler has been called with the item from the inbox
         assert mock_handler.call_count == 1
@@ -385,7 +386,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         for _ in range(5):
             inbox.put(mocker.MagicMock())
         # Wait for all handler invocations to complete
-        poll_until(lambda: mock_handler.call_count >= 5, timeout=5)
+        poll_until(lambda: mock_handler.call_count >= 5, timeout=EVENTUAL_TIMEOUT)
 
         # Handler has been called 5 times
         assert mock_handler.call_count == 5
@@ -485,7 +486,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
         # Wait for the background exception handler to be called
-        poll_until(lambda: background_exc_spy.call_count >= 1, timeout=5)
+        poll_until(lambda: background_exc_spy.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
         # Handler has now been called
         assert mock_handler.call_count == 1
         # Background exception handler was called
@@ -506,14 +507,20 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
 
         inbox.put(mocker.MagicMock())
         # Wait for the handler to replace itself with the mock
-        poll_until(lambda: getattr(handler_manager, handler_name) is not handler, timeout=5)
+        poll_until(
+            lambda: getattr(handler_manager, handler_name) is not handler,
+            timeout=EVENTUAL_TIMEOUT,
+        )
         # Handler has been replaced with a mock, but the mock has not been invoked
         assert getattr(handler_manager, handler_name) is not handler
         assert getattr(handler_manager, handler_name).call_count == 0
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
         # Wait for the mock handler invocation to complete
-        poll_until(lambda: getattr(handler_manager, handler_name).call_count >= 1, timeout=5)
+        poll_until(
+            lambda: getattr(handler_manager, handler_name).call_count >= 1,
+            timeout=EVENTUAL_TIMEOUT,
+        )
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 
@@ -597,7 +604,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add the event to the client event inbox
         inbox.put(event)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
 
         # Handler has been called with the arguments from the event
         assert mock_handler.call_count == 1
@@ -607,7 +614,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         non_matching_event = client_event.ClientEvent("NON_MATCHING_EVENT")
         inbox.put(non_matching_event)
         # Wait for the runner to consume the non-matching event
-        poll_until(inbox.empty, timeout=5)
+        poll_until(inbox.empty, timeout=EVENTUAL_TIMEOUT)
 
         # Handler has not been called again
         assert mock_handler.call_count == 1
@@ -628,7 +635,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         for _ in range(5):
             inbox.put(event)
         # Wait for all handler invocations to complete
-        poll_until(lambda: mock_handler.call_count >= 5, timeout=5)
+        poll_until(lambda: mock_handler.call_count >= 5, timeout=EVENTUAL_TIMEOUT)
 
         # Handler has been called 5 times
         assert mock_handler.call_count == 5
@@ -652,7 +659,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add the event to the client event inbox, triggering the handler
         inbox.put(event)
         # Wait for the background exception handler to be called
-        poll_until(lambda: background_exc_spy.call_count >= 1, timeout=5)
+        poll_until(lambda: background_exc_spy.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
         # Handler has now been called
         assert mock_handler.call_count == 1
         # Background exception handler was called
@@ -673,14 +680,20 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
 
         inbox.put(event)
         # Wait for the handler to replace itself with the mock
-        poll_until(lambda: getattr(handler_manager, handler_name) is not handler, timeout=5)
+        poll_until(
+            lambda: getattr(handler_manager, handler_name) is not handler,
+            timeout=EVENTUAL_TIMEOUT,
+        )
         # Handler has been replaced with a mock, but the mock has not been invoked
         assert getattr(handler_manager, handler_name) is not handler
         assert getattr(handler_manager, handler_name).call_count == 0
         # Add a new event to the inbox
         inbox.put(event)
         # Wait for the mock handler invocation to complete
-        poll_until(lambda: getattr(handler_manager, handler_name).call_count >= 1, timeout=5)
+        poll_until(
+            lambda: getattr(handler_manager, handler_name).call_count >= 1,
+            timeout=EVENTUAL_TIMEOUT,
+        )
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 

--- a/tests/unit/iothub/test_sync_handler_manager.py
+++ b/tests/unit/iothub/test_sync_handler_manager.py
@@ -6,9 +6,15 @@
 import logging
 import pytest
 import threading
+import time
+import concurrent.futures
 from azure.iot.device.common import handle_exceptions
 from azure.iot.device.iothub import client_event
-from azure.iot.device.iothub.sync_handler_manager import SyncHandlerManager, HandlerManagerException
+from azure.iot.device.iothub.sync_handler_manager import (
+    SyncHandlerManager,
+    HandlerManagerException,
+    HandlerRunnerKillerSentinel,
+)
 from azure.iot.device.iothub.sync_handler_manager import MESSAGE, METHOD, TWIN_DP_PATCH
 from azure.iot.device.iothub.inbox_manager import InboxManager
 from azure.iot.device.iothub.sync_inbox import SyncClientInbox
@@ -387,6 +393,30 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
     def test_handler_resolve_pending_items_before_handler_removal(
         self, mocker, handler_name, handler_manager, inbox
     ):
+        original_get = inbox.get
+        original_put = inbox.put
+        runner_paused = threading.Event()
+        resume_runner = threading.Event()
+        sentinel_added = threading.Event()
+        get_count = 0
+
+        def controlled_get(*args, **kwargs):
+            nonlocal get_count
+            item = original_get(*args, **kwargs)
+            get_count += 1
+            if get_count == 2:
+                runner_paused.set()
+                assert resume_runner.wait(timeout=5)
+            return item
+
+        def tracked_put(item):
+            original_put(item)
+            if isinstance(item, HandlerRunnerKillerSentinel):
+                sentinel_added.set()
+
+        mocker.patch.object(inbox, "get", side_effect=controlled_get)
+        mocker.patch.object(inbox, "put", side_effect=tracked_put)
+
         # Use a threadsafe mock to ensure accurate counts
         mock_handler = ThreadsafeMock()
         assert inbox.empty()
@@ -399,13 +429,23 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         assert not inbox.empty()
         # Set the handler
         setattr(handler_manager, handler_name, mock_handler)
-        # The handler has not yet been called for everything that was in the inbox
-        # NOTE: I'd really like to show that the handler call count is also > 0 here, but
-        # it's pretty difficult to make the timing work
-        assert mock_handler.call_count < 100
+        try:
+            assert runner_paused.wait(timeout=5)
+            assert mock_handler.call_count < 100
+            assert not inbox.empty()
 
-        # Immediately remove the handler
-        setattr(handler_manager, handler_name, None)
+            # Remove the handler while items are still pending
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                removal_future = executor.submit(setattr, handler_manager, handler_name, None)
+                try:
+                    assert sentinel_added.wait(timeout=5)
+                    assert not removal_future.done()
+                finally:
+                    resume_runner.set()
+                removal_future.result(timeout=5)
+        finally:
+            resume_runner.set()
+
         # Despite removal, handler has been called for everything that was in the inbox at the
         # time of the removal
         assert mock_handler.call_count == 100
@@ -414,6 +454,8 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add some more items
         for _ in range(100):
             inbox.put(mocker.MagicMock())
+        # Give any incorrectly retained runner an opportunity to invoke the handler
+        time.sleep(0.2)
         # Despite more items added to inbox, no further handler calls have been made beyond the
         # initial calls that were made when the original items were added
         assert mock_handler.call_count == 100

--- a/tests/unit/iothub/test_sync_handler_manager.py
+++ b/tests/unit/iothub/test_sync_handler_manager.py
@@ -352,7 +352,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
     @pytest.mark.it(
         "Is invoked by the runner when the Inbox corresponding to the handler receives an object, passing that object to the handler"
     )
-    def test_handler_invoked(self, mocker, handler_name, handler_manager, inbox, wait_for):
+    def test_handler_invoked(self, mocker, handler_name, handler_manager, inbox, poll_until):
         # Set the handler
         mock_handler = mocker.MagicMock()
         setattr(handler_manager, handler_name, mock_handler)
@@ -362,7 +362,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         mock_obj = mocker.MagicMock()
         inbox.put(mock_obj)
-        wait_for(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1)
 
         # Handler has been called with the item from the inbox
         assert mock_handler.call_count == 1
@@ -371,7 +371,9 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
     @pytest.mark.it(
         "Is invoked by the runner every time the Inbox corresponding to the handler receives an object"
     )
-    def test_handler_invoked_multiple(self, mocker, handler_name, handler_manager, inbox, wait_for):
+    def test_handler_invoked_multiple(
+        self, mocker, handler_name, handler_manager, inbox, poll_until
+    ):
         # Set the handler
         mock_handler = ThreadsafeMock()
         setattr(handler_manager, handler_name, mock_handler)
@@ -381,7 +383,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add 5 items to the corresponding inbox, triggering the handler
         for _ in range(5):
             inbox.put(mocker.MagicMock())
-        wait_for(lambda: mock_handler.call_count >= 5)
+        poll_until(lambda: mock_handler.call_count >= 5)
 
         # Handler has been called 5 times
         assert mock_handler.call_count == 5
@@ -461,7 +463,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         "Sends a HandlerManagerException to the background exception handler if any exception is raised during its invocation"
     )
     def test_exception_in_handler(
-        self, mocker, handler_name, handler_manager, inbox, arbitrary_exception, wait_for
+        self, mocker, handler_name, handler_manager, inbox, arbitrary_exception, poll_until
     ):
         background_exc_spy = mocker.spy(handle_exceptions, "handle_background_exception")
         # Handler will raise exception when called
@@ -475,7 +477,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
-        wait_for(lambda: background_exc_spy.call_count >= 1)
+        poll_until(lambda: background_exc_spy.call_count >= 1)
         # Handler has now been called
         assert mock_handler.call_count == 1
         # Background exception handler was called
@@ -487,7 +489,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
     @pytest.mark.it(
         "Can be updated with a new value that the corresponding handler runner will immediately begin using for handler invocations instead"
     )
-    def test_handler_update_handler(self, mocker, handler_name, handler_manager, inbox, wait_for):
+    def test_handler_update_handler(self, mocker, handler_name, handler_manager, inbox, poll_until):
         def handler(arg):
             # Invoking handler replaces the set handler with a mock
             setattr(handler_manager, handler_name, mocker.MagicMock())
@@ -495,13 +497,13 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         setattr(handler_manager, handler_name, handler)
 
         inbox.put(mocker.MagicMock())
-        wait_for(lambda: getattr(handler_manager, handler_name) is not handler)
+        poll_until(lambda: getattr(handler_manager, handler_name) is not handler)
         # Handler has been replaced with a mock, but the mock has not been invoked
         assert getattr(handler_manager, handler_name) is not handler
         assert getattr(handler_manager, handler_name).call_count == 0
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
-        wait_for(lambda: getattr(handler_manager, handler_name).call_count >= 1)
+        poll_until(lambda: getattr(handler_manager, handler_name).call_count >= 1)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 
@@ -575,7 +577,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
     @pytest.mark.it(
         "Is invoked by the runner only when the Client Event Inbox receives a matching Client Event, passing any arguments to the handler"
     )
-    def test_handler_invoked(self, mocker, handler_name, handler_manager, inbox, event, wait_for):
+    def test_handler_invoked(self, mocker, handler_name, handler_manager, inbox, event, poll_until):
         # Set the handler
         mock_handler = mocker.MagicMock()
         setattr(handler_manager, handler_name, mock_handler)
@@ -584,7 +586,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
 
         # Add the event to the client event inbox
         inbox.put(event)
-        wait_for(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1)
 
         # Handler has been called with the arguments from the event
         assert mock_handler.call_count == 1
@@ -593,7 +595,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add non-matching event to the client event inbox
         non_matching_event = client_event.ClientEvent("NON_MATCHING_EVENT")
         inbox.put(non_matching_event)
-        wait_for(inbox.empty)
+        poll_until(inbox.empty)
 
         # Handler has not been called again
         assert mock_handler.call_count == 1
@@ -601,7 +603,9 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
     @pytest.mark.it(
         "Is invoked by the runner every time the Client Event Inbox receives a matching Client Event"
     )
-    def test_handler_invoked_multiple(self, handler_name, handler_manager, inbox, event, wait_for):
+    def test_handler_invoked_multiple(
+        self, handler_name, handler_manager, inbox, event, poll_until
+    ):
         # Set the handler
         mock_handler = ThreadsafeMock()
         setattr(handler_manager, handler_name, mock_handler)
@@ -611,7 +615,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add 5 matching events to the corresponding inbox, triggering the handler
         for _ in range(5):
             inbox.put(event)
-        wait_for(lambda: mock_handler.call_count >= 5)
+        poll_until(lambda: mock_handler.call_count >= 5)
 
         # Handler has been called 5 times
         assert mock_handler.call_count == 5
@@ -620,7 +624,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         "Sends a HandlerManagerException to the background exception handler if any exception is raised during its invocation"
     )
     def test_exception_in_handler(
-        self, mocker, handler_name, handler_manager, inbox, event, arbitrary_exception, wait_for
+        self, mocker, handler_name, handler_manager, inbox, event, arbitrary_exception, poll_until
     ):
         background_exc_spy = mocker.spy(handle_exceptions, "handle_background_exception")
         # Handler will raise exception when called
@@ -634,7 +638,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add the event to the client event inbox, triggering the handler
         inbox.put(event)
-        wait_for(lambda: background_exc_spy.call_count >= 1)
+        poll_until(lambda: background_exc_spy.call_count >= 1)
         # Handler has now been called
         assert mock_handler.call_count == 1
         # Background exception handler was called
@@ -646,7 +650,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
     @pytest.mark.it(
         "Can be updated with a new value that the Client Event handler runner will immediately begin using for handler invocations instead"
     )
-    def test_updated_handler(self, mocker, handler_name, handler_manager, inbox, event, wait_for):
+    def test_updated_handler(self, mocker, handler_name, handler_manager, inbox, event, poll_until):
         def handler(*args):
             # Invoking handler replaces the set handler with a mock
             setattr(handler_manager, handler_name, mocker.MagicMock())
@@ -654,13 +658,13 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         setattr(handler_manager, handler_name, handler)
 
         inbox.put(event)
-        wait_for(lambda: getattr(handler_manager, handler_name) is not handler)
+        poll_until(lambda: getattr(handler_manager, handler_name) is not handler)
         # Handler has been replaced with a mock, but the mock has not been invoked
         assert getattr(handler_manager, handler_name) is not handler
         assert getattr(handler_manager, handler_name).call_count == 0
         # Add a new event to the inbox
         inbox.put(event)
-        wait_for(lambda: getattr(handler_manager, handler_name).call_count >= 1)
+        poll_until(lambda: getattr(handler_manager, handler_name).call_count >= 1)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 

--- a/tests/unit/iothub/test_sync_handler_manager.py
+++ b/tests/unit/iothub/test_sync_handler_manager.py
@@ -363,7 +363,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         mock_obj = mocker.MagicMock()
         inbox.put(mock_obj)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
 
         # Handler has been called with the item from the inbox
         assert mock_handler.call_count == 1
@@ -385,7 +385,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         for _ in range(5):
             inbox.put(mocker.MagicMock())
         # Wait for all handler invocations to complete
-        poll_until(lambda: mock_handler.call_count >= 5)
+        poll_until(lambda: mock_handler.call_count >= 5, timeout=5)
 
         # Handler has been called 5 times
         assert mock_handler.call_count == 5
@@ -485,7 +485,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
         # Wait for the background exception handler to be called
-        poll_until(lambda: background_exc_spy.call_count >= 1)
+        poll_until(lambda: background_exc_spy.call_count >= 1, timeout=5)
         # Handler has now been called
         assert mock_handler.call_count == 1
         # Background exception handler was called
@@ -506,14 +506,14 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
 
         inbox.put(mocker.MagicMock())
         # Wait for the handler to replace itself with the mock
-        poll_until(lambda: getattr(handler_manager, handler_name) is not handler)
+        poll_until(lambda: getattr(handler_manager, handler_name) is not handler, timeout=5)
         # Handler has been replaced with a mock, but the mock has not been invoked
         assert getattr(handler_manager, handler_name) is not handler
         assert getattr(handler_manager, handler_name).call_count == 0
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
         # Wait for the mock handler invocation to complete
-        poll_until(lambda: getattr(handler_manager, handler_name).call_count >= 1)
+        poll_until(lambda: getattr(handler_manager, handler_name).call_count >= 1, timeout=5)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 
@@ -597,7 +597,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add the event to the client event inbox
         inbox.put(event)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=5)
 
         # Handler has been called with the arguments from the event
         assert mock_handler.call_count == 1
@@ -607,7 +607,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         non_matching_event = client_event.ClientEvent("NON_MATCHING_EVENT")
         inbox.put(non_matching_event)
         # Wait for the runner to consume the non-matching event
-        poll_until(inbox.empty)
+        poll_until(inbox.empty, timeout=5)
 
         # Handler has not been called again
         assert mock_handler.call_count == 1
@@ -628,7 +628,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         for _ in range(5):
             inbox.put(event)
         # Wait for all handler invocations to complete
-        poll_until(lambda: mock_handler.call_count >= 5)
+        poll_until(lambda: mock_handler.call_count >= 5, timeout=5)
 
         # Handler has been called 5 times
         assert mock_handler.call_count == 5
@@ -652,7 +652,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add the event to the client event inbox, triggering the handler
         inbox.put(event)
         # Wait for the background exception handler to be called
-        poll_until(lambda: background_exc_spy.call_count >= 1)
+        poll_until(lambda: background_exc_spy.call_count >= 1, timeout=5)
         # Handler has now been called
         assert mock_handler.call_count == 1
         # Background exception handler was called
@@ -673,14 +673,14 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
 
         inbox.put(event)
         # Wait for the handler to replace itself with the mock
-        poll_until(lambda: getattr(handler_manager, handler_name) is not handler)
+        poll_until(lambda: getattr(handler_manager, handler_name) is not handler, timeout=5)
         # Handler has been replaced with a mock, but the mock has not been invoked
         assert getattr(handler_manager, handler_name) is not handler
         assert getattr(handler_manager, handler_name).call_count == 0
         # Add a new event to the inbox
         inbox.put(event)
         # Wait for the mock handler invocation to complete
-        poll_until(lambda: getattr(handler_manager, handler_name).call_count >= 1)
+        poll_until(lambda: getattr(handler_manager, handler_name).call_count >= 1, timeout=5)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 

--- a/tests/unit/iothub/test_sync_handler_manager.py
+++ b/tests/unit/iothub/test_sync_handler_manager.py
@@ -17,7 +17,7 @@ from azure.iot.device.iothub.sync_handler_manager import (
 from azure.iot.device.iothub.sync_handler_manager import MESSAGE, METHOD, TWIN_DP_PATCH
 from azure.iot.device.iothub.inbox_manager import InboxManager
 from azure.iot.device.iothub.sync_inbox import SyncClientInbox
-from tests.unit.helpers import EVENTUAL_TIMEOUT
+from tests.unit.helpers import BATCH_COMPLETION_TIMEOUT, PROMPT_TIMEOUT
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -364,7 +364,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         mock_obj = mocker.MagicMock()
         inbox.put(mock_obj)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=PROMPT_TIMEOUT)
 
         # Handler has been called with the item from the inbox
         assert mock_handler.call_count == 1
@@ -386,7 +386,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         for _ in range(5):
             inbox.put(mocker.MagicMock())
         # Wait for all handler invocations to complete
-        poll_until(lambda: mock_handler.call_count >= 5, timeout=EVENTUAL_TIMEOUT)
+        poll_until(lambda: mock_handler.call_count >= 5, timeout=BATCH_COMPLETION_TIMEOUT)
 
         # Handler has been called 5 times
         assert mock_handler.call_count == 5
@@ -486,7 +486,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
         # Wait for the background exception handler to be called
-        poll_until(lambda: background_exc_spy.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
+        poll_until(lambda: background_exc_spy.call_count >= 1, timeout=PROMPT_TIMEOUT)
         # Handler has now been called
         assert mock_handler.call_count == 1
         # Background exception handler was called
@@ -509,7 +509,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Wait for the handler to replace itself with the mock
         poll_until(
             lambda: getattr(handler_manager, handler_name) is not handler,
-            timeout=EVENTUAL_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         # Handler has been replaced with a mock, but the mock has not been invoked
         assert getattr(handler_manager, handler_name) is not handler
@@ -519,7 +519,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Wait for the mock handler invocation to complete
         poll_until(
             lambda: getattr(handler_manager, handler_name).call_count >= 1,
-            timeout=EVENTUAL_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
@@ -604,7 +604,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add the event to the client event inbox
         inbox.put(event)
         # Wait for the handler invocation to complete
-        poll_until(lambda: mock_handler.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
+        poll_until(lambda: mock_handler.call_count >= 1, timeout=PROMPT_TIMEOUT)
 
         # Handler has been called with the arguments from the event
         assert mock_handler.call_count == 1
@@ -614,7 +614,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         non_matching_event = client_event.ClientEvent("NON_MATCHING_EVENT")
         inbox.put(non_matching_event)
         # Wait for the runner to consume the non-matching event
-        poll_until(inbox.empty, timeout=EVENTUAL_TIMEOUT)
+        poll_until(inbox.empty, timeout=PROMPT_TIMEOUT)
 
         # Handler has not been called again
         assert mock_handler.call_count == 1
@@ -635,7 +635,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         for _ in range(5):
             inbox.put(event)
         # Wait for all handler invocations to complete
-        poll_until(lambda: mock_handler.call_count >= 5, timeout=EVENTUAL_TIMEOUT)
+        poll_until(lambda: mock_handler.call_count >= 5, timeout=BATCH_COMPLETION_TIMEOUT)
 
         # Handler has been called 5 times
         assert mock_handler.call_count == 5
@@ -659,7 +659,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add the event to the client event inbox, triggering the handler
         inbox.put(event)
         # Wait for the background exception handler to be called
-        poll_until(lambda: background_exc_spy.call_count >= 1, timeout=EVENTUAL_TIMEOUT)
+        poll_until(lambda: background_exc_spy.call_count >= 1, timeout=PROMPT_TIMEOUT)
         # Handler has now been called
         assert mock_handler.call_count == 1
         # Background exception handler was called
@@ -682,7 +682,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Wait for the handler to replace itself with the mock
         poll_until(
             lambda: getattr(handler_manager, handler_name) is not handler,
-            timeout=EVENTUAL_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         # Handler has been replaced with a mock, but the mock has not been invoked
         assert getattr(handler_manager, handler_name) is not handler
@@ -692,7 +692,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Wait for the mock handler invocation to complete
         poll_until(
             lambda: getattr(handler_manager, handler_name).call_count >= 1,
-            timeout=EVENTUAL_TIMEOUT,
+            timeout=PROMPT_TIMEOUT,
         )
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1

--- a/tests/unit/iothub/test_sync_handler_manager.py
+++ b/tests/unit/iothub/test_sync_handler_manager.py
@@ -6,7 +6,6 @@
 import logging
 import pytest
 import threading
-import time
 from azure.iot.device.common import handle_exceptions
 from azure.iot.device.iothub import client_event
 from azure.iot.device.iothub.sync_handler_manager import (
@@ -395,7 +394,13 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         "Is invoked for every item already in the corresponding Inbox at the moment of handler removal"
     )
     def test_handler_resolve_pending_items_before_handler_removal(
-        self, mocker, handler_name, handler_manager, inbox, run_in_daemon_thread
+        self,
+        mocker,
+        handler_name,
+        handler_name_internal,
+        handler_manager,
+        inbox,
+        run_in_daemon_thread,
     ):
         # Intercept inbox operations so the runner can be paused with work remaining
         original_get = inbox.get
@@ -456,12 +461,12 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # time of the removal
         assert mock_handler.call_count == 100
         assert inbox.empty()
+        assert getattr(handler_manager, handler_name) is None
+        assert handler_manager._receiver_handler_runners[handler_name_internal] is None
 
         # Add some more items
         for _ in range(100):
             inbox.put(mocker.MagicMock())
-        # Give any incorrectly retained runner an opportunity to invoke the handler
-        time.sleep(0.2)
         # Despite more items added to inbox, no further handler calls have been made beyond the
         # initial calls that were made when the original items were added
         assert mock_handler.call_count == 100

--- a/tests/unit/iothub/test_sync_handler_manager.py
+++ b/tests/unit/iothub/test_sync_handler_manager.py
@@ -6,7 +6,6 @@
 import logging
 import pytest
 import threading
-import time
 from azure.iot.device.common import handle_exceptions
 from azure.iot.device.iothub import client_event
 from azure.iot.device.iothub.sync_handler_manager import SyncHandlerManager, HandlerManagerException
@@ -24,9 +23,9 @@ logging.basicConfig(level=logging.DEBUG)
 # This means we must be very careful to always change both test modules when a change is made to
 # shared behavior, or when shared features are added.
 
-# NOTE ON TIMING/DELAY
-# Several tests in this module have sleeps/delays in their implementation due to needing to wait
-# for things to happen in other threads.
+# NOTE ON SYNCHRONIZATION
+# Handler work happens on other threads. Wait for observable outcomes rather than assuming that
+# work will complete within a fixed delay.
 
 all_internal_receiver_handlers = [MESSAGE, METHOD, TWIN_DP_PATCH]
 all_internal_client_event_handlers = [
@@ -166,7 +165,6 @@ class TestStop(object):
         assert mock_msg_handler.call_count < 200
         assert mock_mth_handler.call_count < 200
         hm.stop()
-        time.sleep(0.1)
         assert mock_msg_handler.call_count == 200
         assert mock_mth_handler.call_count == 200
         assert msg_inbox.empty()
@@ -349,7 +347,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
     @pytest.mark.it(
         "Is invoked by the runner when the Inbox corresponding to the handler receives an object, passing that object to the handler"
     )
-    def test_handler_invoked(self, mocker, handler_name, handler_manager, inbox):
+    def test_handler_invoked(self, mocker, handler_name, handler_manager, inbox, wait_for):
         # Set the handler
         mock_handler = mocker.MagicMock()
         setattr(handler_manager, handler_name, mock_handler)
@@ -359,7 +357,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add an item to corresponding inbox, triggering the handler
         mock_obj = mocker.MagicMock()
         inbox.put(mock_obj)
-        time.sleep(0.1)
+        wait_for(lambda: mock_handler.call_count >= 1)
 
         # Handler has been called with the item from the inbox
         assert mock_handler.call_count == 1
@@ -368,7 +366,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
     @pytest.mark.it(
         "Is invoked by the runner every time the Inbox corresponding to the handler receives an object"
     )
-    def test_handler_invoked_multiple(self, mocker, handler_name, handler_manager, inbox):
+    def test_handler_invoked_multiple(self, mocker, handler_name, handler_manager, inbox, wait_for):
         # Set the handler
         mock_handler = ThreadsafeMock()
         setattr(handler_manager, handler_name, mock_handler)
@@ -378,7 +376,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add 5 items to the corresponding inbox, triggering the handler
         for _ in range(5):
             inbox.put(mocker.MagicMock())
-        time.sleep(0.2)
+        wait_for(lambda: mock_handler.call_count >= 5)
 
         # Handler has been called 5 times
         assert mock_handler.call_count == 5
@@ -408,8 +406,6 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
 
         # Immediately remove the handler
         setattr(handler_manager, handler_name, None)
-        # Wait to give a chance for the handler runner to finish calling everything
-        time.sleep(0.2)
         # Despite removal, handler has been called for everything that was in the inbox at the
         # time of the removal
         assert mock_handler.call_count == 100
@@ -418,17 +414,16 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add some more items
         for _ in range(100):
             inbox.put(mocker.MagicMock())
-        # Wait to give a chance for the handler to be called (it won't)
-        time.sleep(0.2)
         # Despite more items added to inbox, no further handler calls have been made beyond the
         # initial calls that were made when the original items were added
         assert mock_handler.call_count == 100
+        assert not inbox.empty()
 
     @pytest.mark.it(
         "Sends a HandlerManagerException to the background exception handler if any exception is raised during its invocation"
     )
     def test_exception_in_handler(
-        self, mocker, handler_name, handler_manager, inbox, arbitrary_exception
+        self, mocker, handler_name, handler_manager, inbox, arbitrary_exception, wait_for
     ):
         background_exc_spy = mocker.spy(handle_exceptions, "handle_background_exception")
         # Handler will raise exception when called
@@ -442,7 +437,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add an item to corresponding inbox, triggering the handler
         inbox.put(mocker.MagicMock())
-        time.sleep(0.1)
+        wait_for(lambda: background_exc_spy.call_count >= 1)
         # Handler has now been called
         assert mock_handler.call_count == 1
         # Background exception handler was called
@@ -454,7 +449,7 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
     @pytest.mark.it(
         "Can be updated with a new value that the corresponding handler runner will immediately begin using for handler invocations instead"
     )
-    def test_handler_update_handler(self, mocker, handler_name, handler_manager, inbox):
+    def test_handler_update_handler(self, mocker, handler_name, handler_manager, inbox, wait_for):
         def handler(arg):
             # Invoking handler replaces the set handler with a mock
             setattr(handler_manager, handler_name, mocker.MagicMock())
@@ -462,13 +457,13 @@ class SharedReceiverHandlerPropertyTests(SharedHandlerPropertyTests):
         setattr(handler_manager, handler_name, handler)
 
         inbox.put(mocker.MagicMock())
-        time.sleep(0.1)
+        wait_for(lambda: getattr(handler_manager, handler_name) is not handler)
         # Handler has been replaced with a mock, but the mock has not been invoked
         assert getattr(handler_manager, handler_name) is not handler
         assert getattr(handler_manager, handler_name).call_count == 0
         # Add a new item to the inbox
         inbox.put(mocker.MagicMock())
-        time.sleep(0.1)
+        wait_for(lambda: getattr(handler_manager, handler_name).call_count >= 1)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 
@@ -542,7 +537,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
     @pytest.mark.it(
         "Is invoked by the runner only when the Client Event Inbox receives a matching Client Event, passing any arguments to the handler"
     )
-    def test_handler_invoked(self, mocker, handler_name, handler_manager, inbox, event):
+    def test_handler_invoked(self, mocker, handler_name, handler_manager, inbox, event, wait_for):
         # Set the handler
         mock_handler = mocker.MagicMock()
         setattr(handler_manager, handler_name, mock_handler)
@@ -551,7 +546,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
 
         # Add the event to the client event inbox
         inbox.put(event)
-        time.sleep(0.1)
+        wait_for(lambda: mock_handler.call_count >= 1)
 
         # Handler has been called with the arguments from the event
         assert mock_handler.call_count == 1
@@ -560,7 +555,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add non-matching event to the client event inbox
         non_matching_event = client_event.ClientEvent("NON_MATCHING_EVENT")
         inbox.put(non_matching_event)
-        time.sleep(0.1)
+        wait_for(inbox.empty)
 
         # Handler has not been called again
         assert mock_handler.call_count == 1
@@ -568,7 +563,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
     @pytest.mark.it(
         "Is invoked by the runner every time the Client Event Inbox receives a matching Client Event"
     )
-    def test_handler_invoked_multiple(self, handler_name, handler_manager, inbox, event):
+    def test_handler_invoked_multiple(self, handler_name, handler_manager, inbox, event, wait_for):
         # Set the handler
         mock_handler = ThreadsafeMock()
         setattr(handler_manager, handler_name, mock_handler)
@@ -578,7 +573,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         # Add 5 matching events to the corresponding inbox, triggering the handler
         for _ in range(5):
             inbox.put(event)
-        time.sleep(0.2)
+        wait_for(lambda: mock_handler.call_count >= 5)
 
         # Handler has been called 5 times
         assert mock_handler.call_count == 5
@@ -587,7 +582,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         "Sends a HandlerManagerException to the background exception handler if any exception is raised during its invocation"
     )
     def test_exception_in_handler(
-        self, mocker, handler_name, handler_manager, inbox, event, arbitrary_exception
+        self, mocker, handler_name, handler_manager, inbox, event, arbitrary_exception, wait_for
     ):
         background_exc_spy = mocker.spy(handle_exceptions, "handle_background_exception")
         # Handler will raise exception when called
@@ -601,7 +596,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         assert background_exc_spy.call_count == 0
         # Add the event to the client event inbox, triggering the handler
         inbox.put(event)
-        time.sleep(0.1)
+        wait_for(lambda: background_exc_spy.call_count >= 1)
         # Handler has now been called
         assert mock_handler.call_count == 1
         # Background exception handler was called
@@ -613,7 +608,7 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
     @pytest.mark.it(
         "Can be updated with a new value that the Client Event handler runner will immediately begin using for handler invocations instead"
     )
-    def test_updated_handler(self, mocker, handler_name, handler_manager, inbox, event):
+    def test_updated_handler(self, mocker, handler_name, handler_manager, inbox, event, wait_for):
         def handler(*args):
             # Invoking handler replaces the set handler with a mock
             setattr(handler_manager, handler_name, mocker.MagicMock())
@@ -621,13 +616,13 @@ class SharedClientEventHandlerPropertyTests(SharedHandlerPropertyTests):
         setattr(handler_manager, handler_name, handler)
 
         inbox.put(event)
-        time.sleep(0.1)
+        wait_for(lambda: getattr(handler_manager, handler_name) is not handler)
         # Handler has been replaced with a mock, but the mock has not been invoked
         assert getattr(handler_manager, handler_name) is not handler
         assert getattr(handler_manager, handler_name).call_count == 0
         # Add a new event to the inbox
         inbox.put(event)
-        time.sleep(0.1)
+        wait_for(lambda: getattr(handler_manager, handler_name).call_count >= 1)
         # The mock was now called
         assert getattr(handler_manager, handler_name).call_count == 1
 

--- a/tests/unit/iothub/test_sync_inbox.py
+++ b/tests/unit/iothub/test_sync_inbox.py
@@ -4,10 +4,9 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import concurrent.futures
 import pytest
 import logging
-import threading
-import time
 from azure.iot.device.iothub.sync_inbox import SyncClientInbox, InboxEmpty
 
 logging.basicConfig(level=logging.DEBUG)
@@ -82,19 +81,20 @@ class TestSyncClientInboxGet(object):
     @pytest.mark.it(
         "Blocks on an empty inbox until an item is available to remove and return, if using blocking mode"
     )
-    def test_waits_for_item_to_be_added_if_inbox_empty_in_blocking_mode(self, mocker):
+    def test_waits_for_item_to_be_added_if_inbox_empty_in_blocking_mode(
+        self, mocker, track_call_started
+    ):
         inbox = SyncClientInbox()
         assert inbox.empty()
         item = mocker.MagicMock()
+        get_started = track_call_started(inbox._queue, "get")
 
-        def insert_item():
-            time.sleep(0.01)  # wait before inserting
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            get_future = executor.submit(inbox.get, block=True)
+            assert get_started.wait(timeout=5)
+            assert not get_future.done()
             inbox.put(item)
-
-        insertion_thread = threading.Thread(target=insert_item)
-        insertion_thread.start()
-
-        retrieved_item = inbox.get(block=True)
+            retrieved_item = get_future.result(timeout=5)
         assert retrieved_item is item
         assert inbox.empty()
 

--- a/tests/unit/iothub/test_sync_inbox.py
+++ b/tests/unit/iothub/test_sync_inbox.py
@@ -4,7 +4,6 @@
 # license information.
 # --------------------------------------------------------------------------
 
-import concurrent.futures
 import pytest
 import logging
 from azure.iot.device.iothub.sync_inbox import SyncClientInbox, InboxEmpty
@@ -82,19 +81,20 @@ class TestSyncClientInboxGet(object):
         "Blocks on an empty inbox until an item is available to remove and return, if using blocking mode"
     )
     def test_waits_for_item_to_be_added_if_inbox_empty_in_blocking_mode(
-        self, mocker, track_call_started
+        self, mocker, track_call_started, run_in_daemon_thread
     ):
         inbox = SyncClientInbox()
         assert inbox.empty()
         item = mocker.MagicMock()
         get_started = track_call_started(inbox._queue, "get")
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            get_future = executor.submit(inbox.get, block=True)
+        get_future = run_in_daemon_thread(inbox.get, block=True)
+        try:
             assert get_started.wait(timeout=5)
             assert not get_future.done()
+        finally:
             inbox.put(item)
-            retrieved_item = get_future.result(timeout=5)
+        retrieved_item = get_future.result(timeout=5)
         assert retrieved_item is item
         assert inbox.empty()
 

--- a/tests/unit/iothub/test_sync_inbox.py
+++ b/tests/unit/iothub/test_sync_inbox.py
@@ -81,25 +81,19 @@ class TestSyncClientInboxGet(object):
         "Blocks on an empty inbox until an item is available to remove and return, if using blocking mode"
     )
     def test_waits_for_item_to_be_added_if_inbox_empty_in_blocking_mode(
-        self, mocker, track_call_started, run_in_daemon_thread
+        self, mocker, assert_call_blocks
     ):
         inbox = SyncClientInbox()
         assert inbox.empty()
         item = mocker.MagicMock()
-        # Track when the background get reaches the blocking queue operation
-        get_started = track_call_started(inbox._queue, "get")
 
-        # Begin waiting for an item on a background thread
-        get_future = run_in_daemon_thread(inbox.get, block=True)
-        try:
-            # The get is blocked waiting for an item
-            assert get_started.wait(timeout=5)
-            assert not get_future.done()
-        finally:
-            # Always add the item so a failed assertion cannot strand the background thread
-            inbox.put(item)
-        # The get returns once the item is available
-        retrieved_item = get_future.result(timeout=5)
+        # Get blocks on the empty queue until the item is added
+        retrieved_item = assert_call_blocks(
+            inbox.get,
+            blocked_on=inbox._queue.get,
+            release=lambda: inbox.put(item),
+            kwargs={"block": True},
+        )
         assert retrieved_item is item
         assert inbox.empty()
 

--- a/tests/unit/iothub/test_sync_inbox.py
+++ b/tests/unit/iothub/test_sync_inbox.py
@@ -86,14 +86,19 @@ class TestSyncClientInboxGet(object):
         inbox = SyncClientInbox()
         assert inbox.empty()
         item = mocker.MagicMock()
+        # Track when the background get reaches the blocking queue operation
         get_started = track_call_started(inbox._queue, "get")
 
+        # Begin waiting for an item on a background thread
         get_future = run_in_daemon_thread(inbox.get, block=True)
         try:
+            # The get is blocked waiting for an item
             assert get_started.wait(timeout=5)
             assert not get_future.done()
         finally:
+            # Always add the item so a failed assertion cannot strand the background thread
             inbox.put(item)
+        # The get returns once the item is available
         retrieved_item = get_future.result(timeout=5)
         assert retrieved_item is item
         assert inbox.empty()


### PR DESCRIPTION
## What changed
- add reusable `poll_until` and `async_poll_until` fixtures with required explicit timeouts
- preserve the original 100 ms expectation for single handler operations and use 500 ms only for five-item batches
- replace post-removal observation sleeps with direct assertions that the handler and runner are cleared before adding new items
- keep five-second bounds only for deliberately paused cleanup/deadlock-safety orchestration
- add `assert_call_blocks` for blocking sync API assertions
- replace historical Janus teardown sleeps with explicit `Queue.aclose()`

## Why
A Python 3.12 unit-test run observed only 2 of 5 handler invocations after a fixed 100 ms sleep. Positive completion tests now poll for outcomes while retaining meaningful timing bounds. Negative post-removal behavior is verified structurally: the setter does not return until the runner exits, after which both handler and runner references must be `None`.

## Validation
- full Python 3.12.14 unit suite with coverage: 5437 passed, 6 skipped
- sleep-free handler-removal cases: 100 repeated runs, 900/900 tests passed
- refined handler deadlines: 100 repeated runs, 7500/7500 tests passed
- Black and Ruff passed