### PR TITLE
packaging: require typing-extensions 4.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "PySocks",
     "requests>=2.32.3,<3.0.0",
     "requests-unixsocket>=0.4.1",
-    "typing-extensions",
+    "typing-extensions>=4.0.0,<5.0.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -95,7 +95,7 @@ requires-dist = [
     { name = "pysocks" },
     { name = "requests", specifier = ">=2.32.3,<3.0.0" },
     { name = "requests-unixsocket", specifier = ">=0.4.1" },
-    { name = "typing-extensions" },
+    { name = "typing-extensions", specifier = ">=4.0.0,<5.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- require `typing-extensions>=4.0.0,<5.0.0` because the SDK imports `Self`
- update the lockfile metadata for the declared runtime constraint

## Testing
- built the wheel and verified its `Requires-Dist` metadata
- installed the wheel with the minimum `typing-extensions==4.0.0` and imported every SDK module that uses `Self`, `ParamSpec`, or `TypedDict`
- `uv lock --check`