### PR TITLE
e2e: replace timing waits with bounded synchronization

### DIFF
--- a/dev_utils/dev_utils/service_helper.py
+++ b/dev_utils/dev_utils/service_helper.py
@@ -57,11 +57,12 @@ class ServiceHelper:
     ):
         return await self._run_in_executor(self._inner_object.send_c2d, payload, properties)
 
-    async def wait_for_eventhub_arrival(self, message_id, timeout=60):
+    async def wait_for_eventhub_arrival(self, message_id, timeout=60, event_filter=None):
         return await self._run_in_executor(
             self._inner_object.wait_for_eventhub_arrival,
             message_id,
             timeout,
+            event_filter,
         )
 
     async def get_next_reported_patch_arrival(self, block=True, timeout=240):

--- a/dev_utils/dev_utils/service_helper.py
+++ b/dev_utils/dev_utils/service_helper.py
@@ -29,6 +29,9 @@ class ServiceHelper:
     def set_identity(self, device_id, module_id):
         return self._inner_object.set_identity(device_id, module_id)
 
+    async def wait_until_ready(self, timeout):
+        return await self._run_in_executor(self._inner_object.wait_until_ready, timeout)
+
     async def set_desired_properties(self, desired_props):
         return await self._run_in_executor(self._inner_object.set_desired_properties, desired_props)
 

--- a/dev_utils/dev_utils/service_helper_sync.py
+++ b/dev_utils/dev_utils/service_helper_sync.py
@@ -7,7 +7,7 @@ import queue
 import copy
 import time
 import uuid
-from concurrent.futures import ThreadPoolExecutor
+import concurrent.futures
 from azure.iot.hub import IoTHubRegistryManager
 from azure.iot.hub.protocol.models import Twin, TwinProperties, CloudToDeviceMethod
 from azure.eventhub import EventHubConsumerClient
@@ -78,8 +78,6 @@ class ServiceHelperSync(object):
         eventhub_connection_string,
         eventhub_consumer_group,
     ):
-        self._executor = ThreadPoolExecutor()
-
         self._registry_manager = IoTHubRegistryManager(iothub_connection_string)
 
         logger.info(
@@ -91,13 +89,31 @@ class ServiceHelperSync(object):
         self._eventhub_consumer_client = EventHubConsumerClient.from_connection_string(
             eventhub_connection_string, consumer_group=eventhub_consumer_group
         )
-
-        self._eventhub_future = self._executor.submit(self._eventhub_thread)
         self.device_id = None
         self.module_id = None
         self.incoming_patch_queue = queue.Queue()
         self.cv = threading.Condition()
         self.incoming_eventhub_events = {}
+        self._eventhub_ready = threading.Event()
+        self._eventhub_future = self._start_eventhub_thread()
+        self._eventhub_future.add_done_callback(lambda _: self._eventhub_ready.set())
+
+    def _start_eventhub_thread(self):
+        future = concurrent.futures.Future()
+
+        def run():
+            if not future.set_running_or_notify_cancel():
+                return
+            try:
+                result = self._eventhub_thread()
+            except BaseException as e:
+                future.set_exception(e)
+            else:
+                future.set_result(result)
+
+        self._eventhub_worker = threading.Thread(target=run, daemon=True)
+        self._eventhub_worker.start()
+        return future
 
     def set_identity(self, device_id, module_id):
         if device_id != self.device_id or module_id != self.module_id:
@@ -112,6 +128,15 @@ class ServiceHelperSync(object):
                         )
                     )
                 self.incoming_eventhub_events = {}
+
+    def wait_until_ready(self, timeout):
+        if not self._eventhub_ready.wait(timeout=timeout):
+            raise TimeoutError(
+                "EventHub consumer did not initialize within {} seconds".format(timeout)
+            )
+        if self._eventhub_future.done():
+            self._eventhub_future.result()
+            raise RuntimeError("EventHub consumer exited before initializing")
 
     def set_desired_properties(self, desired_props):
         if self.module_id:
@@ -203,13 +228,12 @@ class ServiceHelperSync(object):
 
         if self._eventhub_future:
             try:
-                # Ensure the EventHub receive loop exits before tearing down the executor
+                # Ensure the EventHub receive loop exits after closing the consumer
                 self._eventhub_future.result(timeout=30)
+            except concurrent.futures.TimeoutError:
+                logger.warning("_eventhub_thread did not exit within 30 seconds")
             except Exception:
                 logger.warning("_eventhub_thread did not exit cleanly", exc_info=True)
-
-        if self._executor:
-            self._executor.shutdown(wait=True)
 
     def _convert_incoming_event(self, event):
         try:
@@ -255,6 +279,8 @@ class ServiceHelperSync(object):
 
         def on_event_batch(partition_context, events):
             try:
+                # A completed receive confirms that the Event Hub consumer is active
+                self._eventhub_ready.set()
                 for event in events:
                     device_id = get_device_id_from_event(event)
                     module_id = get_module_id_from_event(event)
@@ -294,6 +320,7 @@ class ServiceHelperSync(object):
                 logger.info("Starting EventHub receive")
                 self._eventhub_consumer_client.receive_batch(
                     max_wait_time=2,
+                    starting_position="-1",
                     on_event_batch=on_event_batch,
                     on_error=on_error,
                     on_partition_initialize=on_partition_initialize,

--- a/dev_utils/dev_utils/service_helper_sync.py
+++ b/dev_utils/dev_utils/service_helper_sync.py
@@ -7,6 +7,7 @@ import queue
 import copy
 import time
 import uuid
+import datetime
 import concurrent.futures
 from azure.iot.hub import IoTHubRegistryManager
 from azure.iot.hub.protocol.models import Twin, TwinProperties, CloudToDeviceMethod
@@ -94,6 +95,7 @@ class ServiceHelperSync(object):
         self.incoming_patch_queue = queue.Queue()
         self.cv = threading.Condition()
         self.incoming_eventhub_events = {}
+        self._eventhub_start_position = datetime.datetime.now(datetime.timezone.utc)
         self._eventhub_ready = threading.Event()
         self._eventhub_future = self._start_eventhub_thread()
         self._eventhub_future.add_done_callback(lambda _: self._eventhub_ready.set())
@@ -320,7 +322,7 @@ class ServiceHelperSync(object):
                 logger.info("Starting EventHub receive")
                 self._eventhub_consumer_client.receive_batch(
                     max_wait_time=2,
-                    starting_position="-1",
+                    starting_position=self._eventhub_start_position,
                     on_event_batch=on_event_batch,
                     on_error=on_error,
                     on_partition_initialize=on_partition_initialize,

--- a/dev_utils/dev_utils/service_helper_sync.py
+++ b/dev_utils/dev_utils/service_helper_sync.py
@@ -182,15 +182,26 @@ class ServiceHelperSync(object):
             raise TypeError("sending C2D to modules is not supported")
         self._registry_manager.send_c2d_message(self.device_id, payload, properties)
 
-    def wait_for_eventhub_arrival(self, message_id, timeout=900):
+    def wait_for_eventhub_arrival(self, message_id, timeout=900, event_filter=None):
         def get_event(inner_message_id):
             with self.cv:
                 arrivals = self.incoming_eventhub_events
 
                 # if message_id is not set, return any message
                 if not inner_message_id and len(arrivals):
-                    id = list(arrivals.keys())[0]
-                    logger.info("wait_for_eventhub_arrival(None) returning msgid={}".format(id))
+                    if event_filter:
+                        id = next(
+                            (
+                                event_id
+                                for event_id, event in arrivals.items()
+                                if event_filter(event)
+                            ),
+                            None,
+                        )
+                    else:
+                        id = next(iter(arrivals))
+                    if id:
+                        logger.info("wait_for_eventhub_arrival(None) returning msgid={}".format(id))
                 else:
                     id = inner_message_id
 

--- a/tests/e2e/iothub_e2e/aio/conftest.py
+++ b/tests/e2e/iothub_e2e/aio/conftest.py
@@ -7,6 +7,7 @@ import logging
 import datetime
 import json
 import retry_async
+import const
 from utils import create_client_object
 from azure.iot.device.iothub.aio import IoTHubDeviceClient, IoTHubModuleClient
 
@@ -103,14 +104,16 @@ async def service_helper(executor):
         eventhub_consumer_group=test_env.EVENTHUB_CONSUMER_GROUP,
         executor=executor,
     )
-    yield service_helper
+    try:
+        await service_helper.wait_until_ready(timeout=const.E2E_TIMEOUT)
+        yield service_helper
+    finally:
+        logger.info("----------------------------")
+        logger.info("shutting down service_helper")
+        logger.info("----------------------------")
 
-    logger.info("----------------------------")
-    logger.info("shutting down service_helper")
-    logger.info("----------------------------")
+        await service_helper.shutdown()
 
-    await service_helper.shutdown()
-
-    logger.info("---------------------------------")
-    logger.info("service helper shut down complete")
-    logger.info("---------------------------------")
+        logger.info("---------------------------------")
+        logger.info("service helper shut down complete")
+        logger.info("---------------------------------")

--- a/tests/e2e/iothub_e2e/aio/test_c2d.py
+++ b/tests/e2e/iothub_e2e/aio/test_c2d.py
@@ -6,6 +6,7 @@ import pytest
 import logging
 import json
 from dev_utils import get_random_dict
+import const
 
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
@@ -38,7 +39,7 @@ class TestReceiveC2d(object):
 
         await service_helper.send_c2d(message, {})
 
-        await asyncio.wait_for(received.wait(), 60)
+        await asyncio.wait_for(received.wait(), timeout=const.E2E_TIMEOUT)
         assert received.is_set()
 
         assert received_message.data.decode("utf-8") == message

--- a/tests/e2e/iothub_e2e/aio/test_connect_disconnect.py
+++ b/tests/e2e/iothub_e2e/aio/test_connect_disconnect.py
@@ -5,6 +5,8 @@ import asyncio
 import pytest
 import logging
 import parametrize
+import const
+import wait_helpers
 
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
@@ -78,7 +80,7 @@ class TestConnectDisconnect(object):
         await client.disconnect()
 
         # wait for handle_on_connection_state_change to reconnect
-        await reconnected_event.wait()
+        await asyncio.wait_for(reconnected_event.wait(), timeout=const.E2E_TIMEOUT)
 
         logger.info(
             "reconnect_event.wait() returned.  client.connected={}".format(client.connected)
@@ -160,7 +162,7 @@ class TestConnectDisconnect(object):
         await client.connect()
 
         # and wait for us to disconnect
-        await disconnected_event.wait()
+        await asyncio.wait_for(disconnected_event.wait(), timeout=const.E2E_TIMEOUT)
         assert not client.connected
 
         # sleep a while and make sure that we're still disconnected.
@@ -198,14 +200,16 @@ class TestConnectDisconnectDroppedConnection(object):
         assert client.connected
         dropper.drop_outgoing()
 
-        while client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: not client.connected, timeout=const.E2E_TIMEOUT
+        )
 
         # we've passed the test. Now wait to reconnect before we check for leaks. Otherwise we
         # have a pending ConnectOperation floating around and this would get tagged as a leak.
         dropper.restore_all()
-        while not client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: client.connected, timeout=const.E2E_TIMEOUT
+        )
 
         leak_tracker.check_for_leaks()
 
@@ -221,13 +225,15 @@ class TestConnectDisconnectDroppedConnection(object):
         assert client.connected
         dropper.reject_outgoing()
 
-        while client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: not client.connected, timeout=const.E2E_TIMEOUT
+        )
 
         # we've passed the test. Now wait to reconnect before we check for leaks. Otherwise we
         # have a pending ConnectOperation floating around and this would get tagged as a leak.
         dropper.restore_all()
-        while not client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: client.connected, timeout=const.E2E_TIMEOUT
+        )
 
         leak_tracker.check_for_leaks()

--- a/tests/e2e/iothub_e2e/aio/test_methods.py
+++ b/tests/e2e/iothub_e2e/aio/test_methods.py
@@ -3,7 +3,7 @@
 # license information.
 import pytest
 import logging
-import asyncio
+
 import parametrize
 from dev_utils import get_random_dict
 from azure.iot.device.iothub import MethodResponse
@@ -62,7 +62,6 @@ class TestMethods(object):
             )
 
         client.on_method_request_received = handle_on_method_request_received
-        await asyncio.sleep(1)  # wait for subscribe, etc, to complete
 
         # invoke the method call
         method_response = await service_helper.invoke_method(method_name, request_payload)

--- a/tests/e2e/iothub_e2e/aio/test_sas_renewal.py
+++ b/tests/e2e/iothub_e2e/aio/test_sas_renewal.py
@@ -7,6 +7,7 @@ import json
 import logging
 import test_config
 import parametrize
+import const
 
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
@@ -50,7 +51,7 @@ class TestSasRenewal(object):
         # setting on_connection_state_change seems to have the side effect of
         # calling handle_on_connection_state_change once with the initial value.
         # Wait for one disconnect/reconnect cycle so we can get past it.
-        await connected_event.wait()
+        await asyncio.wait_for(connected_event.wait(), timeout=const.E2E_TIMEOUT)
 
         # OK, we're ready to test.  wait for the renewal
         token_before_connect = str(token_object)
@@ -59,9 +60,9 @@ class TestSasRenewal(object):
         connected_event.clear()
 
         logger.info("Waiting for client to disconnect")
-        await disconnected_event.wait()
+        await asyncio.wait_for(disconnected_event.wait(), timeout=const.E2E_TIMEOUT)
         logger.info("Waiting for client to reconnect")
-        await connected_event.wait()
+        await asyncio.wait_for(connected_event.wait(), timeout=const.E2E_TIMEOUT)
         logger.info("Client reconnected")
 
         # Finally verify that our token changed.

--- a/tests/e2e/iothub_e2e/aio/test_send_message.py
+++ b/tests/e2e/iothub_e2e/aio/test_send_message.py
@@ -6,6 +6,8 @@ import pytest
 import logging
 import json
 import dev_utils
+import const
+import wait_helpers
 from azure.iot.device.exceptions import OperationCancelled, ClientError
 
 logger = logging.getLogger(__name__)
@@ -103,16 +105,18 @@ class TestSendMessageDroppedConnection(object):
         dropper.drop_outgoing()
         send_task = asyncio.ensure_future(client.send_message(random_message))
 
-        while client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: not client.connected, timeout=const.E2E_TIMEOUT
+        )
 
         assert not send_task.done()
 
         dropper.restore_all()
-        while not client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: client.connected, timeout=const.E2E_TIMEOUT
+        )
 
-        await send_task
+        await asyncio.wait_for(send_task, timeout=const.E2E_TIMEOUT)
 
         event = await service_helper.wait_for_eventhub_arrival(random_message.message_id)
 
@@ -137,16 +141,18 @@ class TestSendMessageDroppedConnection(object):
         dropper.reject_outgoing()
         send_task = asyncio.ensure_future(client.send_message(random_message))
 
-        while client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: not client.connected, timeout=const.E2E_TIMEOUT
+        )
 
         assert not send_task.done()
 
         dropper.restore_all()
-        while not client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: client.connected, timeout=const.E2E_TIMEOUT
+        )
 
-        await send_task
+        await asyncio.wait_for(send_task, timeout=const.E2E_TIMEOUT)
 
         event = await service_helper.wait_for_eventhub_arrival(random_message.message_id)
 
@@ -211,8 +217,9 @@ class TestSendMessageRetryDisabled(object):
         assert client.connected
 
         dropper.drop_outgoing()
-        while client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: not client.connected, timeout=const.E2E_TIMEOUT
+        )
 
         assert not client.connected
         dropper.restore_all()
@@ -236,11 +243,12 @@ class TestSendMessageRetryDisabled(object):
         dropper.drop_outgoing()
         send_task = asyncio.ensure_future(client.send_message(random_message))
 
-        while client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: not client.connected, timeout=const.E2E_TIMEOUT
+        )
 
         with pytest.raises(OperationCancelled):
-            await send_task
+            await asyncio.wait_for(send_task, timeout=const.E2E_TIMEOUT)
 
         random_message = None  # so this doesn't get tagged as a leak
         # TODO: investigate leak

--- a/tests/e2e/iothub_e2e/aio/test_send_message.py
+++ b/tests/e2e/iothub_e2e/aio/test_send_message.py
@@ -70,7 +70,10 @@ class TestSendMessage(object):
 
         await client.send_message(message)
 
-        event = await service_helper.wait_for_eventhub_arrival(None)
+        expected_body = json.loads(message)
+        event = await service_helper.wait_for_eventhub_arrival(
+            None, event_filter=lambda event: event.message_body == expected_body
+        )
         assert json.dumps(event.message_body) == message
 
         leak_tracker.check_for_leaks()
@@ -83,7 +86,9 @@ class TestSendMessage(object):
 
         await client.send_message(message)
 
-        event = await service_helper.wait_for_eventhub_arrival(None)
+        event = await service_helper.wait_for_eventhub_arrival(
+            None, event_filter=lambda event: event.message_body == message
+        )
         assert event.message_body == message
 
         leak_tracker.check_for_leaks()

--- a/tests/e2e/iothub_e2e/aio/test_twin.py
+++ b/tests/e2e/iothub_e2e/aio/test_twin.py
@@ -5,6 +5,7 @@ import asyncio
 import pytest
 import logging
 import const
+import wait_helpers
 from dev_utils import get_random_dict
 from azure.iot.device.exceptions import ClientError
 
@@ -131,16 +132,18 @@ class TestReportedPropertiesDroppedConnection(object):
         send_task = asyncio.ensure_future(
             client.patch_twin_reported_properties(random_reported_props)
         )
-        while client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: not client.connected, timeout=const.E2E_TIMEOUT
+        )
 
         assert not send_task.done()
 
         dropper.restore_all()
-        while not client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: client.connected, timeout=const.E2E_TIMEOUT
+        )
 
-        await send_task
+        await asyncio.wait_for(send_task, timeout=const.E2E_TIMEOUT)
 
         received_patch = await service_helper.get_next_reported_patch_arrival()
         assert (
@@ -163,16 +166,18 @@ class TestReportedPropertiesDroppedConnection(object):
         send_task = asyncio.ensure_future(
             client.patch_twin_reported_properties(random_reported_props)
         )
-        while client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: not client.connected, timeout=const.E2E_TIMEOUT
+        )
 
         assert not send_task.done()
 
         dropper.restore_all()
-        while not client.connected:
-            await asyncio.sleep(1)
+        await wait_helpers.async_wait_for_condition(
+            lambda: client.connected, timeout=const.E2E_TIMEOUT
+        )
 
-        await send_task
+        await asyncio.wait_for(send_task, timeout=const.E2E_TIMEOUT)
 
         received_patch = await service_helper.get_next_reported_patch_arrival()
         assert (
@@ -208,7 +213,7 @@ class TestDesiredProperties(object):
             {const.TEST_CONTENT: random_dict},
         )
 
-        await asyncio.wait_for(received.wait(), 60)
+        await asyncio.wait_for(received.wait(), timeout=const.E2E_TIMEOUT)
         assert received.is_set()
 
         assert received_patch[const.TEST_CONTENT] == random_dict

--- a/tests/e2e/iothub_e2e/aio/test_twin_stress.py
+++ b/tests/e2e/iothub_e2e/aio/test_twin_stress.py
@@ -121,7 +121,9 @@ class TestTwinStress(object):
             # wait for these properties to arrive at the service
             count_received = 0
             while count_received < batch_size:
-                received_patch = await service_helper.get_next_reported_patch_arrival(timeout=60)
+                received_patch = await service_helper.get_next_reported_patch_arrival(
+                    timeout=const.E2E_TIMEOUT
+                )
                 received_test_content = received_patch[const.REPORTED][const.TEST_CONTENT] or {}
                 logger.info("received {}".format(received_test_content))
 
@@ -180,7 +182,7 @@ class TestTwinStress(object):
             )
 
             # wait for the property update to arrive at the client
-            received_patch = await asyncio.wait_for(patches.get(), 60)
+            received_patch = await asyncio.wait_for(patches.get(), timeout=const.E2E_TIMEOUT)
             assert received_patch[const.TEST_CONTENT] == property_value
 
         leak_tracker.check_for_leaks()
@@ -234,8 +236,12 @@ class TestTwinStress(object):
 
             # Wait for those properties to arrive at the client
             count_received = 0
+            deadline = event_loop.time() + const.E2E_TIMEOUT
             while count_received < batch_size:
-                received_patch = await asyncio.wait_for(patches.get(), 60)
+                remaining = deadline - event_loop.time()
+                if remaining <= 0:
+                    pytest.fail("Timed out waiting for the desired property update batch")
+                received_patch = await asyncio.wait_for(patches.get(), timeout=remaining)
                 received_test_content = received_patch[const.TEST_CONTENT] or {}
 
                 for key in received_test_content:
@@ -332,14 +338,23 @@ class TestTwinStress(object):
         )
         ready_to_test = False
 
+        deadline = asyncio.get_running_loop().time() + const.E2E_TIMEOUT
         while not ready_to_test:
-            twin = await call_with_retry(client, client.get_twin)
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                pytest.fail("Timed out waiting for the initial reported property value")
+            twin = await asyncio.wait_for(
+                call_with_retry(client, client.get_twin), timeout=remaining
+            )
             if twin[const.REPORTED].get(const.TEST_CONTENT, "") == current_property_value:
                 logger.info("Initial value set")
                 ready_to_test = True
             else:
                 logger.info("Waiting for initial value. Sleeping for 5")
-                await asyncio.sleep(5)
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    pytest.fail("Timed out waiting for the initial reported property value")
+                await asyncio.sleep(min(5, remaining))
 
         for i in range(0, iteration_count, batch_size):
             logger.info("Iteration {} of {}".format(i, iteration_count))

--- a/tests/e2e/iothub_e2e/aio/test_twin_stress.py
+++ b/tests/e2e/iothub_e2e/aio/test_twin_stress.py
@@ -64,8 +64,14 @@ class TestTwinStress(object):
 
             # Wait for that reported property to arrive at the service.
             received = False
+            deadline = asyncio.get_running_loop().time() + const.E2E_TIMEOUT
             while not received:
-                received_patch = await service_helper.get_next_reported_patch_arrival()
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    pytest.fail("Timed out waiting for the reported property update")
+                received_patch = await service_helper.get_next_reported_patch_arrival(
+                    timeout=remaining
+                )
                 if (
                     const.REPORTED in received_patch
                     and received_patch[const.REPORTED][const.TEST_CONTENT]

--- a/tests/e2e/iothub_e2e/aio/test_twin_stress.py
+++ b/tests/e2e/iothub_e2e/aio/test_twin_stress.py
@@ -100,9 +100,7 @@ class TestTwinStress(object):
         await call_with_retry(client, client.patch_twin_reported_properties, reset_reported_props)
 
         for _ in range(0, iteration_count, batch_size):
-            props = {
-                "key_{}".format(k): get_random_property_value() for k in range(0, iteration_count)
-            }
+            props = {"key_{}".format(k): get_random_property_value() for k in range(0, batch_size)}
 
             # Do overlapped calls to update `batch_size` properties.
             tasks = [
@@ -120,9 +118,13 @@ class TestTwinStress(object):
 
             # wait for these properties to arrive at the service
             count_received = 0
+            deadline = asyncio.get_running_loop().time() + const.E2E_TIMEOUT
             while count_received < batch_size:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    pytest.fail("Timed out waiting for the reported property update batch")
                 received_patch = await service_helper.get_next_reported_patch_arrival(
-                    timeout=const.E2E_TIMEOUT
+                    timeout=remaining
                 )
                 received_test_content = received_patch[const.REPORTED][const.TEST_CONTENT] or {}
                 logger.info("received {}".format(received_test_content))

--- a/tests/e2e/iothub_e2e/conftest.py
+++ b/tests/e2e/iothub_e2e/conftest.py
@@ -4,6 +4,7 @@
 import pytest
 import logging
 import concurrent.futures
+import threading
 import test_config
 import device_identity_helper
 import const
@@ -46,6 +47,27 @@ def executor():
     executor = concurrent.futures.ThreadPoolExecutor()
     yield executor
     executor.shutdown()
+
+
+@pytest.fixture(scope="function")
+def run_in_daemon_thread():
+    def run(fn, *args, **kwargs):
+        future = concurrent.futures.Future()
+
+        def invoke():
+            if not future.set_running_or_notify_cancel():
+                return
+            try:
+                result = fn(*args, **kwargs)
+            except BaseException as e:
+                future.set_exception(e)
+            else:
+                future.set_result(result)
+
+        threading.Thread(target=invoke, daemon=True).start()
+        return future
+
+    return run
 
 
 @pytest.fixture(scope="function")

--- a/tests/e2e/iothub_e2e/const.py
+++ b/tests/e2e/iothub_e2e/const.py
@@ -9,6 +9,9 @@ TEST_CONTENT = "testContent"
 REPORTED = "reported"
 DESIRED = "desired"
 
+# Maximum time allowed for an external service or network state transition.
+E2E_TIMEOUT = 60
+
 # properties of the eventhub message
 EVENTHUB_SYSPROP_CONTENT_TYPE = "content-type"
 EVENTHUB_SYSPROP_CONTENT_ENCODING = "content-encoding"

--- a/tests/e2e/iothub_e2e/drop_fixtures.py
+++ b/tests/e2e/iothub_e2e/drop_fixtures.py
@@ -7,12 +7,6 @@ from dev_utils import iptables, test_env
 
 logger = logging.getLogger(__name__)
 
-print("reconnecting mqtt")
-iptables.reconnect_all("mqtt", test_env.IOTHUB_HOSTNAME)
-print("reconnecting mqttws")
-iptables.reconnect_all("mqttws", test_env.IOTHUB_HOSTNAME)
-print("Done")
-
 
 class Dropper(object):
     def __init__(self, transport):

--- a/tests/e2e/iothub_e2e/sync/conftest.py
+++ b/tests/e2e/iothub_e2e/sync/conftest.py
@@ -2,10 +2,10 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 import pytest
-import time
 from dev_utils import test_env, ServiceHelperSync
 import logging
 import datetime
+import const
 from utils import create_client_object
 from azure.iot.device.iothub import IoTHubDeviceClient, IoTHubModuleClient
 
@@ -60,15 +60,16 @@ def service_helper():
         eventhub_connection_string=test_env.EVENTHUB_CONNECTION_STRING,
         eventhub_consumer_group=test_env.EVENTHUB_CONSUMER_GROUP,
     )
-    time.sleep(3)
-    yield service_helper
+    try:
+        service_helper.wait_until_ready(timeout=const.E2E_TIMEOUT)
+        yield service_helper
+    finally:
+        logger.info("----------------------------")
+        logger.info("shutting down service_helper")
+        logger.info("----------------------------")
 
-    logger.info("----------------------------")
-    logger.info("shutting down service_helper")
-    logger.info("----------------------------")
+        service_helper.shutdown()
 
-    service_helper.shutdown()
-
-    logger.info("---------------------------------")
-    logger.info("service helper shut down complete")
-    logger.info("---------------------------------")
+        logger.info("---------------------------------")
+        logger.info("service helper shut down complete")
+        logger.info("---------------------------------")

--- a/tests/e2e/iothub_e2e/sync/test_sync_c2d.py
+++ b/tests/e2e/iothub_e2e/sync/test_sync_c2d.py
@@ -6,6 +6,7 @@ import logging
 import json
 import threading
 from dev_utils import get_random_dict
+import const
 
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
@@ -36,8 +37,7 @@ class TestReceiveC2d(object):
 
         service_helper.send_c2d(message, {})
 
-        received.wait(timeout=60)
-        assert received.is_set()
+        assert received.wait(timeout=const.E2E_TIMEOUT)
 
         assert received_message.data.decode("utf-8") == message
 

--- a/tests/e2e/iothub_e2e/sync/test_sync_connect_disconnect.py
+++ b/tests/e2e/iothub_e2e/sync/test_sync_connect_disconnect.py
@@ -6,6 +6,8 @@ import logging
 import time
 import threading
 import parametrize
+import const
+import wait_helpers
 
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
@@ -79,7 +81,7 @@ class TestConnectDisconnect(object):
 
         # wait for handle_on_connection_state_change to reconnect
         logger.info("waiting for reconnect_event to be set.")
-        reconnected_event.wait()
+        assert reconnected_event.wait(timeout=const.E2E_TIMEOUT)
 
         logger.info(
             "reconnect_event.wait() returned.  client.connected={}".format(client.connected)
@@ -154,7 +156,7 @@ class TestConnectDisconnect(object):
         client.connect()
 
         # and wait for us to disconnect
-        disconnected_event.wait()
+        assert disconnected_event.wait(timeout=const.E2E_TIMEOUT)
         assert not client.connected
 
         # sleep a while and make sure that we're still disconnected.
@@ -189,14 +191,12 @@ class TestConnectDisconnectDroppedConnection(object):
         assert client.connected
         dropper.drop_outgoing()
 
-        while client.connected:
-            time.sleep(1)
+        wait_helpers.wait_for_condition(lambda: not client.connected, timeout=const.E2E_TIMEOUT)
 
         # we've passed the test. Now wait to reconnect before we check for leaks. Otherwise we
         # have a pending ConnectOperation floating around and this would get tagged as a leak.
         dropper.restore_all()
-        while not client.connected:
-            time.sleep(1)
+        wait_helpers.wait_for_condition(lambda: client.connected, timeout=const.E2E_TIMEOUT)
 
         leak_tracker.check_for_leaks()
 
@@ -212,13 +212,11 @@ class TestConnectDisconnectDroppedConnection(object):
         assert client.connected
         dropper.reject_outgoing()
 
-        while client.connected:
-            time.sleep(1)
+        wait_helpers.wait_for_condition(lambda: not client.connected, timeout=const.E2E_TIMEOUT)
 
         # we've passed the test. Now wait to reconnect before we check for leaks. Otherwise we
         # have a pending ConnectOperation floating around and this would get tagged as a leak.
         dropper.restore_all()
-        while not client.connected:
-            time.sleep(1)
+        wait_helpers.wait_for_condition(lambda: client.connected, timeout=const.E2E_TIMEOUT)
 
         leak_tracker.check_for_leaks()

--- a/tests/e2e/iothub_e2e/sync/test_sync_methods.py
+++ b/tests/e2e/iothub_e2e/sync/test_sync_methods.py
@@ -3,7 +3,6 @@
 # license information.
 import pytest
 import logging
-import time
 from dev_utils import get_random_dict
 import parametrize
 from azure.iot.device.iothub import MethodResponse
@@ -62,7 +61,6 @@ class TestMethods(object):
             )
 
         client.on_method_request_received = handle_on_method_request_received
-        time.sleep(1)  # wait for subscribe, etc, to complete
 
         # invoke the method call
         method_response = service_helper.invoke_method(method_name, request_payload)

--- a/tests/e2e/iothub_e2e/sync/test_sync_sas_renewal.py
+++ b/tests/e2e/iothub_e2e/sync/test_sync_sas_renewal.py
@@ -7,6 +7,7 @@ import logging
 import threading
 import test_config
 import parametrize
+import const
 
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
@@ -47,7 +48,7 @@ class TestSasRenewal(object):
         # setting on_connection_state_change seems to have the side effect of
         # calling handle_on_connection_state_change once with the initial value.
         # Wait for one disconnect/reconnect cycle so we can get past it.
-        connected_event.wait()
+        assert connected_event.wait(timeout=const.E2E_TIMEOUT)
 
         # OK, we're ready to test.  wait for the renewal
         token_before_connect = str(token_object)
@@ -56,9 +57,9 @@ class TestSasRenewal(object):
         connected_event.clear()
 
         logger.info("Waiting for client to disconnect")
-        disconnected_event.wait()
+        assert disconnected_event.wait(timeout=const.E2E_TIMEOUT)
         logger.info("Waiting for client to reconnect")
-        connected_event.wait()
+        assert connected_event.wait(timeout=const.E2E_TIMEOUT)
         logger.info("Client reconnected")
 
         # Finally verify that our token changed.

--- a/tests/e2e/iothub_e2e/sync/test_sync_send_message.py
+++ b/tests/e2e/iothub_e2e/sync/test_sync_send_message.py
@@ -4,8 +4,9 @@
 import pytest
 import logging
 import json
-import time
 import dev_utils
+import const
+import wait_helpers
 from azure.iot.device.exceptions import OperationCancelled, ClientError
 
 logger = logging.getLogger(__name__)
@@ -91,25 +92,29 @@ class TestSendMessageDroppedConnection(object):
     @pytest.mark.it("Sends if connection drops before sending")
     @pytest.mark.uses_iptables
     def test_sync_sends_if_drop_before_sending(
-        self, client, random_message, dropper, service_helper, executor, leak_tracker
+        self,
+        client,
+        random_message,
+        dropper,
+        service_helper,
+        run_in_daemon_thread,
+        leak_tracker,
     ):
         leak_tracker.set_initial_object_list()
 
         assert client.connected
 
         dropper.drop_outgoing()
-        send_task = executor.submit(client.send_message, random_message)
+        send_task = run_in_daemon_thread(client.send_message, random_message)
 
-        while client.connected:
-            time.sleep(1)
+        wait_helpers.wait_for_condition(lambda: not client.connected, timeout=const.E2E_TIMEOUT)
 
         assert not send_task.done()
 
         dropper.restore_all()
-        while not client.connected:
-            time.sleep(1)
+        wait_helpers.wait_for_condition(lambda: client.connected, timeout=const.E2E_TIMEOUT)
 
-        send_task.result()
+        send_task.result(timeout=const.E2E_TIMEOUT)
 
         event = service_helper.wait_for_eventhub_arrival(random_message.message_id)
         assert json.dumps(event.message_body) == random_message.data
@@ -120,25 +125,29 @@ class TestSendMessageDroppedConnection(object):
     @pytest.mark.it("Sends if connection rejects send")
     @pytest.mark.uses_iptables
     def test_sync_sends_if_reject_before_sending(
-        self, client, random_message, dropper, service_helper, executor, leak_tracker
+        self,
+        client,
+        random_message,
+        dropper,
+        service_helper,
+        run_in_daemon_thread,
+        leak_tracker,
     ):
         leak_tracker.set_initial_object_list()
 
         assert client.connected
 
         dropper.reject_outgoing()
-        send_task = executor.submit(client.send_message, random_message)
+        send_task = run_in_daemon_thread(client.send_message, random_message)
 
-        while client.connected:
-            time.sleep(1)
+        wait_helpers.wait_for_condition(lambda: not client.connected, timeout=const.E2E_TIMEOUT)
 
         assert not send_task.done()
 
         dropper.restore_all()
-        while not client.connected:
-            time.sleep(1)
+        wait_helpers.wait_for_condition(lambda: client.connected, timeout=const.E2E_TIMEOUT)
 
-        send_task.result()
+        send_task.result(timeout=const.E2E_TIMEOUT)
 
         event = service_helper.wait_for_eventhub_arrival(random_message.message_id)
         assert json.dumps(event.message_body) == random_message.data
@@ -198,8 +207,7 @@ class TestSendMessageRetryDisabled(object):
         assert client.connected
 
         dropper.drop_outgoing()
-        while client.connected:
-            time.sleep(1)
+        wait_helpers.wait_for_condition(lambda: not client.connected, timeout=const.E2E_TIMEOUT)
 
         assert not client.connected
         dropper.restore_all()
@@ -214,20 +222,19 @@ class TestSendMessageRetryDisabled(object):
     @pytest.mark.it("Fails if connection disconnects before sending")
     @pytest.mark.uses_iptables
     def test_sync_fails_if_disconnect_before_sending_with_retry_disabled(
-        self, client, random_message, dropper, executor, leak_tracker
+        self, client, random_message, dropper, run_in_daemon_thread, leak_tracker
     ):
         leak_tracker.set_initial_object_list()
 
         assert client.connected
 
         dropper.drop_outgoing()
-        send_task = executor.submit(client.send_message, random_message)
+        send_task = run_in_daemon_thread(client.send_message, random_message)
 
-        while client.connected:
-            time.sleep(1)
+        wait_helpers.wait_for_condition(lambda: not client.connected, timeout=const.E2E_TIMEOUT)
 
         with pytest.raises(OperationCancelled):
-            send_task.result()
+            send_task.result(timeout=const.E2E_TIMEOUT)
 
         random_message = None  # So this doesn't get tagged as a leak
         # TODO: investigate this leak

--- a/tests/e2e/iothub_e2e/sync/test_sync_send_message.py
+++ b/tests/e2e/iothub_e2e/sync/test_sync_send_message.py
@@ -66,7 +66,10 @@ class TestSendMessage(object):
 
         client.send_message(message)
 
-        event = service_helper.wait_for_eventhub_arrival(None)
+        expected_body = json.loads(message)
+        event = service_helper.wait_for_eventhub_arrival(
+            None, event_filter=lambda event: event.message_body == expected_body
+        )
         assert json.dumps(event.message_body) == message
 
         leak_tracker.check_for_leaks()
@@ -79,7 +82,9 @@ class TestSendMessage(object):
 
         client.send_message(message)
 
-        event = service_helper.wait_for_eventhub_arrival(None)
+        event = service_helper.wait_for_eventhub_arrival(
+            None, event_filter=lambda event: event.message_body == message
+        )
         assert event.message_body == message
 
         leak_tracker.check_for_leaks()

--- a/tests/e2e/iothub_e2e/sync/test_sync_twin.py
+++ b/tests/e2e/iothub_e2e/sync/test_sync_twin.py
@@ -6,6 +6,7 @@ import logging
 import time
 import const
 import queue
+import wait_helpers
 from dev_utils import get_random_dict
 from azure.iot.device.exceptions import ClientError
 
@@ -112,24 +113,30 @@ class TestReportedPropertiesDroppedConnection(object):
 
     @pytest.mark.it("Updates reported properties if connection drops before sending")
     def test_sync_updates_reported_if_drop_before_sending(
-        self, client, random_reported_props, dropper, service_helper, executor, leak_tracker
+        self,
+        client,
+        random_reported_props,
+        dropper,
+        service_helper,
+        run_in_daemon_thread,
+        leak_tracker,
     ):
         leak_tracker.set_initial_object_list()
 
         assert client.connected
         dropper.drop_outgoing()
 
-        send_task = executor.submit(client.patch_twin_reported_properties, random_reported_props)
-        while client.connected:
-            time.sleep(1)
+        send_task = run_in_daemon_thread(
+            client.patch_twin_reported_properties, random_reported_props
+        )
+        wait_helpers.wait_for_condition(lambda: not client.connected, timeout=const.E2E_TIMEOUT)
 
         assert not send_task.done()
 
         dropper.restore_all()
-        while not client.connected:
-            time.sleep(1)
+        wait_helpers.wait_for_condition(lambda: client.connected, timeout=const.E2E_TIMEOUT)
 
-        send_task.result()
+        send_task.result(timeout=const.E2E_TIMEOUT)
 
         received_patch = service_helper.get_next_reported_patch_arrival()
         assert (
@@ -142,24 +149,30 @@ class TestReportedPropertiesDroppedConnection(object):
 
     @pytest.mark.it("Updates reported properties if connection rejects send")
     def test_sync_updates_reported_if_reject_before_sending(
-        self, client, random_reported_props, dropper, service_helper, executor, leak_tracker
+        self,
+        client,
+        random_reported_props,
+        dropper,
+        service_helper,
+        run_in_daemon_thread,
+        leak_tracker,
     ):
         leak_tracker.set_initial_object_list()
 
         assert client.connected
         dropper.reject_outgoing()
 
-        send_task = executor.submit(client.patch_twin_reported_properties, random_reported_props)
-        while client.connected:
-            time.sleep(1)
+        send_task = run_in_daemon_thread(
+            client.patch_twin_reported_properties, random_reported_props
+        )
+        wait_helpers.wait_for_condition(lambda: not client.connected, timeout=const.E2E_TIMEOUT)
 
         assert not send_task.done()
 
         dropper.restore_all()
-        while not client.connected:
-            time.sleep(1)
+        wait_helpers.wait_for_condition(lambda: client.connected, timeout=const.E2E_TIMEOUT)
 
-        send_task.result()
+        send_task.result(timeout=const.E2E_TIMEOUT)
 
         received_patch = service_helper.get_next_reported_patch_arrival()
         assert (
@@ -198,9 +211,12 @@ class TestDesiredProperties(object):
             {const.TEST_CONTENT: random_dict},
         )
 
+        deadline = time.monotonic() + const.E2E_TIMEOUT
         while True:
-            received_patch = received_patches.get(timeout=60)
-
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                pytest.fail("Timed out waiting for the expected desired property patch")
+            received_patch = received_patches.get(timeout=remaining)
             if received_patch[const.TEST_CONTENT] == random_dict:
                 twin = client.get_twin()
                 assert twin[const.DESIRED][const.TEST_CONTENT] == random_dict

--- a/tests/e2e/iothub_e2e/test_service_helper.py
+++ b/tests/e2e/iothub_e2e/test_service_helper.py
@@ -17,6 +17,7 @@ def service_helper():
     helper = object.__new__(ServiceHelperSync)
     helper._eventhub_ready = threading.Event()
     helper._eventhub_future = concurrent.futures.Future()
+    helper._eventhub_start_position = "eventhub-start-position"
     return helper
 
 
@@ -93,7 +94,10 @@ class TestEventHubConsumer(object):
         service_helper._eventhub_thread()
 
         assert service_helper._eventhub_ready.is_set()
-        assert eventhub_client.receive_batch.call_args.kwargs["starting_position"] == "-1"
+        assert (
+            eventhub_client.receive_batch.call_args.kwargs["starting_position"]
+            == service_helper._eventhub_start_position
+        )
 
 
 @pytest.mark.describe("ServiceHelperSync - .shutdown()")

--- a/tests/e2e/iothub_e2e/test_service_helper.py
+++ b/tests/e2e/iothub_e2e/test_service_helper.py
@@ -18,6 +18,8 @@ def service_helper():
     helper._eventhub_ready = threading.Event()
     helper._eventhub_future = concurrent.futures.Future()
     helper._eventhub_start_position = "eventhub-start-position"
+    helper.cv = threading.Condition()
+    helper.incoming_eventhub_events = {}
     return helper
 
 
@@ -112,3 +114,24 @@ class TestShutdown(object):
 
         assert service_helper._eventhub_consumer_client.close.call_count == 1
         assert service_helper._eventhub_future.result.call_args == mocker.call(timeout=30)
+
+
+@pytest.mark.describe("ServiceHelperSync - .wait_for_eventhub_arrival()")
+class TestWaitForEventHubArrival(object):
+    @pytest.mark.it("Returns the first event matching the supplied filter")
+    def test_filters_arrivals(self, mocker, service_helper):
+        stale_event = mocker.MagicMock(message_body="stale")
+        expected_event = mocker.MagicMock(message_body="expected")
+        service_helper.incoming_eventhub_events = {
+            "stale": stale_event,
+            "expected": expected_event,
+        }
+
+        event = service_helper.wait_for_eventhub_arrival(
+            None,
+            timeout=0.1,
+            event_filter=lambda event: event.message_body == "expected",
+        )
+
+        assert event is expected_event
+        assert service_helper.incoming_eventhub_events == {"stale": stale_event}

--- a/tests/e2e/iothub_e2e/test_service_helper.py
+++ b/tests/e2e/iothub_e2e/test_service_helper.py
@@ -34,7 +34,8 @@ class TestWaitUntilReady(object):
             service_helper.wait_until_ready(timeout=0.01)
 
     @pytest.mark.it("Raises the Event Hub consumer error if it exits during initialization")
-    def test_raises_consumer_error(self, service_helper, arbitrary_exception):
+    def test_raises_consumer_error(self, service_helper):
+        arbitrary_exception = RuntimeError("arbitrary Event Hub failure")
         service_helper._eventhub_future.set_exception(arbitrary_exception)
         service_helper._eventhub_ready.set()
 
@@ -65,7 +66,8 @@ class TestEventHubConsumer(object):
         assert eventhub_thread.call_count == 1
 
     @pytest.mark.it("Exposes errors raised on the daemon thread")
-    def test_exposes_error(self, mocker, service_helper, arbitrary_exception):
+    def test_exposes_error(self, mocker, service_helper):
+        arbitrary_exception = RuntimeError("arbitrary Event Hub failure")
         mocker.patch.object(service_helper, "_eventhub_thread", side_effect=arbitrary_exception)
 
         future = service_helper._start_eventhub_thread()

--- a/tests/e2e/iothub_e2e/test_wait_helpers.py
+++ b/tests/e2e/iothub_e2e/test_wait_helpers.py
@@ -8,7 +8,7 @@ import asyncio
 
 import pytest
 
-from tests.e2e.iothub_e2e import wait_helpers
+import wait_helpers
 
 
 @pytest.mark.describe("E2E wait helpers")

--- a/tests/e2e/iothub_e2e/wait_helpers.py
+++ b/tests/e2e/iothub_e2e/wait_helpers.py
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+import asyncio
+import time
+
+
+def wait_for_condition(condition, *, timeout, interval=0.1):
+    deadline = time.monotonic() + timeout
+    while not condition():
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("Timed out waiting for condition")
+        time.sleep(min(interval, remaining))
+
+
+async def async_wait_for_condition(condition, *, timeout, interval=0.1):
+    async def poll_condition():
+        while not condition():
+            await asyncio.sleep(interval)
+
+    await asyncio.wait_for(poll_condition(), timeout=timeout)

--- a/tests/unit/test_e2e_wait_helpers.py
+++ b/tests/unit/test_e2e_wait_helpers.py
@@ -1,0 +1,40 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import asyncio
+
+import pytest
+
+from tests.e2e.iothub_e2e import wait_helpers
+
+
+@pytest.mark.describe("E2E wait helpers")
+class TestWaitHelpers(object):
+    @pytest.mark.it("Polls a synchronous condition until it becomes true")
+    def test_wait_for_condition(self, mocker):
+        condition = mocker.Mock(side_effect=[False, True])
+
+        wait_helpers.wait_for_condition(condition, timeout=0.1, interval=0)
+
+        assert condition.call_count == 2
+
+    @pytest.mark.it("Times out waiting for a synchronous condition")
+    def test_wait_for_condition_timeout(self):
+        with pytest.raises(TimeoutError):
+            wait_helpers.wait_for_condition(lambda: False, timeout=0.01, interval=0.001)
+
+    @pytest.mark.it("Polls a condition without blocking the event loop")
+    async def test_async_wait_for_condition(self, mocker):
+        condition = mocker.Mock(side_effect=[False, True])
+
+        await wait_helpers.async_wait_for_condition(condition, timeout=0.1, interval=0)
+
+        assert condition.call_count == 2
+
+    @pytest.mark.it("Times out waiting for an asynchronous condition")
+    async def test_async_wait_for_condition_timeout(self):
+        with pytest.raises(asyncio.TimeoutError):
+            await wait_helpers.async_wait_for_condition(lambda: False, timeout=0.01, interval=0.001)

--- a/tests/unit/test_service_helper.py
+++ b/tests/unit/test_service_helper.py
@@ -1,0 +1,108 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import concurrent.futures
+import threading
+
+import pytest
+
+from dev_utils.service_helper_sync import ServiceHelperSync
+
+
+@pytest.fixture
+def service_helper():
+    helper = object.__new__(ServiceHelperSync)
+    helper._eventhub_ready = threading.Event()
+    helper._eventhub_future = concurrent.futures.Future()
+    return helper
+
+
+@pytest.mark.describe("ServiceHelperSync - .wait_until_ready()")
+class TestWaitUntilReady(object):
+    @pytest.mark.it("Returns when the Event Hub consumer is ready")
+    def test_returns_when_ready(self, service_helper):
+        service_helper._eventhub_ready.set()
+
+        service_helper.wait_until_ready(timeout=0.1)
+
+    @pytest.mark.it("Raises TimeoutError if the Event Hub consumer does not become ready")
+    def test_times_out(self, service_helper):
+        with pytest.raises(TimeoutError):
+            service_helper.wait_until_ready(timeout=0.01)
+
+    @pytest.mark.it("Raises the Event Hub consumer error if it exits during initialization")
+    def test_raises_consumer_error(self, service_helper, arbitrary_exception):
+        service_helper._eventhub_future.set_exception(arbitrary_exception)
+        service_helper._eventhub_ready.set()
+
+        with pytest.raises(arbitrary_exception.__class__) as e_info:
+            service_helper.wait_until_ready(timeout=0.1)
+
+        assert e_info.value is arbitrary_exception
+
+    @pytest.mark.it("Raises RuntimeError if the Event Hub consumer exits without an error")
+    def test_raises_if_consumer_exits(self, service_helper):
+        service_helper._eventhub_future.set_result(None)
+        service_helper._eventhub_ready.set()
+
+        with pytest.raises(RuntimeError):
+            service_helper.wait_until_ready(timeout=0.1)
+
+
+@pytest.mark.describe("ServiceHelperSync - Event Hub consumer")
+class TestEventHubConsumer(object):
+    @pytest.mark.it("Runs on a daemon thread and exposes its result")
+    def test_runs_on_daemon_thread(self, mocker, service_helper):
+        eventhub_thread = mocker.patch.object(service_helper, "_eventhub_thread", return_value=None)
+
+        future = service_helper._start_eventhub_thread()
+
+        assert future.result(timeout=0.1) is None
+        assert service_helper._eventhub_worker.daemon
+        assert eventhub_thread.call_count == 1
+
+    @pytest.mark.it("Exposes errors raised on the daemon thread")
+    def test_exposes_error(self, mocker, service_helper, arbitrary_exception):
+        mocker.patch.object(service_helper, "_eventhub_thread", side_effect=arbitrary_exception)
+
+        future = service_helper._start_eventhub_thread()
+
+        with pytest.raises(arbitrary_exception.__class__) as e_info:
+            future.result(timeout=0.1)
+
+        assert e_info.value is arbitrary_exception
+
+    @pytest.mark.it("Becomes ready after the first receive cycle")
+    def test_ready_after_receive(self, mocker, service_helper):
+        eventhub_client = mocker.MagicMock()
+        eventhub_client.__enter__.return_value = eventhub_client
+        service_helper._eventhub_consumer_client = eventhub_client
+
+        def receive_batch(**kwargs):
+            kwargs["on_partition_initialize"](mocker.MagicMock())
+            assert not service_helper._eventhub_ready.is_set()
+            kwargs["on_event_batch"](mocker.MagicMock(), [])
+
+        eventhub_client.receive_batch.side_effect = receive_batch
+
+        service_helper._eventhub_thread()
+
+        assert service_helper._eventhub_ready.is_set()
+        assert eventhub_client.receive_batch.call_args.kwargs["starting_position"] == "-1"
+
+
+@pytest.mark.describe("ServiceHelperSync - .shutdown()")
+class TestShutdown(object):
+    @pytest.mark.it("Returns if the Event Hub receiver does not exit before the timeout")
+    def test_receiver_timeout(self, mocker, service_helper):
+        service_helper._eventhub_consumer_client = mocker.MagicMock()
+        service_helper._eventhub_future = mocker.MagicMock()
+        service_helper._eventhub_future.result.side_effect = concurrent.futures.TimeoutError()
+
+        service_helper.shutdown()
+
+        assert service_helper._eventhub_consumer_client.close.call_count == 1
+        assert service_helper._eventhub_future.result.call_args == mocker.call(timeout=30)


### PR DESCRIPTION
## Stack
- Stacked on #1252; review this PR after or against that branch.

## What changed
- replace one-second connection polling and unbounded event/future waits with bounded condition-based synchronization
- remove method subscription sleeps because receive-handler setters synchronously wait for feature subscription
- signal Event Hub readiness after the first active receive cycle instead of sleeping three seconds
- start each helper from its construction timestamp so later partitions retain new events without replaying prior test traffic
- filter raw-string telemetry waits by expected payload so delayed unrelated events cannot satisfy them
- guarantee service-helper shutdown if readiness fails before fixture yield
- run the Event Hub receiver on a daemon-backed future so its 30-second shutdown timeout cannot be bypassed
- bound twin matching/retry loops with absolute deadlines
- remove import-time iptables mutation; existing per-test setup restores network state
- co-locate focused wait-helper and Event Hub lifecycle tests under the IoT Hub E2E suite

## Validation
- Python 3.12 unit suite: 5437 passed, 6 skipped
- E2E infrastructure tests: 13 passed
- Black and Ruff passed
- all 132 IoT Hub E2E tests collected without cloud access
- previous natural build, Python E2E, DPS E2E, and Horton E2E gates passed