### PR TITLE
fix: make async loop creation thread-safe

### DIFF
--- a/azure-iot-device/azure/iot/device/iothub/aio/loop_management.py
+++ b/azure-iot-device/azure/iot/device/iothub/aio/loop_management.py
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-""" This module contains functions of managing event loops for the IoTHub client
-"""
+"""This module contains functions of managing event loops for the IoTHub client"""
+
 import asyncio
 import threading
 import logging
@@ -16,21 +16,24 @@ loops = {
     "CLIENT_INTERNAL_LOOP": None,
     "CLIENT_HANDLER_RUNNER_LOOP": None,
 }
+_loop_creation_lock = threading.Lock()
 
 
 def _cleanup():
     """Clear all running loops and end respective threads.
     ONLY FOR TESTING USAGE
     By using this function, you can wipe all global loops.
+    Do not call while clients or inboxes are still in use.
     DO NOT USE THIS IN PRODUCTION CODE
     """
-    for loop_name, loop in loops.items():
-        if loop is not None:
-            logger.debug("Stopping event loop - {}".format(loop_name))
-            loop.call_soon_threadsafe(loop.stop)
-            # NOTE: Stopping the loop will also end the thread, because the only thing keeping
-            # the thread alive was the loop running
-            loops[loop_name] = None
+    with _loop_creation_lock:
+        for loop_name, loop in loops.items():
+            if loop is not None:
+                logger.debug("Stopping event loop - {}".format(loop_name))
+                loop.call_soon_threadsafe(loop.stop)
+                # NOTE: Stopping the loop will also end the thread, because the only thing keeping
+                # the thread alive was the loop running
+                loops[loop_name] = None
 
 
 def _make_new_loop(loop_name):
@@ -45,23 +48,28 @@ def _make_new_loop(loop_name):
     loops[loop_name] = new_loop
 
 
+def _get_or_create_loop(loop_name):
+    loop = loops[loop_name]
+    if loop is None:
+        with _loop_creation_lock:
+            loop = loops[loop_name]
+            if loop is None:
+                _make_new_loop(loop_name)
+                loop = loops[loop_name]
+    return loop
+
+
 def get_client_internal_loop():
     """Return the loop for internal client operations"""
-    if loops["CLIENT_INTERNAL_LOOP"] is None:
-        _make_new_loop("CLIENT_INTERNAL_LOOP")
-    return loops["CLIENT_INTERNAL_LOOP"]
+    return _get_or_create_loop("CLIENT_INTERNAL_LOOP")
 
 
 def get_client_handler_runner_loop():
     """Return the loop for handler runners"""
-    if loops["CLIENT_HANDLER_RUNNER_LOOP"] is None:
-        _make_new_loop("CLIENT_HANDLER_RUNNER_LOOP")
-    return loops["CLIENT_HANDLER_RUNNER_LOOP"]
+    return _get_or_create_loop("CLIENT_HANDLER_RUNNER_LOOP")
 
 
 def get_client_handler_loop():
     """Return the loop for invoking user-provided handlers on the client"""
     # TODO: Try and store the user loop somehow
-    if loops["CLIENT_HANDLER_LOOP"] is None:
-        _make_new_loop("CLIENT_HANDLER_LOOP")
-    return loops["CLIENT_HANDLER_LOOP"]
+    return _get_or_create_loop("CLIENT_HANDLER_LOOP")

--- a/azure-iot-device/azure/iot/device/iothub/aio/loop_management.py
+++ b/azure-iot-device/azure/iot/device/iothub/aio/loop_management.py
@@ -16,6 +16,7 @@ loops = {
     "CLIENT_INTERNAL_LOOP": None,
     "CLIENT_HANDLER_RUNNER_LOOP": None,
 }
+# Janus queues bind to the first loop they use, so concurrent callers must receive the same loop.
 _loop_creation_lock = threading.Lock()
 
 
@@ -52,6 +53,7 @@ def _get_or_create_loop(loop_name):
     loop = loops[loop_name]
     if loop is None:
         with _loop_creation_lock:
+            # Another caller may have created the loop while this caller waited for the lock.
             loop = loops[loop_name]
             if loop is None:
                 _make_new_loop(loop_name)

--- a/tests/unit/iothub/aio/test_async_inbox.py
+++ b/tests/unit/iothub/aio/test_async_inbox.py
@@ -105,6 +105,14 @@ class TestAsyncClientInboxGet(object):
         assert retrieved_item is item
         assert inbox.empty()
 
+    @pytest.mark.it("Runs Janus async operations on the shared internal loop")
+    async def test_uses_shared_internal_loop(self, mocker, inbox):
+        inbox.put(mocker.MagicMock())
+
+        await asyncio.wait_for(inbox.get(), timeout=PROMPT_TIMEOUT)
+
+        assert inbox._queue._loop is loop_management.get_client_internal_loop()
+
     @pytest.mark.it(
         "Blocks on an empty inbox until an item is available to remove and return, if using blocking mode"
     )

--- a/tests/unit/iothub/aio/test_loop_management.py
+++ b/tests/unit/iothub/aio/test_loop_management.py
@@ -9,7 +9,6 @@ import asyncio
 import concurrent.futures
 import logging
 import threading
-import time
 from azure.iot.device.iothub.aio import loop_management
 from tests.unit.helpers import BATCH_COMPLETION_TIMEOUT
 
@@ -55,23 +54,33 @@ class SharedCustomLoopTests(object):
 
     @pytest.mark.it("Creates only one event loop when first called concurrently")
     def test_threadsafe_first_call(self, mocker, fn_under_test):
-        start_barrier = threading.Barrier(3)
+        class CoordinatedLoopMap(dict):
+            def __init__(self, loops):
+                super().__init__(loops)
+                self._read_barrier = threading.Barrier(2)
+                self._read_lock = threading.Lock()
+                self._reads_to_coordinate = 2
+
+            def __getitem__(self, loop_name):
+                loop = super().__getitem__(loop_name)
+                with self._read_lock:
+                    coordinate_read = self._reads_to_coordinate > 0
+                    if coordinate_read:
+                        self._reads_to_coordinate -= 1
+                if coordinate_read:
+                    self._read_barrier.wait(timeout=BATCH_COMPLETION_TIMEOUT)
+                return loop
 
         def make_loop(loop_name):
-            time.sleep(0.05)
             loop_management.loops[loop_name] = mocker.MagicMock()
 
+        mocker.patch.object(loop_management, "loops", CoordinatedLoopMap(loop_management.loops))
         make_loop_mock = mocker.patch.object(
             loop_management, "_make_new_loop", side_effect=make_loop
         )
 
-        def get_loop():
-            start_barrier.wait(timeout=BATCH_COMPLETION_TIMEOUT)
-            return fn_under_test()
-
         with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-            futures = [executor.submit(get_loop) for _ in range(2)]
-            start_barrier.wait(timeout=BATCH_COMPLETION_TIMEOUT)
+            futures = [executor.submit(fn_under_test) for _ in range(2)]
             returned_loops = [future.result(timeout=BATCH_COMPLETION_TIMEOUT) for future in futures]
 
         assert make_loop_mock.call_count == 1

--- a/tests/unit/iothub/aio/test_loop_management.py
+++ b/tests/unit/iothub/aio/test_loop_management.py
@@ -6,8 +6,12 @@
 
 import pytest
 import asyncio
+import concurrent.futures
 import logging
+import threading
+import time
 from azure.iot.device.iothub.aio import loop_management
+from tests.unit.helpers import BATCH_COMPLETION_TIMEOUT
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -48,6 +52,30 @@ class SharedCustomLoopTests(object):
         loop1 = fn_under_test()
         loop2 = fn_under_test()
         assert loop1 is loop2
+
+    @pytest.mark.it("Creates only one event loop when first called concurrently")
+    def test_threadsafe_first_call(self, mocker, fn_under_test):
+        start_barrier = threading.Barrier(3)
+
+        def make_loop(loop_name):
+            time.sleep(0.05)
+            loop_management.loops[loop_name] = mocker.MagicMock()
+
+        make_loop_mock = mocker.patch.object(
+            loop_management, "_make_new_loop", side_effect=make_loop
+        )
+
+        def get_loop():
+            start_barrier.wait(timeout=BATCH_COMPLETION_TIMEOUT)
+            return fn_under_test()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(get_loop) for _ in range(2)]
+            start_barrier.wait(timeout=BATCH_COMPLETION_TIMEOUT)
+            returned_loops = [future.result(timeout=BATCH_COMPLETION_TIMEOUT) for future in futures]
+
+        assert make_loop_mock.call_count == 1
+        assert returned_loops[0] is returned_loops[1]
 
 
 @pytest.mark.describe(".get_client_internal_loop()")


### PR DESCRIPTION
## Summary

- serialize first-time creation of the three shared async client event loops
- preserve lock-free access after a loop has been published
- synchronize test-only loop cleanup with loop creation
- add concurrent initialization and Janus loop-affinity regression coverage

## Root cause

[Python E2E build 163209](https://dev.azure.com/azure-iot-sdks/f9b79625-2860-4d92-a4ee-57b03fabfd10/_build/results?buildId=163209) timed out in the first async C2D test on Windows/Python 3.10. Message delivery succeeded, but the log showed `CLIENT_INTERNAL_LOOP` being created twice by concurrent first callers.

The loop getters used an unsynchronized check-then-create. After #1258 stopped constructing each Janus queue through the internal loop, the loop was no longer guaranteed to be initialized before the handler runner and feature-enablement paths started concurrently. The queue could bind to the first loop while the second loop replaced the global reference. Every subsequent queue receive then failed Janus's loop-affinity check, and the handler manager's immediate restart behavior turned the failure into a tight restart loop until pytest timed out.

## Why this shape

The process-wide loops are intentionally shared by clients to isolate internal work, handler runners, and user coroutine handlers. Moving to per-client loops would require broader ownership and shutdown changes while leaving lazy initialization subject to the same race. Eager creation would unconditionally start three daemon threads. A centralized, double-checked creation lock restores the existing singleton invariant at its owner and keeps the established hot path lock-free.

## Why prior review missed it

#1258's reviews and tests focused on Janus resource closure and removing an unnecessary event-loop round trip during queue construction. Its unit tests verified sequential construction, queue operations, and shutdown, and its complete E2E matrix passed. The older loop manager only asserted that repeated sequential calls returned the same loop; it had no concurrent-first-access coverage.

The change therefore exposed a pre-existing race rather than introducing an obviously incorrect Janus operation. It requires two independent first consumers to enter a narrow scheduling window, which did not occur in #1258's runs and appeared later in one Windows job. This PR makes that concurrency contract explicit and deterministic in tests.

## Validation

- regression demonstrated before the fix: all three loop getters created two loops under synchronized concurrent first access
- Python 3.10 focused async lifecycle suite: 153 passed
- Python 3.14 related async lifecycle suite: 933 passed, 3 skipped
- full unit suite: 5445 passed, 6 skipped
- concurrency regression repeated 20 times
- package sdist and wheel build succeeded
- Black and Ruff passed
- independent design and code reviews completed
