### PR TITLE
e2e: allow serial DPS registrations to complete

### DIFF
--- a/tests/e2e/provisioning_e2e/pytest.ini
+++ b/tests/e2e/provisioning_e2e/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-timeout=30
+timeout=60
 testdox_format=plaintext
 asyncio_mode=auto
 addopts=

--- a/tests/e2e/provisioning_e2e/tests/test_async_certificate_enrollments.py
+++ b/tests/e2e/provisioning_e2e/tests/test_async_certificate_enrollments.py
@@ -28,7 +28,6 @@ from create_x509_chain_crypto import (
     delete_directories_certs_created_from_pipeline,
 )
 
-
 logging.basicConfig(level=logging.DEBUG)
 
 
@@ -53,6 +52,8 @@ type_to_device_indices = {
     "group_intermediate": [3, 4, 5],
     "group_ca": [6, 7, 8],
 }
+# Group tests perform three serial network registrations, so use a larger hang backstop.
+GROUP_REGISTRATION_TIMEOUT = 120
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -133,6 +134,7 @@ async def test_device_register_with_no_device_id_for_a_x509_individual_enrollmen
     "A group of devices get provisioned to the linked IoTHub with device_ids equal to the individual registration_ids inside a group enrollment that has been created with intermediate X509 authentication"
 )
 @pytest.mark.parametrize("protocol", ["mqtt", "mqttws"])
+@pytest.mark.timeout(GROUP_REGISTRATION_TIMEOUT)
 async def test_group_of_devices_register_with_no_device_id_for_a_x509_intermediate_authentication_group_enrollment(
     protocol,
 ):
@@ -196,6 +198,7 @@ async def test_group_of_devices_register_with_no_device_id_for_a_x509_intermedia
     "A group of devices get provisioned to the linked IoTHub with device_ids equal to the individual registration_ids inside a group enrollment that has been created with an already uploaded ca cert X509 authentication"
 )
 @pytest.mark.parametrize("protocol", ["mqtt", "mqttws"])
+@pytest.mark.timeout(GROUP_REGISTRATION_TIMEOUT)
 async def test_group_of_devices_register_with_no_device_id_for_a_x509_ca_authentication_group_enrollment(
     protocol,
 ):

--- a/tests/e2e/provisioning_e2e/tests/test_async_certificate_enrollments.py
+++ b/tests/e2e/provisioning_e2e/tests/test_async_certificate_enrollments.py
@@ -52,8 +52,12 @@ type_to_device_indices = {
     "group_intermediate": [3, 4, 5],
     "group_ca": [6, 7, 8],
 }
-# Group tests perform three serial network registrations, so use a larger hang backstop.
-GROUP_REGISTRATION_TIMEOUT = 120
+# Allow 40 seconds per serial registration and derive each group limit from its device list.
+REGISTRATION_TIMEOUT_PER_DEVICE = 40
+
+
+def group_registration_timeout(group_type):
+    return REGISTRATION_TIMEOUT_PER_DEVICE * len(type_to_device_indices[group_type])
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -134,7 +138,7 @@ async def test_device_register_with_no_device_id_for_a_x509_individual_enrollmen
     "A group of devices get provisioned to the linked IoTHub with device_ids equal to the individual registration_ids inside a group enrollment that has been created with intermediate X509 authentication"
 )
 @pytest.mark.parametrize("protocol", ["mqtt", "mqttws"])
-@pytest.mark.timeout(GROUP_REGISTRATION_TIMEOUT)
+@pytest.mark.timeout(group_registration_timeout("group_intermediate"))
 async def test_group_of_devices_register_with_no_device_id_for_a_x509_intermediate_authentication_group_enrollment(
     protocol,
 ):
@@ -198,7 +202,7 @@ async def test_group_of_devices_register_with_no_device_id_for_a_x509_intermedia
     "A group of devices get provisioned to the linked IoTHub with device_ids equal to the individual registration_ids inside a group enrollment that has been created with an already uploaded ca cert X509 authentication"
 )
 @pytest.mark.parametrize("protocol", ["mqtt", "mqttws"])
-@pytest.mark.timeout(GROUP_REGISTRATION_TIMEOUT)
+@pytest.mark.timeout(group_registration_timeout("group_ca"))
 async def test_group_of_devices_register_with_no_device_id_for_a_x509_ca_authentication_group_enrollment(
     protocol,
 ):

--- a/tests/e2e/provisioning_e2e/tests/test_sync_certificate_enrollments.py
+++ b/tests/e2e/provisioning_e2e/tests/test_sync_certificate_enrollments.py
@@ -51,8 +51,12 @@ type_to_device_indices = {
     "group_intermediate": [3, 4, 5],
     "group_ca": [6, 7, 8],
 }
-# Group tests perform three serial network registrations, so use a larger hang backstop.
-GROUP_REGISTRATION_TIMEOUT = 120
+# Allow 40 seconds per serial registration and derive each group limit from its device list.
+REGISTRATION_TIMEOUT_PER_DEVICE = 40
+
+
+def group_registration_timeout(group_type):
+    return REGISTRATION_TIMEOUT_PER_DEVICE * len(type_to_device_indices[group_type])
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -133,7 +137,7 @@ def test_device_register_with_no_device_id_for_a_x509_individual_enrollment(prot
     "A group of devices get provisioned to the linked IoTHub with device_ids equal to the individual registration_ids inside a group enrollment that has been created with intermediate X509 authentication"
 )
 @pytest.mark.parametrize("protocol", ["mqtt", "mqttws"])
-@pytest.mark.timeout(GROUP_REGISTRATION_TIMEOUT)
+@pytest.mark.timeout(group_registration_timeout("group_intermediate"))
 def test_group_of_devices_register_with_no_device_id_for_a_x509_intermediate_authentication_group_enrollment(
     protocol,
 ):
@@ -198,7 +202,7 @@ def test_group_of_devices_register_with_no_device_id_for_a_x509_intermediate_aut
     "A group of devices get provisioned to the linked IoTHub with device_ids equal to the individual registration_ids inside a group enrollment that has been created with an already uploaded ca cert X509 authentication"
 )
 @pytest.mark.parametrize("protocol", ["mqtt", "mqttws"])
-@pytest.mark.timeout(GROUP_REGISTRATION_TIMEOUT)
+@pytest.mark.timeout(group_registration_timeout("group_ca"))
 def test_group_of_devices_register_with_no_device_id_for_a_x509_ca_authentication_group_enrollment(
     protocol,
 ):

--- a/tests/e2e/provisioning_e2e/tests/test_sync_certificate_enrollments.py
+++ b/tests/e2e/provisioning_e2e/tests/test_sync_certificate_enrollments.py
@@ -27,7 +27,6 @@ from create_x509_chain_crypto import (
     delete_directories_certs_created_from_pipeline,
 )
 
-
 logging.basicConfig(level=logging.DEBUG)
 
 
@@ -52,6 +51,8 @@ type_to_device_indices = {
     "group_intermediate": [3, 4, 5],
     "group_ca": [6, 7, 8],
 }
+# Group tests perform three serial network registrations, so use a larger hang backstop.
+GROUP_REGISTRATION_TIMEOUT = 120
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -132,6 +133,7 @@ def test_device_register_with_no_device_id_for_a_x509_individual_enrollment(prot
     "A group of devices get provisioned to the linked IoTHub with device_ids equal to the individual registration_ids inside a group enrollment that has been created with intermediate X509 authentication"
 )
 @pytest.mark.parametrize("protocol", ["mqtt", "mqttws"])
+@pytest.mark.timeout(GROUP_REGISTRATION_TIMEOUT)
 def test_group_of_devices_register_with_no_device_id_for_a_x509_intermediate_authentication_group_enrollment(
     protocol,
 ):
@@ -196,6 +198,7 @@ def test_group_of_devices_register_with_no_device_id_for_a_x509_intermediate_aut
     "A group of devices get provisioned to the linked IoTHub with device_ids equal to the individual registration_ids inside a group enrollment that has been created with an already uploaded ca cert X509 authentication"
 )
 @pytest.mark.parametrize("protocol", ["mqtt", "mqttws"])
+@pytest.mark.timeout(GROUP_REGISTRATION_TIMEOUT)
 def test_group_of_devices_register_with_no_device_id_for_a_x509_ca_authentication_group_enrollment(
     protocol,
 ):


### PR DESCRIPTION
## Summary

- raise the DPS E2E suite timeout from 30 to 60 seconds
- give X.509 group enrollment tests a 120-second timeout for three serial registrations
- apply the group override consistently to sync/async and MQTT/MQTT-over-WebSockets cases

## Why

[DPS E2E build 163238](https://dev.azure.com/azure-iot-sdks/f9b79625-2860-4d92-a4ee-57b03fabfd10/_build/results?buildId=163238) timed out in the async X.509 group enrollment MQTT-over-WebSockets case. The suite-level 30-second pytest timeout covered the entire test even though it performs three sequential network registrations.

The same outer timeout also matched the SDK registration stage's 30-second timeout, allowing pytest to interrupt single-registration tests before the SDK could surface its more useful operation error.

A 60-second default preserves bounded hang detection while allowing SDK errors to surface. The 120-second marker is limited to group tests that make three serial registration attempts.

## Validation

- Python 3.10 collected all 24 DPS E2E cases
- verified 16 individual cases use the 60-second suite default
- verified all 8 sync/async X.509 group cases use the 120-second override
- Black and Ruff passed
